### PR TITLE
Improved iPad Support

### DIFF
--- a/demo/ipad.html
+++ b/demo/ipad.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CodeMirror: iPad Demo</title>
+
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"
+        />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+
+
+    <link rel="stylesheet" href="../lib/codemirror.css">
+    <script src="../lib/codemirror.js"></script>
+    <script src="../mode/javascript/javascript.js"></script>
+      
+    <link rel="stylesheet" href="../doc/docs.css">
+
+    <style type="text/css">
+      .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
+  
+      .CodeMirror-scroll {
+        overflow: auto;
+        -webkit-overflow-scrolling: touch;
+        }
+    </style>
+  </head>
+  <body>
+    <h1>CodeMirror: iPad Demo</h1>
+
+    <form><textarea id="code" name="code">
+
+  function onTouchMove (e) {
+     if (e.touches.length != 1) return;
+    var cm = this, display = cm.display, doc = cm.doc, sel = doc.sel;
+    var pos = posFromMouse(cm, e.touches[0]);
+    var now = +new Date;
+
+    // if moving after short pause on first touch within selection, drag
+    
+    if (touchMode == "single" && cm.options.dragDrop && dragAndDrop && !isReadOnly(cm) && !posEq(sel.from, sel.to) && !posLess(pos, sel.from) && !posLess(sel.to, pos) && lastClick.time < now-100) {
+      touchMode = "drag";     
+    }
+    else if (touchMode == "single" && lastClick.time < now-100) {
+      // select instead of scrolling if there is a short pause before movement
+      touchMode = "select";
+    }
+    else if (touchMode == "single") {
+      touchMode = "scroll";
+    }
+    else if (touchMode == "double") {
+    // if moving on the second touch, extend selection and cancel scroll
+      touchMode = "select";      
+    }
+
+
+    if (touchMode == "select") {
+      extendSelection(cm.doc, lastClick.pos, pos);
+      e_preventDefault(e);
+    }
+    else if (touchMode == "drag") {
+      e_preventDefault(e);
+    }        
+  }
+
+
+    </textarea></form>
+
+    <script>
+var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
+  mode: "javascript",
+  styleActiveLine: false,
+  lineNumbers: true,
+  lineWrapping: true,
+  moveInputWithCursor: false,
+  fixedGutter: false
+});
+</script>
+
+    <p>Optimized for iPad.</p>
+
+  </body>
+</html>

--- a/demo/ipad.html
+++ b/demo/ipad.html
@@ -13,12 +13,19 @@
     <link rel="stylesheet" href="../lib/codemirror.css">
     <script src="../lib/codemirror.js"></script>
     <script src="../mode/javascript/javascript.js"></script>
-      
+          <script src="../addon/selection/active-line.js"></script>
+
     <link rel="stylesheet" href="../doc/docs.css">
 
     <style type="text/css">
       .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
   
+      .CodeMirror-lines>div>div>div:nth-child(even) pre {
+        background-color: rgba(0,0,0,0.1);
+      }
+
+ .CodeMirror-activeline-background {background: rgba(255, 0,255,1) !important; }
+
       .CodeMirror-scroll {
         overflow: auto;
         -webkit-overflow-scrolling: touch;
@@ -69,7 +76,7 @@
     <script>
 var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
   mode: "javascript",
-  styleActiveLine: false,
+  styleActiveLine: true,
   lineNumbers: true,
   lineWrapping: true,
   moveInputWithCursor: false,

--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -190,9 +190,9 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   word-break: normal;
 }
 .CodeMirror-linebackground {
-  position: absolute;
-  left: 0; right: 0; top: 0; bottom: 0;
-  z-index: 0;
+  position: relative;
+  height: 13px;
+  margin-bottom: -13px;
 }
 
 .CodeMirror-linewidget {

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1457,7 +1457,7 @@ window.CodeMirror = (function() {
 
   function registerEventHandlers(cm) {
     var d = cm.display;
-    
+
     // iOS mouse simulation is slightly broken; handle touch events directly
     if (ios) {
       on(d.scroller, "touchstart", operation(cm, onTouchStart));
@@ -1593,7 +1593,7 @@ window.CodeMirror = (function() {
     if (e.touches.length != 1) return;
 
      var now = +new Date;
-     var cm = this, display = cm.display, doc = cm.doc, sel = doc.sel;
+     var cm = this, doc = cm.doc;
      
      var pos = posFromMouse(cm, e.touches[0]);
 
@@ -1621,7 +1621,7 @@ window.CodeMirror = (function() {
 
   function onTouchMove (e) {
      if (e.touches.length != 1) return;
-    var cm = this, display = cm.display, doc = cm.doc, sel = doc.sel;
+    var cm = this, doc = cm.doc, sel = doc.sel;
     var pos = posFromMouse(cm, e.touches[0]);
     var now = +new Date;
 
@@ -1655,7 +1655,7 @@ window.CodeMirror = (function() {
   function onTouchEnd(e) {
     if (e.changedTouches.length != 1) return;
     var now = +new Date;
-    var cm = this, display = cm.display, doc = cm.doc, sel = doc.sel;
+    var cm = this, doc = cm.doc;
     var pos = posFromMouse(cm, e.changedTouches[0]);
 
     if (touchMode == "single" && lastClick.time < now-300) {

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1465,7 +1465,7 @@ window.CodeMirror = (function() {
       on(d.scroller, "touchend", operation(cm, onTouchEnd));
     }
     else {
-      on(d.scroller, "mousedown", operation(cm, onMouseDown));      
+      on(d.scroller, "mousedown", operation(cm, onMouseDown));
       on(d.scroller, "dblclick", operation(cm, e_preventDefault));
     }
 
@@ -1593,14 +1593,14 @@ window.CodeMirror = (function() {
     if (e.touches.length != 1) return;
 
      var now = +new Date;
-     var cm = this, doc = cm.doc;
-     
+     var cm = this;
+
      var pos = posFromMouse(cm, e.touches[0]);
 
     if (!cm.state.focused) cm.focus();
 
      if (!lastClick || lastClick.time < now-300) {
-       touchMode = "single";      
+       touchMode = "single";
      }
      else if (touchMode == "single") {
       touchMode = "double";
@@ -1620,15 +1620,15 @@ window.CodeMirror = (function() {
   }
 
   function onTouchMove (e) {
-     if (e.touches.length != 1) return;
+    if (e.touches.length != 1) return;
     var cm = this, doc = cm.doc, sel = doc.sel;
     var pos = posFromMouse(cm, e.touches[0]);
     var now = +new Date;
 
     // if moving after short pause on first touch within selection, drag
-    
+
     if (touchMode == "single" && cm.options.dragDrop && dragAndDrop && !isReadOnly(cm) && !posEq(sel.from, sel.to) && !posLess(pos, sel.from) && !posLess(sel.to, pos) && lastClick.time < now-100) {
-      touchMode = "drag";     
+      touchMode = "drag";
     }
     else if (touchMode == "single" && lastClick.time < now-100) {
       // select instead of scrolling if there is a short pause before movement
@@ -1639,7 +1639,7 @@ window.CodeMirror = (function() {
     }
     else if (touchMode == "double") {
     // if moving on the second touch, extend selection and cancel scroll
-      touchMode = "select";      
+      touchMode = "select";
     }
 
 
@@ -1649,7 +1649,7 @@ window.CodeMirror = (function() {
     }
     else if (touchMode == "drag") {
       e_preventDefault(e);
-    }        
+    }
   }
 
   function onTouchEnd(e) {
@@ -1659,10 +1659,9 @@ window.CodeMirror = (function() {
     var pos = posFromMouse(cm, e.changedTouches[0]);
 
     if (touchMode == "single" && lastClick.time < now-300) {
-      // if more than 300ms since touch start, show context menu 
+      // if more than 300ms since touch start, show context menu
       touchMode == "context";
-    e_preventDefault(e);
-
+      e_preventDefault(e);
     }
     else if (touchMode == "single") {
     // if this is the first touch and there was no movement, move cursor to current position
@@ -1671,7 +1670,7 @@ window.CodeMirror = (function() {
     }
     else if (touchMode == "double") {
     // second touch without movement, select word
-   
+
     var word = findWordAt(getLine(doc, pos.line).text, pos);
       extendSelection(cm.doc, word.from, word.to);
     e_preventDefault(e);
@@ -1698,7 +1697,6 @@ window.CodeMirror = (function() {
       }
       e_preventDefault(e);
     }
-    
   }
 
   function onMouseDown(e) {

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1457,8 +1457,18 @@ window.CodeMirror = (function() {
 
   function registerEventHandlers(cm) {
     var d = cm.display;
-    on(d.scroller, "mousedown", operation(cm, onMouseDown));
-    on(d.scroller, "dblclick", operation(cm, e_preventDefault));
+    
+    // iOS mouse simulation is slightly broken; handle touch events directly
+    if (ios) {
+      on(d.scroller, "touchstart", operation(cm, onTouchStart));
+      on(d.scroller, "touchmove", operation(cm, onTouchMove));
+      on(d.scroller, "touchend", operation(cm, onTouchEnd));
+    }
+    else {
+      on(d.scroller, "mousedown", operation(cm, onMouseDown));      
+      on(d.scroller, "dblclick", operation(cm, e_preventDefault));
+    }
+
     on(d.lineSpace, "selectstart", function(e) {
       if (!eventInWidget(d, e)) e_preventDefault(e);
     });
@@ -1577,7 +1587,120 @@ window.CodeMirror = (function() {
     return coordsChar(cm, x - space.left, y - space.top);
   }
 
-  var lastClick, lastDoubleClick;
+  var lastClick, lastDoubleClick, touchMode;
+
+  function onTouchStart(e) {
+    if (e.touches.length != 1) return;
+
+     var now = +new Date;
+     var cm = this, display = cm.display, doc = cm.doc, sel = doc.sel;
+     
+     var pos = posFromMouse(cm, e.touches[0]);
+
+    if (!cm.state.focused) cm.focus();
+
+     if (!lastClick || lastClick.time < now-300) {
+       touchMode = "single";      
+     }
+     else if (touchMode == "single") {
+      touchMode = "double";
+      e_preventDefault(e);
+     }
+     else if (touchMode == "double") {
+      touchMode = "triple";
+      e_preventDefault(e);
+
+     }
+     else {
+      touchMode = "single";
+     }
+
+     lastClick = {time: now, pos: pos};
+
+  }
+
+  function onTouchMove (e) {
+     if (e.touches.length != 1) return;
+    var cm = this, display = cm.display, doc = cm.doc, sel = doc.sel;
+    var pos = posFromMouse(cm, e.touches[0]);
+    var now = +new Date;
+
+    // if moving after short pause on first touch within selection, drag
+    
+    if (touchMode == "single" && cm.options.dragDrop && dragAndDrop && !isReadOnly(cm) && !posEq(sel.from, sel.to) && !posLess(pos, sel.from) && !posLess(sel.to, pos) && lastClick.time < now-100) {
+      touchMode = "drag";     
+    }
+    else if (touchMode == "single" && lastClick.time < now-100) {
+      // select instead of scrolling if there is a short pause before movement
+      touchMode = "select";
+    }
+    else if (touchMode == "single") {
+      touchMode = "scroll";
+    }
+    else if (touchMode == "double") {
+    // if moving on the second touch, extend selection and cancel scroll
+      touchMode = "select";      
+    }
+
+
+    if (touchMode == "select") {
+      extendSelection(cm.doc, lastClick.pos, pos);
+      e_preventDefault(e);
+    }
+    else if (touchMode == "drag") {
+      e_preventDefault(e);
+    }        
+  }
+
+  function onTouchEnd(e) {
+    if (e.changedTouches.length != 1) return;
+    var now = +new Date;
+    var cm = this, display = cm.display, doc = cm.doc, sel = doc.sel;
+    var pos = posFromMouse(cm, e.changedTouches[0]);
+
+    if (touchMode == "single" && lastClick.time < now-300) {
+      // if more than 300ms since touch start, show context menu 
+      touchMode == "context";
+    e_preventDefault(e);
+
+    }
+    else if (touchMode == "single") {
+    // if this is the first touch and there was no movement, move cursor to current position
+    extendSelection(cm.doc, pos);
+    e_preventDefault(e);
+    }
+    else if (touchMode == "double") {
+    // second touch without movement, select word
+   
+    var word = findWordAt(getLine(doc, pos.line).text, pos);
+      extendSelection(cm.doc, word.from, word.to);
+    e_preventDefault(e);
+    }
+    else if (touchMode == "triple") {
+    // third touch without movement, select line
+    selectLine(cm, pos.line);
+    e_preventDefault(e);
+    }
+    else if (touchMode == "select") {
+    e_preventDefault(e);
+    }
+    else if (touchMode = "drag") {
+      // Don't do a replace if the drop happened inside of the selected text.
+      if (!(posLess(pos, cm.doc.sel.from) || posLess(cm.doc.sel.to, pos))) {
+        cm.state.draggingText(e);
+      }
+      else {
+        var text = cm.getSelection();
+        var curFrom = cm.doc.sel.from, curTo = cm.doc.sel.to;
+        setSelection(cm.doc, pos, pos);
+        replaceRange(cm.doc, "", curFrom, curTo, "paste");
+        cm.replaceSelection(text, null, "paste");
+      }
+      e_preventDefault(e);
+    }
+    
+  }
+
   function onMouseDown(e) {
     var cm = this, display = cm.display, doc = cm.doc, sel = doc.sel;
     sel.shift = e.shiftKey;

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -106,7 +106,7 @@ window.CodeMirror = (function() {
     d.scrollbarV = elt("div", [elt("div", null, null, "width: 1px")], "CodeMirror-vscrollbar");
     d.scrollbarFiller = elt("div", null, "CodeMirror-scrollbar-filler");
     // DIVs containing the selection and the actual code
-    d.lineDiv = elt("div", null, null, "position: relative; z-index: 5");
+    d.lineDiv = elt("div");
     d.selectionDiv = elt("div", null, null, "position: relative; z-index: 1");
     // Blinky cursor, and element used to ensure cursor fits at the end of a line
     d.cursor = elt("div", "\u00a0", "CodeMirror-cursor");
@@ -120,7 +120,7 @@ window.CodeMirror = (function() {
     // Moved around its parent to cover visible view
     d.mover = elt("div", [elt("div", [d.lineSpace], "CodeMirror-lines")], null, "position: relative");
     // Set to the height of the text, causes scrolling
-    d.sizer = elt("div", [d.mover], "CodeMirror-sizer", "z-index: 5");
+    d.sizer = elt("div", [d.mover], "CodeMirror-sizer");
     // D is needed because behavior of elts with overflow: auto and padding is inconsistent across browsers
     d.heightForcer = elt("div", null, null, "position: absolute; height: " + scrollerCutOff + "px; width: 1px;");
     // Will contain the gutters, if any
@@ -136,6 +136,8 @@ window.CodeMirror = (function() {
                             d.scrollbarFiller, d.scroller], "CodeMirror");
     // Work around IE7 z-index bug
     if (ie_lt8) { d.gutters.style.zIndex = -1; d.scroller.style.paddingRight = 0; }
+    // iOS doesn't like the way elements are stacked either
+    if (ios) { d.gutters.style.zIndex = -1; }
     if (place.appendChild) place.appendChild(d.wrapper); else place(d.wrapper);
 
     // Needed to hide big blue blinking cursor on Mobile Safari
@@ -675,7 +677,7 @@ window.CodeMirror = (function() {
       }
     }
     if (!wrap) {
-      wrap = elt("div", null, line.wrapClass, "position: relative");
+      wrap = elt("div", null, line.wrapClass, "");
       wrap.appendChild(lineElement);
     }
     // Kludge to make sure the styled element lies behind the selection (by z-index)

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -106,7 +106,7 @@ window.CodeMirror = (function() {
     d.scrollbarV = elt("div", [elt("div", null, null, "width: 1px")], "CodeMirror-vscrollbar");
     d.scrollbarFiller = elt("div", null, "CodeMirror-scrollbar-filler");
     // DIVs containing the selection and the actual code
-    d.lineDiv = elt("div");
+    d.lineDiv = elt("div", null, null, "position: relative; z-index: 5");
     d.selectionDiv = elt("div", null, null, "position: relative; z-index: 1");
     // Blinky cursor, and element used to ensure cursor fits at the end of a line
     d.cursor = elt("div", "\u00a0", "CodeMirror-cursor");
@@ -120,7 +120,7 @@ window.CodeMirror = (function() {
     // Moved around its parent to cover visible view
     d.mover = elt("div", [elt("div", [d.lineSpace], "CodeMirror-lines")], null, "position: relative");
     // Set to the height of the text, causes scrolling
-    d.sizer = elt("div", [d.mover], "CodeMirror-sizer");
+    d.sizer = elt("div", [d.mover], "CodeMirror-sizer", "z-index: 5");
     // D is needed because behavior of elts with overflow: auto and padding is inconsistent across browsers
     d.heightForcer = elt("div", null, null, "position: absolute; height: " + scrollerCutOff + "px; width: 1px;");
     // Will contain the gutters, if any


### PR DESCRIPTION
This includes a couple of fixes to make CodeMirror work better on an iPad.

1. Mobile Safari handles z-index within a specific parent element and positioning type - with the previous version the selection would hide the code and the gutter background would hide the line numbers. I have moved lineDiv in front of selectionDiv and sizer in front of gutters. This does mean that the gutter background won't cover horizontally scrolled code, but using a fixed gutter runs into other issues on iOS anyway.

2. I have replaced onMouseDown with a set of touch event handlers when running on iOS.
 * Mobile safari does not generate mouse events until it knows if it is a click or double click - i.e. it waits 300ms then fires all the events at once, so anything timing related won't work. The new implementation moves the cursor immediately and decides later if it also needs to select the word/line.
 * To avoid conflicts with scrolling, drag and selection are triggered with either a 100ms pause before movement or movement on the second touch.