### PR TITLE
auto expand folded regions when fold ranges become invalid

### DIFF
--- a/addon/fold/foldgutter.js
+++ b/addon/fold/foldgutter.js
@@ -69,11 +69,16 @@
     var opts = cm.state.foldGutter.options, cur = from;
     cm.eachLine(from, to, function(line) {
       var mark = null;
+      var pos = Pos(cur), func = opts.rangeFinder || CodeMirror.fold.auto;
+      var range = func && func(cm, pos);
       if (isFolded(cm, cur)) {
-        mark = marker(opts.indicatorFolded);
+        if (range)
+          mark = marker(opts.indicatorFolded);
+        else
+          cm.findMarksAt(pos).filter(function (m) {return m.__isFold;})
+            .forEach(function (m) { m.clear(); });
       } else {
-        var pos = Pos(cur, 0), func = opts.rangeFinder || CodeMirror.fold.auto;
-        var range = func && func(cm, pos);
+        
         if (range && range.from.line + 1 < range.to.line)
           mark = marker(opts.indicatorOpen);
       }

--- a/addon/fold/foldgutter.js
+++ b/addon/fold/foldgutter.js
@@ -78,7 +78,7 @@
           cm.findMarksAt(pos).filter(function (m) {return m.__isFold;})
             .forEach(function (m) { m.clear(); });
       } else {
-        
+
         if (range && range.from.line + 1 < range.to.line)
           mark = marker(opts.indicatorOpen);
       }


### PR DESCRIPTION
This addresses an issue where fold markers do nothing if a folded region is made invalid  as a result of an undo or delete action. To reproduce:
* Enter the following fragment
```javascript
function () {

}
```
* Fold the function
* Delete the closing brace

Result is that the fold marker no longer expands the folded region, although one is still able to click text marker or indeed expand the fold by navigating the cursor into the region.

In an attempt to address this issue, this pull request expands a folded region when they become invalid.
Credits to @JeffryBooher for spotting the issue.