### PR TITLE
fixed issue where extra spaces added to class attr

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -7377,7 +7377,7 @@
     if (test.test(node.className)) node.className = node.className.replace(test, "");
   }
   function addClass(node, cls) {
-    if (!classTest(cls).test(node.className)) node.className = (node.className || "").trim() + " " + cls;
+    if (!classTest(cls).test(node.className)) node.className = (node.className||"") + ((node.className||"").substr((node.className||"").length-1)==" " ? "":" ") + cls;
   }
   function joinClasses(a, b) {
     var as = a.split(" ");

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -7377,7 +7377,7 @@
     if (test.test(node.className)) node.className = node.className.replace(test, "");
   }
   function addClass(node, cls) {
-    if (!classTest(cls).test(node.className)) node.className += " " + cls;
+    if (!classTest(cls).test(node.className)) node.className = (node.className || "").trim() + " " + cls;
   }
   function joinClasses(a, b) {
     var as = a.split(" ");


### PR DESCRIPTION
when ever a class was added to a node, regardless of if a space was present at the end of the class attribute an additional one was added to ensure the new class was not appended to the end of the last class. This caused an ever increasing amount of spaces in the class attribute. Updated the addClass function to trim the current value of the class attribute, append a space and then append the new class