### PR TITLE
fixed onKeyEventTargetKeyDown in keymap/vim.js

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -4811,6 +4811,7 @@
         lastChange.changes.push(new InsertModeKey(keyName));
         return true;
       }
+      if (typeof keyName.indexOf === 'undefined') { return; }
       if (keyName.indexOf('Delete') != -1 || keyName.indexOf('Backspace') != -1) {
         CodeMirror.lookupKey(keyName, 'vim-insert', onKeyFound);
       }


### PR DESCRIPTION
when CodeMirror.keyName returns a non string object like false or true, the indexOf function is undefined. This causes the undefined is not a function error to be thrown.