### PR TITLE
Fix `eventInWidget` exceptions on textNodes

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2759,8 +2759,9 @@
   // Return true when the given mouse event happened in a widget
   function eventInWidget(display, e) {
     for (var n = e_target(e); n != display.wrapper; n = n.parentNode) {
-      if (!n || n.getAttribute("cm-ignore-events") == "true" || n.parentNode == display.sizer && n != display.mover) return true;
+      if (!n || (n.getAttribute && n.getAttribute("cm-ignore-events") == "true") || n.parentNode == display.sizer && n != display.mover) return true;
     }
+    return false;
   }
 
   // Given a mouse event, find the corresponding position. If liberal


### PR DESCRIPTION
# Issue:

`eventInWidget` is sometimes passed events that have as their target a text node. These nodes do not support `getAttribute`, at least in Chrome. I think Firefox is okay.

## Duplication:

Go to http://codemirror.net/demo/markselection.html (in Chrome), open the console, and then right click on the yellow highlighted text. An uncaught exception should fire.

## Patch:

Check for the existence of `getAttribute` before trying to call it. Also, explicitly return `false` at end of function (this is just a stylistic change for clarity).

Hopefully this is the correct, intended behavior. Thanks again for your hard work on CodeMirror. I saw your tweet about not responding to patch requests too quickly to engender additional participation, so I figured I'd try to fix this one myself.