### PR TITLE
[perl] Add lineComment attribute to Perl mode

### DIFF
--- a/mode/perl/perl.js
+++ b/mode/perl/perl.js
@@ -780,16 +780,21 @@ CodeMirror.defineMode("perl",function(){
                                 return "meta";}
                 return null;}
 
-        return{
-                startState:function(){
-                        return{
-                                tokenize:tokenPerl,
-                                chain:null,
-                                style:null,
-                                tail:null};},
-                token:function(stream,state){
-                        return (state.tokenize||tokenPerl)(stream,state);}
-                };});
+        return {
+            startState: function() {
+                return {
+                    tokenize: tokenPerl,
+                    chain: null,
+                    style: null,
+                    tail: null
+                };
+            },
+            token: function(stream, state) {
+                return (state.tokenize || tokenPerl)(stream, state);
+            },
+            lineComment: '#'
+        };
+});
 
 CodeMirror.registerHelper("wordChars", "perl", /[\w$]/);
 


### PR DESCRIPTION
Also clean up style a bit. `perl.js` is oddly spaced!