### PR TITLE
fix issue - loop fixated in big comment with JSON notation

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5190,8 +5190,10 @@
     sol: function() {return this.pos == this.lineStart;},
     peek: function() {return this.string.charAt(this.pos) || undefined;},
     next: function() {
-      if (this.pos < this.string.length)
-        return this.string.charAt(this.pos++);
+      if (this.pos < this.string.length) {
+          this.pos = this.pos + 1;
+          return this.string.charAt(this.pos);
+      }
     },
     eat: function(match) {
       var ch = this.string.charAt(this.pos);


### PR DESCRIPTION
Hello, I am a developer on a big service. We use your codeMirror as script editor. Our support team found bug - the loop fixated when JSON notation is inside the big comment (/*...*/) - http://prntscr.com/5xbxph. As the result - script editor crashes and the page is not available for any manipulations. Besides Google Chrome actually crashes too and I need to restart it again. 

I fix it (I hope so :) ), but it should be tested for real.

Best Regards, Andrew!