### PR TITLE
Mobile branch: Fix for copying large chunks of text

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1210,7 +1210,7 @@
       function prepareCopyCut(e) {
         if (cm.somethingSelected()) {
           lastCopied = cm.getSelections();
-          if (this.inaccurateSelection) {
+          if (input.inaccurateSelection) {
             input.prevInput = "";
             input.inaccurateSelection = false;
             te.value = lastCopied.join("\n");


### PR DESCRIPTION
Selecting and copying a large chunk of text places a single dash into clipboard.

This is related to line 1285, where the input's content is trimmed for performance:

https://github.com/codemirror/CodeMirror/blob/mobile/lib/codemirror.js#L1285

    minimal = hasCopyEvent &&
      (range.to().line - range.from().line > 100 || (selected = cm.getSelection()).length > 1000);
    var content = minimal ? "-" : selected || cm.getSelection();

The problem is apparently a typo during refactoring/renaming from 'd' on the master branch to 'input' here.