### PR TITLE
[tern addon] Improve tooltip UX

### DIFF
--- a/addon/tern/tern.js
+++ b/addon/tern/tern.js
@@ -589,7 +589,11 @@
       cm.off("cursorActivity", clear);
       fadeOut(tip);
     }
-    setTimeout(clear, 1700);
+    function clearWithTimeout() {
+      cm.getWrapperElement().removeEventListener("mousemove", clearWithTimeout);
+      setTimeout(clear, 3000);
+    }
+    cm.getWrapperElement().addEventListener("mousemove", clearWithTimeout);
     cm.on("cursorActivity", clear);
   }
 


### PR DESCRIPTION
Call the clear() function only after a mouse move has been triggered and
not just after a timeout has passed. This can make longer documentation
texts easier to read.

Extend the clear() function timeout, so that the user has enough time to
move the mouse pointer to the [doc] link.