### PR TITLE
[tern addon] open [doc] link in a new tab/window

### DIFF
--- a/addon/tern/tern.js
+++ b/addon/tern/tern.js
@@ -252,7 +252,9 @@
           tip.appendChild(document.createTextNode(" — " + data.doc));
         if (data.url) {
           tip.appendChild(document.createTextNode(" "));
-          tip.appendChild(elt("a", null, "[docs]")).href = data.url;
+          var child = tip.appendChild(elt("a", null, "[docs]"));
+          child.href = data.url;
+          child.target = "_blank";
         }
       }
       tempTooltip(cm, tip);


### PR DESCRIPTION
Opening the documentation in the same window navigates away from the
code editor.