### PR TITLE
Making tooltip go away on scroll or blur

### DIFF
--- a/addon/tern/tern.js
+++ b/addon/tern/tern.js
@@ -595,6 +595,8 @@
       cm.state.ternTooltip = null;
       if (!tip.parentNode) return;
       cm.off("cursorActivity", clear);
+      cm.off('blur', clear);
+      cm.off('scroll', clear);
       fadeOut(tip);
     }
     var mouseOnTip = false, old = false;
@@ -607,6 +609,8 @@
     });
     setTimeout(maybeClear, 1700);
     cm.on("cursorActivity", clear);
+    cm.on('blur', clear);
+    cm.on('scroll', clear);
   }
 
   function makeTooltip(x, y, content) {


### PR DESCRIPTION
Easiest to see the difference on touch-enabled device. Go to Tern demo page (link below), click on a variable name and press Ctrl+I. Now pan the editor's content. The tooltip stays at a fixed position, whilst the variable name detaches and moves off.

The fix listens to scroll and blur, switching the tooltip off.