### PR TITLE
Fixed an issue with invalid repeating regular expressions flags being highlighted as valid ones

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -118,7 +118,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
       } else if (state.lastType == "operator" || state.lastType == "keyword c" ||
                state.lastType == "sof" || /^[\[{}\(,;:]$/.test(state.lastType)) {
         readRegexp(stream);
-        stream.eatWhile(/[gimy]/); // 'y' is "sticky" option in Mozilla
+        stream.match(/^\b(([gimy])(?!.*\2))+\b/); // 'y' is "sticky" option in Mozilla
         return ret("regexp", "string-2");
       } else {
         stream.eatWhile(isOperatorChar);


### PR DESCRIPTION
I fixed an issue where invalid repeating regular expressions flags (e.g. `gg`, `mim`, `gmigy`) would be recognized and highlighted as they were valid.