### PR TITLE
[css mode] teach it about CSS variables

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -57,6 +57,11 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
       if (/[\d.]/.test(stream.peek())) {
         stream.eatWhile(/[\w.%]/);
         return ret("number", "unit");
+      } else if (stream.match(/^-[\w\\\-]+/)) {
+        stream.eatWhile(/[\w\\\-]/);
+        if (stream.match(/^\s*:/, false))
+          return ret("variable-2", "variable-definition");
+        return ret("variable-2", "variable");
       } else if (stream.match(/^\w+-/)) {
         return ret("meta", "meta");
       }


### PR DESCRIPTION
Currently CSS variables e.g. --main-color not only fail to highlight properly, but also screw up the parsing later in the document, so auto-indenting fails. (It indents an extra step after using a variable in var(), and sometimes un-indents a step after declaring the variable).
This fixes both of these problems by correctly parsing occurrences of --variable-name

Tests run locally, all pass.