### PR TITLE
Missed changes from the @document work

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -345,8 +345,8 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
       if (cx.type == "prop" && (ch == "}" || ch == ")")) cx = cx.prev;
       if (cx.prev &&
           (ch == "}" && (cx.type == "block" || cx.type == "top" || cx.type == "interpolation" || cx.type == "font_face") ||
-           ch == ")" && (cx.type == "parens" || cx.type == "media_parens") ||
-           ch == "{" && (cx.type == "at" || cx.type == "media"))) {
+           ch == ")" && (cx.type == "parens" || cx.type == "atBlock_parens") ||
+           ch == "{" && (cx.type == "at" || cx.type == "atBlock"))) {
         indent = cx.indent - indentUnit;
         cx = cx.prev;
       }

--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -16,6 +16,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
 
   var indentUnit = config.indentUnit,
       tokenHooks = parserConfig.tokenHooks,
+      documentTypes = parserConfig.documentTypes || {},
       mediaTypes = parserConfig.mediaTypes || {},
       mediaFeatures = parserConfig.mediaFeatures || {},
       propertyKeywords = parserConfig.propertyKeywords || {},
@@ -607,7 +608,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
     "font-stretch", "font-weight", "font-style"
   ], fontProperties = keySet(fontProperties_);
 
-  var allWords = mediaTypes_.concat(mediaFeatures_).concat(propertyKeywords_)
+  var allWords = documentTypes_.concat(mediaTypes_).concat(mediaFeatures_).concat(propertyKeywords_)
     .concat(nonStandardPropertyKeywords_).concat(colorKeywords_).concat(valueKeywords_);
   CodeMirror.registerHelper("hintWords", "css", allWords);
 
@@ -634,6 +635,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
   }
 
   CodeMirror.defineMIME("text/css", {
+    documentTypes: documentTypes,
     mediaTypes: mediaTypes,
     mediaFeatures: mediaFeatures,
     propertyKeywords: propertyKeywords,


### PR DESCRIPTION
So I noticed today I missed a couple changes when doing the work for @document.  The most important is in the indent() function, where it referred to the now renamed media and media_parens states.
Also I've added documentTypes to the parserConfig, allWords hint array and CSS mime definition, but I'm not sure if that's needed.  I didn't add it to the LESS and SASS definitions because I'm not sure if that is necessary/they interact well.