### PR TITLE
[closebrackets addon] Option to override expansion of triple quotes #238...

### DIFF
--- a/addon/edit/closebrackets.js
+++ b/addon/edit/closebrackets.js
@@ -10,6 +10,7 @@
     mod(CodeMirror);
 })(function(CodeMirror) {
   var DEFAULT_BRACKETS = "()[]{}''\"\"";
+  var DEFAULT_TRIPLES = "'\"";
   var DEFAULT_EXPLODE_ON_ENTER = "[]{}";
   var SPACE_CHAR_REGEX = /\s/;
 
@@ -19,13 +20,14 @@
     if (old != CodeMirror.Init && old)
       cm.removeKeyMap("autoCloseBrackets");
     if (!val) return;
-    var pairs = DEFAULT_BRACKETS, explode = DEFAULT_EXPLODE_ON_ENTER;
+    var pairs = DEFAULT_BRACKETS, triples = DEFAULT_TRIPLES, explode = DEFAULT_EXPLODE_ON_ENTER;
     if (typeof val == "string") pairs = val;
     else if (typeof val == "object") {
       if (val.pairs != null) pairs = val.pairs;
+      if (val.triples != null) triples = val.triples;
       if (val.explode != null) explode = val.explode;
     }
-    var map = buildKeymap(pairs);
+    var map = buildKeymap(pairs, triples);
     if (explode) map.Enter = buildExplodeHandler(explode);
     cm.addKeyMap(map);
   });
@@ -52,7 +54,7 @@
     }
   }
 
-  function buildKeymap(pairs) {
+  function buildKeymap(pairs, triples) {
     var map = {
       name : "autoCloseBrackets",
       Backspace: function(cm) {
@@ -85,7 +87,7 @@
               curType = "skipThree";
             else
               curType = "skip";
-          } else if (left == right && cur.ch > 1 &&
+          } else if (left == right && cur.ch > 1 && triples.indexOf(left) >= 0 &&
                      cm.getRange(Pos(cur.line, cur.ch - 2), cur) == left + left &&
                      (cur.ch <= 2 || cm.getRange(Pos(cur.line, cur.ch - 3), Pos(cur.line, cur.ch - 2)) != left)) {
             curType = "addFour";


### PR DESCRIPTION
When the closebrackets addon is enabled, typing three quotes in a row causes six quotes to be inserted and puts the cursor in the middle.  Triple quotes make sense in Python and CoffeeScript, but not in the majority of languages.  I added an option to disable this behaviour, usage: `cm = CodeMirror(element, {autoCloseBrackets: {triples: ''}})`.  The default value for `triples` is `"'\""`.