### PR TITLE
[sql-hint addon] Fix defaultTable for new tables format

### DIFF
--- a/addon/hint/sql-hint.js
+++ b/addon/hint/sql-hint.js
@@ -208,8 +208,16 @@
   CodeMirror.registerHelper("hint", "sql", function(editor, options) {
     tables = (options && options.tables) || {};
     var defaultTableName = options && options.defaultTable;
-    defaultTable = (defaultTableName && getItem(tables, defaultTableName)) || [];
+    defaultTable = defaultTableName && getItem(tables, defaultTableName);
     keywords = keywords || getKeywords(editor);
+
+    if (defaultTableName && !defaultTable)
+      defaultTable = findTableByAlias(defaultTableName, editor);
+
+    defaultTable = defaultTable || [];
+
+    if (Array.isArray(tables) && defaultTable.columns)
+      defaultTable = defaultTable.columns;
 
     var cur = editor.getCursor();
     var result = [];


### PR DESCRIPTION
Fix the `defaultTable` option when using the new tables format.