### PR TITLE
Fix scroll position jump on mousedown in Chrome

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3517,10 +3517,11 @@
         e_preventDefault(e2);
         if (!modifier)
           extendSelection(cm.doc, start);
-        display.input.focus();
-        // Work around unexplainable focus problem in IE9 (#2127)
-        if (ie && ie_version == 9)
+        // Work around unexplainable focus problem in IE9 (#2127) and Chrome (#3081)
+        if (webkit || ie && ie_version == 9)
           setTimeout(function() {document.body.focus(); display.input.focus();}, 20);
+        else
+          display.input.focus();
       }
     });
     // Let the drag handler handle this.


### PR DESCRIPTION
Apparently, there's a similar issue in IE9 and I could reuse that code. I don't know if this has any side effects, but it seems to fix the main issue.
Furthermore, I don't know if this issue only exists in Chrome or in whole Webkit.

For #3081.