### PR TITLE
[yaml mode] add ext "yml"

### DIFF
--- a/mode/meta.js
+++ b/mode/meta.js
@@ -128,7 +128,7 @@
     {name: "Verilog", mime: "text/x-verilog", mode: "verilog", ext: ["v"]},
     {name: "XML", mimes: ["application/xml", "text/xml"], mode: "xml", ext: ["xml", "xsl", "xsd"], alias: ["rss", "wsdl", "xsd"]},
     {name: "XQuery", mime: "application/xquery", mode: "xquery", ext: ["xy", "xquery"]},
-    {name: "YAML", mime: "text/x-yaml", mode: "yaml", ext: ["yaml"], alias: ["yml"]},
+    {name: "YAML", mime: "text/x-yaml", mode: "yaml", ext: ["yaml", "yml"], alias: ["yml"]},
     {name: "Z80", mime: "text/x-z80", mode: "z80", ext: ["z80"]}
   ];
   // Ensure all modes have a mime property for backwards compatibility


### PR DESCRIPTION
Yaml files could have `yml` extension, travis  for example use name [.travis.yml](http://docs.travis-ci.com/user/build-configuration "Travis") for configuration file.