### PR TITLE
[vim] Fix a bug in linewise visual mode 

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -4806,7 +4806,7 @@
       var anchor = cm.getCursor('anchor');
       var head = cm.getCursor('head');
       // Enter or exit visual mode to match mouse selection.
-      if (vim.visualMode && cursorEqual(head, anchor) && lineLength(cm, head.line) > head.ch) {
+      if (vim.visualMode && cursorEqual(head, anchor)) {
         exitVisualMode(cm, false);
       } else if (!vim.visualMode && !vim.insertMode && cm.somethingSelected()) {
         vim.visualMode = true;

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1909,6 +1909,13 @@ testVim('visual_block_corners', function(cm, vim, helpers) {
   selections = cm.getSelections();
   eq('891cde', selections.join(''));
 }, {value: '12345\n67891\nabcde'});
+testVim('visual_linewise_substitute', function(cm, vim, helpers) {
+  cm.setCursor(0, 3);
+  helpers.doKeys('V', 'j', 'j', 'j');
+  cm.openDialog = helpers.fakeOpenDialog('\'<,\'>s/123/foo/g');
+  helpers.doKeys(':');
+  eq('foo45\nfoo45\nfoo45\n\n', cm.getValue());
+}, {value: '12345\n12345\n12345\n\n'});
 testVim('visual_block_mode_switch', function(cm, vim, helpers) {
   // switch between visual modes
   cm.setCursor(1, 1);


### PR DESCRIPTION
ex commands (such as :s) operating on linewise block would do nothing if the block happened to end on an empty line.