### PR TITLE
[dialog] Add option to not select value on open

### DIFF
--- a/addon/dialog/dialog.js
+++ b/addon/dialog/dialog.js
@@ -58,7 +58,9 @@
     if (inp) {
       if (options.value) {
         inp.value = options.value;
-        inp.select();
+        if (options.selectValueOnOpen !== false) {
+          inp.select();
+        }
       }
 
       if (options.onInput)

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -3491,7 +3491,8 @@
     function dialog(cm, template, shortText, onClose, options) {
       if (cm.openDialog) {
         cm.openDialog(template, onClose, { bottom: true, value: options.value,
-            onKeyDown: options.onKeyDown, onKeyUp: options.onKeyUp });
+            onKeyDown: options.onKeyDown, onKeyUp: options.onKeyUp,
+            selectValueOnOpen: false});
       }
       else {
         onClose(prompt(shortText, ''));


### PR DESCRIPTION
Behavior introduced in https://github.com/codemirror/CodeMirror/issues/2866 is not desired for vim mode. Adding a `selectValueOnOption` option to flag it (defaults to true). @marijnh thoughts?