### PR TITLE
When using async mode, if there are multiple calls to show the widget (s...

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -88,6 +88,10 @@
     },
 
     showWidget: function(data) {
+      // If the widget already exists, then close it to prevent multiple layered widgets.
+      // This only happes if we're using async callbacks to show the widget
+      if ( this.widget ) this.widget.close();
+
       this.widget = new Widget(this, data);
       CodeMirror.signal(data, "shown");
 


### PR DESCRIPTION
...taggered data loading from multiple sources) then close the widget prior to adding data.