### PR TITLE
[sublime] Sublime-style smart backspace

### DIFF
--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -409,6 +409,22 @@
 
   map[cK + ctrl + "Backspace"] = "delLineLeft";
 
+  cmds[map["Backspace"] = "smartBackspace"] = function(cm) {
+    if (cm.somethingSelected()) {
+      return CodeMirror.Pass;
+    }
+
+    var tabSize = cm.getOption('tabSize');
+    var cursor = cm.getCursor();
+    var toStartOfLine = cm.getRange({line: cursor.line, ch: 0}, cursor);
+    var column = CodeMirror.countColumn(toStartOfLine, null, tabSize);
+
+    if (/^\s+$/.test(toStartOfLine) && column % tabSize == 0) {
+      return cm.indentSelection('subtract');
+    }
+    return CodeMirror.Pass;
+  };
+
   cmds[map[cK + ctrl + "K"] = "delLineRight"] = function(cm) {
     cm.operation(function() {
       var ranges = cm.listSelections();


### PR DESCRIPTION
In Sublime, when you hit backspace, the editor checks to see if everything proceeding your cursor is whitespace. If it is, and your cursor is on an even multiple of the tab size, it will simply delete one full tab, which is pretty nice.

I've tried to mimic this here. It's a bit hacky without some defined API for figuring out the real length of hard vs soft tabs but I think this suffices. Thoughts?