### PR TITLE
[lint addon] add support for jshint globals option

### DIFF
--- a/addon/lint/javascript-lint.js
+++ b/addon/lint/javascript-lint.js
@@ -23,7 +23,7 @@
 
   function validator(text, options) {
     if (!window.JSHINT) return [];
-    JSHINT(text, options);
+    JSHINT(text, options, options.globals);
     var errors = JSHINT.data().errors, result = [];
     if (errors) parseErrors(errors, result);
     return result;


### PR DESCRIPTION
`options` with a `globals` key as defined in a standard `.jshintrc` is actually separated into two arguments to the `JSHINT` function in the `jshint` cli: `https://github.com/gameclosure/jshint/blob/master/src/cli.js#L487`.  This forwards `options.globals` properly to `JSHINT`.