### PR TITLE
Mac: Hold Option key to copy selection (instead of Cmd)

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3518,7 +3518,7 @@
       lastClick = {time: now, pos: start};
     }
 
-    var sel = cm.doc.sel, modifier = mac ? e.metaKey : e.ctrlKey, contained;
+    var sel = cm.doc.sel, modifier = mac ? e.altKey : e.ctrlKey, contained;
     if (cm.options.dragDrop && dragAndDrop && !isReadOnly(cm) &&
         type == "single" && (contained = sel.contains(start)) > -1 &&
         !sel.ranges[contained].empty())
@@ -3768,7 +3768,7 @@
       try {
         var text = e.dataTransfer.getData("Text");
         if (text) {
-          if (cm.state.draggingText && !(mac ? e.metaKey : e.ctrlKey))
+          if (cm.state.draggingText && !(mac ? e.altKey : e.ctrlKey))
             var selected = cm.listSelections();
           setSelectionNoUndo(cm.doc, simpleSelection(pos, pos));
           if (selected) for (var i = 0; i < selected.length; ++i)


### PR DESCRIPTION
(https://github.com/adobe/brackets/issues/9172#issuecomment-85076558, https://github.com/adobe/brackets/issues/3125#issuecomment-83274492)

__Note:__ I don't own a Mac myself, so this is something I couldn't confirm/test myself, but rather through @nethip and @infin80.

So apparently, at least in Chrome, Mac's Cmd key state (`e.metaKey`) doesn't get passed through to the MouseEvent, which prevents a user from copying a selection by holding down Cmd while moving text using Drag & Drop.
As the Cmd key doesn't work and the Option key (`e.altKey`) seems to be the usual key for that feature on Mac, I switched over to using that key, which seems to work (as I pointed out above, I am not able to test it myself).
The only issue here is that the Option key is already used to create a rectangular selection, so every time you hold it down you will see a crosshairs cursor.

Looking for feedback. Thanks.

CEF ~ Chrome 39.0.2171.36