### PR TITLE
Fix variable color in the monokai and solarized themes.

### DIFF
--- a/theme/monokai.css
+++ b/theme/monokai.css
@@ -18,7 +18,7 @@
 .cm-s-monokai span.cm-keyword {color: #f92672;}
 .cm-s-monokai span.cm-string {color: #e6db74;}
 
-.cm-s-monokai span.cm-variable {color: #a6e22e;}
+.cm-s-monokai span.cm-variable {color: #f8f8f2;}
 .cm-s-monokai span.cm-variable-2 {color: #9effff;}
 .cm-s-monokai span.cm-def {color: #fd971f;}
 .cm-s-monokai span.cm-bracket {color: #f8f8f2;}

--- a/theme/solarized.css
+++ b/theme/solarized.css
@@ -53,7 +53,7 @@ http://ethanschoonover.com/solarized/img/solarized-palette.png
 .cm-s-solarized .cm-number { color: #d33682; }
 .cm-s-solarized .cm-def { color: #2aa198; }
 
-.cm-s-solarized .cm-variable { color: #268bd2; }
+.cm-s-solarized .cm-variable { color: #839496; }
 .cm-s-solarized .cm-variable-2 { color: #b58900; }
 .cm-s-solarized .cm-variable-3 { color: #6c71c4; }
 


### PR DESCRIPTION
I've noticed that the colors for the Monokai and the Solarized theme are wrong. After inspecting around, I've noticed that any non-keyword gets marked as 'cm-variable'. This makes looking at files like Java and C++ (which we do a lot at Google) very hard with theses themes.

Here is the before:
Solarized Dark: https://drive.google.com/file/d/0B_n2OUyge9Hac185Y3JtOWM3WG8/view?usp=sharing
Monokai: https://drive.google.com/file/d/0B_n2OUyge9HaTkNTaXVvWnJmNTQ/view?usp=sharing

Solarized Dark: https://drive.google.com/file/d/0B_n2OUyge9Hacjc5bmpfZmFFMUU/view?usp=sharing
Monokai: https://drive.google.com/file/d/0B_n2OUyge9HaTkNTaXVvWnJmNTQ/view?usp=sharing