### PR TITLE
removed an unnecessary line to close the popup widget

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -137,7 +137,6 @@
           completion.close();
         } else {
           debounce = requestAnimationFrame(update);
-          if (completion.widget) completion.widget.close();
         }
       }
       this.cm.on("cursorActivity", activity);


### PR DESCRIPTION
It seems that this line is an unnecessary, as the popup widget is already closed in the finishUpdate function.

This would solve: https://github.com/codemirror/CodeMirror/issues/3157