### PR TITLE
Enable interpolation in LESS

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -750,6 +750,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
         }
       },
       "@": function(stream) {
+        if (stream.eat("{")) return [null, "interpolation"];
         if (stream.match(/^(charset|document|font-face|import|(-(moz|ms|o|webkit)-)?keyframes|media|namespace|page|supports)\b/, false)) return false;
         stream.eatWhile(/[\w\\\-]/);
         if (stream.match(/^\s*:/, false))


### PR DESCRIPTION
[LESS supports interpolation](http://lesscss.org/features/#variables-feature-variable-interpolation) as well (using `@` as the special char, like in `@{dark-bg}`).

It would be great if [interpolation inside a string](http://lesscss.org/features/#variables-feature-urls) would be highlighted as well.