### PR TITLE
Fix for StringStream.match() when a RegExp starts with \b

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5857,7 +5857,7 @@
           // If the regex starts with \b than we need to consider the previous
           // character as the pattern implies that any previous
           // character should be a non-word character to satisfy the regex.
-          // However, when parsing the string as a stream, every search will 
+          // However, when parsing the string as a stream, every search will
           // match a leading \b pattern because each successive search moves the
           // start of line forward and ignores the previous characters. The
           // following check will honor the leading \b in the pattern.

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5852,6 +5852,20 @@
       } else {
         var match = this.string.slice(this.pos).match(pattern);
         if (match && match.index > 0) return null;
+
+        if (pattern.source.indexOf('\\b') == 0) {
+          // If the regex starts with \b than we need to consider the previous
+          // character as the pattern implies that any previous
+          // character should be a non-word character to satisfy the regex.
+          // However, when parsing the string as a stream, every search will 
+          // match a leading \b pattern because each successive search moves the
+          // start of line forward and ignores the previous characters. The
+          // following check will honor the leading \b in the pattern.
+          if (this.pos > 1 && /\w/.test(this.string.charAt(this.pos-1))) {
+              return;
+          }
+        }
+
         if (match && consume !== false) this.pos += match[0].length;
         return match;
       }


### PR DESCRIPTION
Here's a fix for a small bug with highlighting search matches.  If a user wants to perform a whole word search they will typically wrap their pattern with a leading and trailing \b.  (eg. /\btext\b/)  Currently the search highlighter will highlight additional matches which are not whole word matches.  This patch is a fix for this issue.

Thanks!