### PR TITLE
Change "language modes" link to "over 100 languages"

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
 <section id=features>
   <h2>Features</h2>
   <ul>
-    <li>Support for <a href="mode/index.html">over 90 languages</a> out of the box
+    <li>Support for <a href="mode/index.html">over 100 languages</a> out of the box
     <li>A powerful, <a href="mode/htmlmixed/index.html">composable</a> language mode <a href="doc/manual.html#modeapi">system</a>
     <li><a href="doc/manual.html#addon_show-hint">Autocompletion</a> (<a href="demo/xmlcomplete.html">XML</a>)
     <li><a href="doc/manual.html#addon_foldcode">Code folding</a>


### PR DESCRIPTION
Currently, CM has exactly 101 modes linked to on the [modes page], so we can safely change that statement.

Determined using `document.querySelectorAll("article li > a").length` (it's only 100 list items as `gfm` and `markdown` share a line).