### PR TITLE
[markdown mode] Fix inappropiate behavior of continuelist addon

### DIFF
--- a/addon/edit/continuelist.js
+++ b/addon/edit/continuelist.js
@@ -22,7 +22,7 @@
       var pos = ranges[i].head, match;
       var eolState = cm.getStateAfter(pos.line);
       var inList = eolState.list !== false;
-      var inQuote = eolState.quote !== false;
+      var inQuote = eolState.quote !== 0;
 
       if (!ranges[i].empty() || (!inList && !inQuote) || !(match = cm.getLine(pos.line).match(listRE))) {
         cm.execCommand("newlineAndIndent");

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -116,18 +116,20 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
     var sol = stream.sol();
 
-    var prevLineIsList = (state.list !== false);
-    if (state.list !== false && state.indentationDiff >= 0) { // Continued list
-      if (state.indentationDiff < 4) { // Only adjust indentation if *not* a code block
-        state.indentation -= state.indentationDiff;
+    var prevLineIsList = state.list !== false;
+    if (prevLineIsList) {
+      if (state.indentationDiff >= 0) { // Continued list
+        if (state.indentationDiff < 4) { // Only adjust indentation if *not* a code block
+          state.indentation -= state.indentationDiff;
+        }
+        state.list = null;
+      } else if (state.indentation > 0) {
+        state.list = null;
+        state.listDepth = Math.floor(state.indentation / 4);
+      } else { // No longer a list
+        state.list = false;
+        state.listDepth = 0;
       }
-      state.list = null;
-    } else if (state.list !== false && state.indentation > 0) {
-      state.list = null;
-      state.listDepth = Math.floor(state.indentation / 4);
-    } else if (state.list !== false) { // No longer a list
-      state.list = false;
-      state.listDepth = 0;
     }
 
     var match = null;


### PR DESCRIPTION
Steps to reproduce the issue:
1. Go to http://codemirror.net/mode/markdown/index.html
2. Replace all the text with `- --` (which is a horizontal ruler)
3. Press Enter

Result:
``` md
- --
- 
```

Expected:
``` md
- --

```
The issue was that `state.quote`, a numeric value, was compared to `false`.

I also improved the markdown mode a tiny bit.