### PR TITLE
[clike mode] Remove C 'entry' keyword

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -185,7 +185,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     return obj;
   }
   var cKeywords = "auto if break int case long char register continue return default short do sizeof " +
-    "double static else struct entry switch extern typedef float union for unsigned " +
+    "double static else struct switch extern typedef float union for unsigned " +
     "goto while enum void const signed volatile";
 
   function cppHook(stream, state) {


### PR DESCRIPTION
It was never standardized and is no longer a reserved word: http://publications.gbdirect.co.uk/c_book/chapter2/keywords_and_identifiers.html