### PR TITLE
[python mode] better highlighting for and/or/not

### DIFF
--- a/mode/python/python.js
+++ b/mode/python/python.js
@@ -162,15 +162,13 @@
       if (stream.match(tripleDelimiters) || stream.match(doubleDelimiters))
         return null;
 
-      if (stream.match(doubleOperators)
-          || stream.match(singleOperators)
-          || stream.match(wordOperators))
+      if (stream.match(doubleOperators) || stream.match(singleOperators))
         return "operator";
 
       if (stream.match(singleDelimiters))
         return null;
 
-      if (stream.match(keywords))
+      if (stream.match(keywords) || stream.match(wordOperators))
         return "keyword";
 
       if (stream.match(builtins))


### PR DESCRIPTION
Currently and/or/not in most themes look like normal text because cm-operator doesn't usually get special styling. This patch highlights them as keywords to make them stand out better.