### PR TITLE
Add support for configuring language mode via vim 'filetype' setting

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -4151,16 +4151,37 @@
           // Calling set with a boolean option sets it to true.
           value = true;
         }
-        if (!optionIsBoolean && !value || forceGet) {
-          var oldValue = getOption(optionName);
-          // If no value is provided, then we assume this is a get.
+        // 'ft' is an alias for 'filetype'.
+        if (optionName == 'ft') {
+          optionName = 'filetype';
+        }
+        // If no value is provided, then we assume this is a get.
+        if (!optionIsBoolean && value === undefined || forceGet) {
+          var oldValue;
+          if (optionName == 'filetype') {
+            // The 'filetype' option proxies to the CodeMirror 'mode' option.
+            oldValue = cm.getMode().name;
+            if (oldValue == 'null') {
+              oldValue = '';
+            }
+          } else {
+            oldValue = getOption(optionName);
+          }
           if (oldValue === true || oldValue === false) {
             showConfirm(cm, ' ' + (oldValue ? '' : 'no') + optionName);
           } else {
             showConfirm(cm, '  ' + optionName + '=' + oldValue);
           }
         } else {
-          setOption(optionName, value);
+          if (optionName == 'filetype') {
+            // The 'filetype' option proxies to the CodeMirror 'mode' option.
+            if (value == '') {
+              value = 'null';
+            }
+            cm.setOption('mode', value);
+          } else {
+            setOption(optionName, value);
+          }
         }
       },
       registers: function(cm,params) {

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -3682,6 +3682,35 @@ testVim('ex_set_string', function(cm, vim, helpers) {
   helpers.doEx('set testoption=c')
   eq('c', CodeMirror.Vim.getOption('testoption'));
 });
+testVim('ex_set_filetype', function(cm, vim, helpers) {
+  CodeMirror.defineMode('test_mode', function() {
+    return {token: function(stream) {
+      stream.match(/^\s+|^\S+/);
+    }};
+  });
+  CodeMirror.defineMode('test_mode_2', function() {
+    return {token: function(stream) {
+      stream.match(/^\s+|^\S+/);
+    }};
+  });
+  // Test mode is set.
+  helpers.doEx('set filetype=test_mode');
+  eq('test_mode', cm.getMode().name);
+  // Test 'ft' alias also sets mode.
+  helpers.doEx('set ft=test_mode_2');
+  eq('test_mode_2', cm.getMode().name);
+});
+testVim('ex_set_filetype_null', function(cm, vim, helpers) {
+  CodeMirror.defineMode('test_mode', function() {
+    return {token: function(stream) {
+      stream.match(/^\s+|^\S+/);
+    }};
+  });
+  cm.setOption('mode', 'test_mode');
+  // Test mode is set to null.
+  helpers.doEx('set filetype=');
+  eq('null', cm.getMode().name);
+});
 // TODO: Reset key maps after each test.
 testVim('ex_map_key2key', function(cm, vim, helpers) {
   helpers.doEx('map a x');


### PR DESCRIPTION
Allows using the vim `:set` command to query and override the language mode:
```vim
:set filetype?
:set ft?
:set filetype=clike
:set filetype=
```