### PR TITLE
Radically improve Django mode

### DIFF
--- a/mode/django/django.js
+++ b/mode/django/django.js
@@ -18,7 +18,10 @@
                     "loop", "none", "self", "super", "if", "endif", "as", "not", "and",
                     "else", "import", "with", "endwith", "without", "context", "ifequal", "endifequal",
                     "ifnotequal", "endifnotequal", "extends", "include", "load", "length", "comment",
-                    "endcomment", "empty"];
+                    "endcomment", "empty", "url", "static", "trans", "blocktrans", "now", "regroup",
+                    "lorem", "ifchanged", "endifchanged", "firstof", "debug", "cycle", "csrf_token",
+                    "autoescape", "endautoescape", "spaceless", "ssi", "templatetag",
+                    "verbatim", "endverbatim", "widthratio"];
     keywords = new RegExp("^((" + keywords.join(")|(") + "))\\b");
 
     function tokenBase (stream, state) {

--- a/mode/django/django.js
+++ b/mode/django/django.js
@@ -68,11 +68,22 @@
     // occurs again.
     function inString (delimeter, previousTokenizer) {
       return function (stream, state) {
-        if (stream.eat(delimeter)) {
+        if (!state.escapeNext && stream.eat(delimeter)) {
           state.tokenize = previousTokenizer;
         } else {
+          if (state.escapeNext) {
+            state.escapeNext = false;
+          }
+
           var ch = stream.next();
+
+          // Take into account the backslash for escaping characters, such as
+          // the string delimeter.
+          if (ch == "\\") {
+            state.escapeNext = true;
+          }
         }
+
         return "string";
       };
     }

--- a/mode/django/django.js
+++ b/mode/django/django.js
@@ -44,6 +44,17 @@
         if (stream.match(keywords)) {
           return "keyword";
         }
+        if(state.instring) {
+          if(ch == state.instring) {
+            state.instring = false;
+          }
+          stream.next();
+          return "string";
+        } else if(ch == "'" || ch == '"') {
+          state.instring = ch;
+          stream.next();
+          return "string";
+        }
         return close == "#" ? "comment" : "string";
       };
     }

--- a/mode/django/django.js
+++ b/mode/django/django.js
@@ -21,9 +21,23 @@
                     "endcomment", "empty", "url", "static", "trans", "blocktrans", "now", "regroup",
                     "lorem", "ifchanged", "endifchanged", "firstof", "debug", "cycle", "csrf_token",
                     "autoescape", "endautoescape", "spaceless", "ssi", "templatetag",
-                    "verbatim", "endverbatim", "widthratio"];
+                    "verbatim", "endverbatim", "widthratio"],
+        filters = ["add", "addslashes", "capfirst", "center", "cut", "date",
+                   "default", "default_if_none", "dictsort",
+                   "dictsortreversed", "divisibleby", "escape", "escapejs",
+                   "filesizeformat", "first", "floatformat", "force_escape",
+                   "get_digit", "iriencode", "join", "last", "length",
+                   "length_is", "linebreaks", "linebreaksbr", "linenumbers",
+                   "ljust", "lower", "make_list", "phone2numeric", "pluralize",
+                   "pprint", "random", "removetags", "rjust", "safe",
+                   "safeseq", "slice", "slugify", "stringformat", "striptags",
+                   "time", "timesince", "timeuntil", "title", "truncatechars",
+                   "truncatechars_html", "truncatewords", "truncatewords_html",
+                   "unordered_list", "upper", "urlencode", "urlize",
+                   "urlizetrunc", "wordcount", "wordwrap", "yesno"];
 
     keywords = new RegExp("^\\b(" + keywords.join("|") + ")\\b");
+    filters = new RegExp("^\\|(" + filters.join("|") + ")\\b");
 
     function tokenBase (stream, state) {
       stream.eatWhile(/[^\{]/);
@@ -47,6 +61,9 @@
         }
         if (stream.match(keywords)) {
           return "keyword";
+        }
+        if (stream.match(filters)) {
+          return "variable-2";
         }
         if(state.instring) {
           if(ch == state.instring) {

--- a/mode/django/django.js
+++ b/mode/django/django.js
@@ -51,6 +51,9 @@
       } else if (stream.match("{%")) {
         state.tokenize = inTag;
         return "tag";
+      } else if (stream.match("{#")) {
+        state.tokenize = inComment;
+        return "comment";
       }
 
       // Ignore completely any stream series that do not match the
@@ -277,6 +280,13 @@
       // If nothing was found, advance to the next character
       stream.next();
       return "null";
+    }
+
+    function inComment (stream, state) {
+      if (stream.match("#}")) {
+        state.tokenize = tokenBase;
+      }
+      return "comment";
     }
 
     return {

--- a/mode/django/django.js
+++ b/mode/django/django.js
@@ -14,8 +14,8 @@
   "use strict";
 
   CodeMirror.defineMode("django:inner", function() {
-    var keywords = ["block", "endblock", "for", "endfor", "in", "true", "false",
-                    "loop", "none", "self", "super", "if", "endif", "as", "not", "and",
+    var keywords = ["block", "endblock", "for", "endfor", "true", "false",
+                    "loop", "none", "self", "super", "if", "endif", "as",
                     "else", "import", "with", "endwith", "without", "context", "ifequal", "endifequal",
                     "ifnotequal", "endifnotequal", "extends", "include", "load", "comment",
                     "endcomment", "empty", "url", "static", "trans", "blocktrans", "now", "regroup",
@@ -34,10 +34,12 @@
                    "time", "timesince", "timeuntil", "title", "truncatechars",
                    "truncatechars_html", "truncatewords", "truncatewords_html",
                    "unordered_list", "upper", "urlencode", "urlize",
-                   "urlizetrunc", "wordcount", "wordwrap", "yesno"];
+                   "urlizetrunc", "wordcount", "wordwrap", "yesno"],
+        operators = ["==", "!=", "<", ">", "<=", ">=", "in", "not", "or", "and"];
 
     keywords = new RegExp("^\\b(" + keywords.join("|") + ")\\b");
     filters = new RegExp("^\\b(" + filters.join("|") + ")\\b");
+    operators = new RegExp("^\\b(" + operators.join("|") + ")\\b");
 
     // We have to return "null" instead of null, in order to avoid string
     // styling as the default, when using Django templates inside HTML
@@ -243,6 +245,11 @@
       } else if (stream.match('"')) {
         state.tokenize = inString('"', state.tokenize);
         return "string";
+      }
+
+      // Attempt to match an operator
+      if (stream.match(operators)) {
+        return "operator";
       }
 
       // Attempt to match a keyword

--- a/mode/django/django.js
+++ b/mode/django/django.js
@@ -37,11 +37,11 @@
                    "urlizetrunc", "wordcount", "wordwrap", "yesno"];
 
     keywords = new RegExp("^\\b(" + keywords.join("|") + ")\\b");
-    filters = new RegExp("^\\|(" + filters.join("|") + ")\\b");
+    filters = new RegExp("^\\b(" + filters.join("|") + ")\\b");
 
     function tokenBase (stream, state) {
       if (stream.match("{{")) {
-        state.tokenize = inTag("{{");
+        state.tokenize = inVariable;
         return "tag";
       } else if (stream.match("{%")) {
         state.tokenize = inTag("{%");
@@ -51,6 +51,92 @@
       // Ignore completely any stream series that do not match the
       // Django template opening tags.
       while (stream.next() != null && !stream.match("{{", false) && !stream.match("{%", false)) {}
+      return null;
+    }
+
+    // Apply Django template variable syntax highlighting
+    function inVariable (stream, state) {
+      // Attempt to match a dot that precedes a property
+      if (state.waitDot) {
+        state.waitDot = false;
+
+        if (stream.peek() != ".") {
+          return null;
+        }
+
+        // Dot folowed by a non-word character should be considered an error.
+        if (stream.match(/\.\W+/)) {
+          return "error";
+        } else if (stream.eat(".")) {
+          state.waitProperty = true;
+          return null;
+        } else {
+          throw Error ("Unexpected error while waiting for property.");
+        }
+      }
+
+      // Attempt to match a pipe that precedes a filter
+      if (state.waitPipe) {
+        state.waitPipe = false;
+
+        if (stream.peek() != "|") {
+          return null;
+        }
+
+        // Pipe folowed by a non-word character should be considered an error.
+        if (stream.match(/\.\W+/)) {
+          return "error";
+        } else if (stream.eat("|")) {
+          state.waitFilter = true;
+          return null;
+        } else {
+          throw Error ("Unexpected error while waiting for filter.");
+        }
+      }
+
+      // Highlight properties
+      if (state.waitProperty) {
+        state.waitProperty = false;
+        if (stream.match(/\b(\w+)\b/)) {
+          state.waitDot = true;  // A property can be followed by another property
+          state.waitPipe = true;  // A property can be followed by a filter
+          return "property";
+        }
+      }
+
+      // Highlight filters
+      if (state.waitFilter) {
+          state.waitFilter = false;
+        if (stream.match(filters)) {
+          return "variable-2";
+        }
+      }
+
+      // Ignore all white spaces
+      if (stream.eatSpace()) {
+        state.waitProperty = false;
+        return null;
+      }
+
+      // Attempt to find the variable
+      if (stream.match(/\b(\w+)\b/) && !state.foundVariable) {
+        state.waitDot = true;
+        state.waitPipe = true;  // A property can be followed by a filter
+        return "variable";
+      }
+
+      // If found closing tag reset
+      if (stream.match("}}")) {
+        state.waitProperty = null;
+        state.waitFilter = null;
+        state.waitDot = null;
+        state.waitPipe = null;
+        state.tokenize = tokenBase;
+        return "tag";
+      }
+
+      // If nothing was found, advance to the next character
+      stream.next();
       return null;
     }
 

--- a/mode/django/django.js
+++ b/mode/django/django.js
@@ -295,7 +295,9 @@
       },
       token: function (stream, state) {
         return state.tokenize(stream, state);
-      }
+      },
+      blockCommentStart: "{% comment %}",
+      blockCommentEnd: "{% endcomment %}"
     };
   });
 

--- a/mode/django/django.js
+++ b/mode/django/django.js
@@ -17,12 +17,13 @@
     var keywords = ["block", "endblock", "for", "endfor", "in", "true", "false",
                     "loop", "none", "self", "super", "if", "endif", "as", "not", "and",
                     "else", "import", "with", "endwith", "without", "context", "ifequal", "endifequal",
-                    "ifnotequal", "endifnotequal", "extends", "include", "load", "length", "comment",
+                    "ifnotequal", "endifnotequal", "extends", "include", "load", "comment",
                     "endcomment", "empty", "url", "static", "trans", "blocktrans", "now", "regroup",
                     "lorem", "ifchanged", "endifchanged", "firstof", "debug", "cycle", "csrf_token",
                     "autoescape", "endautoescape", "spaceless", "ssi", "templatetag",
                     "verbatim", "endverbatim", "widthratio"];
-    keywords = new RegExp("^((" + keywords.join(")|(") + "))\\b");
+
+    keywords = new RegExp("^\\b(" + keywords.join("|") + ")\\b");
 
     function tokenBase (stream, state) {
       stream.eatWhile(/[^\{]/);
@@ -58,7 +59,7 @@
           stream.next();
           return "string";
         }
-        return close == "#" ? "comment" : "string";
+        return null;
       };
     }
     return {

--- a/mode/django/index.html
+++ b/mode/django/index.html
@@ -5,6 +5,7 @@
 <link rel=stylesheet href="../../doc/docs.css">
 
 <link rel="stylesheet" href="../../lib/codemirror.css">
+<link rel="stylesheet" href="../../theme/mdn-like.css">
 <script src="../../lib/codemirror.js"></script>
 <script src="../../addon/mode/overlay.js"></script>
 <script src="../xml/xml.js"></script>
@@ -30,23 +31,25 @@
 <form><textarea id="code" name="code">
 <!doctype html>
 <html>
-    <head>
-        <title>My Django web application</title>
-    </head>
-    <body>
-        <h1>
-            {{ page.title|capfirst }}
-        </h1>
-        <ul class="my-list">
-            {% for item in items %}
-                <li>
-                    <a href="{% url 'item_view' item.name|slugify %}">{{ item.name }}</a>
-                </li>
-            {% empty %}
-                <li>You have no items in your list.</li>
-            {% endfor %}
-        </ul>
-    </body>
+  <head>
+    <title>My Django web application</title>
+  </head>
+  <body>
+    <h1>
+      {{ page.title|capfirst }}
+    </h1>
+    <ul class="my-list">
+      {% for item in items %}
+      <li>
+        <a href="{% url 'item_view' item.name|slugify %}">
+          {{ item.name }}
+        </a>
+      </li>
+      {% empty %}
+      <li>You have no items in your list.</li>
+      {% endfor %}
+    </ul>
+  </body>
 </html>
 </textarea></form>
 
@@ -54,8 +57,9 @@
       var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
         lineNumbers: true,
         mode: "django",
-        indentUnit: 4,
-        indentWithTabs: true
+        indentUnit: 2,
+        indentWithTabs: true,
+        theme: "mdn-like"
       });
     </script>
 

--- a/mode/django/index.html
+++ b/mode/django/index.html
@@ -50,6 +50,9 @@
       <li>You have no items in your list.</li>
       {% endfor %}
     </ul>
+    {% comment "this is a forgotten footer" %}
+    <footer></footer>
+    {% endcomment %}
   </body>
 </html>
 </textarea></form>

--- a/mode/django/index.html
+++ b/mode/django/index.html
@@ -35,7 +35,7 @@
     </head>
     <body>
         <h1>
-            {{ page.title }}
+            {{ page.title|capfirst }}
         </h1>
         <ul class="my-list">
             {% for item in items %}

--- a/mode/django/index.html
+++ b/mode/django/index.html
@@ -39,7 +39,7 @@
         </h1>
         <ul class="my-list">
             {% for item in items %}
-                <li>{% item.name %}</li>
+                <li><a href="{% url 'item_view' item.name|slugify %}">{% item.name %}</a></li>
             {% empty %}
                 <li>You have no items in your list.</li>
             {% endfor %}

--- a/mode/django/index.html
+++ b/mode/django/index.html
@@ -39,7 +39,9 @@
         </h1>
         <ul class="my-list">
             {% for item in items %}
-                <li><a href="{% url 'item_view' item.name|slugify %}">{% item.name %}</a></li>
+                <li>
+                    <a href="{% url 'item_view' item.name|slugify %}">{{ item.name }}</a>
+                </li>
             {% empty %}
                 <li>You have no items in your list.</li>
             {% endfor %}

--- a/mode/django/index.html
+++ b/mode/django/index.html
@@ -39,6 +39,7 @@
       {{ page.title|capfirst }}
     </h1>
     <ul class="my-list">
+      {# traverse a list of items and produce links to their views. #}
       {% for item in items %}
       <li>
         <a href="{% url 'item_view' item.name|slugify %}">


### PR DESCRIPTION
This pull request improves radically the Django mode by introducing more features and fixing some bugs.

In detail, this pull request introduces the following

- Comment highlighting (both with inline tag and block comment tag)
- String highlighting
- Variable and variable attribute highlighting
- Operator highlighting
- Highlighting for filters
- Definition of `blockCommentStart` and `blockCommentEnd`
- Appropriate highlighting according to tag type: (`variable`, `tag`, `comment`)

This pull request also fixes two major bugs that made highlighting break:

- Including keywords inside strings highlighted them as keywords instead of string
- Mixing Django template highlighting with HTML highlighting in the same line broke the HTML highlighting

The only oddball in this pull request is the `"null"` token styling. Since the `django` mode is an overlay of `django:inner` over `html`, when using Django templates in HTML tag attributes, returning `null` results in string styling (because of the HTML tag attribute), instead of no styling. For this reason I returned `"null"` to avoid this.

The Django template language is described extensively at https://docs.djangoproject.com/en/1.8/ref/templates/language

This pull request can be tested at https://codemirror-paris.apps.lair.io/mode/django/index.html