### PR TITLE
[vim] Implement window/buffer-local options.

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -397,8 +397,9 @@
       }
     }
 
-    function setOption(name, value) {
+    function setOption(name, value, cm, cfg) {
       var option = options[name];
+      var scope = (cfg || {}).scope;
       if (!option) {
         throw Error('Unknown option: ' + name);
       }
@@ -411,21 +412,40 @@
         }
       }
       if (option.callback) {
-        option.callback(value);
+        if (scope !== 'local') {
+          option.callback(value, undefined);
+        }
+        if (scope !== 'global' && cm) {
+          option.callback(value, cm);
+        }
       } else {
-        option.value = option.type == 'boolean' ? !!value : value;
+        if (scope !== 'local') {
+          option.value = option.type == 'boolean' ? !!value : value;
+        }
+        if (scope !== 'global' && cm) {
+          cm.state.vim.options[name] = {value: value};
+        }
       }
     }
 
-    function getOption(name) {
+    function getOption(name, cm, cfg) {
       var option = options[name];
+      var scope = (cfg || {}).scope;
       if (!option) {
         throw Error('Unknown option: ' + name);
       }
       if (option.callback) {
-        return option.callback();
+        var local = cm && option.callback(undefined, cm);
+        if (scope !== 'global' && local !== undefined) {
+          return local;
+        }
+        if (scope !== 'local') {
+          return option.callback();
+        }
+        return;
       } else {
-        return option.value;
+        var local = (scope !== 'global') && (cm && cm.state.vim.options[name]);
+        return (local || (scope !== 'local') && option || {}).value;
       }
     }
 
@@ -581,8 +601,9 @@
           visualBlock: false,
           lastSelection: null,
           lastPastedText: null,
-          sel: {
-          }
+          sel: {},
+          // Buffer-local/window-local values of vim options.
+          options: {}
         };
       }
       return cm.state.vim;
@@ -640,6 +661,8 @@
         // Add user defined key bindings.
         exCommandDispatcher.map(lhs, rhs, ctx);
       },
+      // TODO: Expose setOption and getOption as instance methods. Need to decide how to namespace
+      // them, or somehow make them work with the existing CodeMirror setOption/getOption API.
       setOption: setOption,
       getOption: getOption,
       defineOption: defineOption,
@@ -3881,7 +3904,10 @@
       { name: 'write', shortName: 'w' },
       { name: 'undo', shortName: 'u' },
       { name: 'redo', shortName: 'red' },
-      { name: 'set', shortName: 'set' },
+      { name: 'set', shortName: 'se' },
+      { name: 'set', shortName: 'se' },
+      { name: 'setlocal', shortName: 'setl' },
+      { name: 'setglobal', shortName: 'setg' },
       { name: 'sort', shortName: 'sor' },
       { name: 'substitute', shortName: 's', possiblyAsync: true },
       { name: 'nohlsearch', shortName: 'noh' },
@@ -4146,6 +4172,9 @@
       },
       set: function(cm, params) {
         var setArgs = params.args;
+        // Options passed through to the setOption/getOption calls. May be passed in by the
+        // local/global versions of the set command
+        var setCfg = params.setCfg || {};
         if (!setArgs || setArgs.length < 1) {
           if (cm) {
             showConfirm(cm, 'Invalid mapping: ' + params.input);
@@ -4175,7 +4204,7 @@
           value = true;
         }
         if (!optionIsBoolean && !value || forceGet) {
-          var oldValue = getOption(optionName);
+          var oldValue = getOption(optionName, cm, setCfg);
           // If no value is provided, then we assume this is a get.
           if (oldValue === true || oldValue === false) {
             showConfirm(cm, ' ' + (oldValue ? '' : 'no') + optionName);
@@ -4183,10 +4212,20 @@
             showConfirm(cm, '  ' + optionName + '=' + oldValue);
           }
         } else {
-          setOption(optionName, value);
+          setOption(optionName, value, cm, setCfg);
         }
       },
-      registers: function(cm,params) {
+      setlocal: function (cm, params) {
+        // setCfg is passed through to setOption
+        params.setCfg = {scope: 'local'};
+        this.set(cm, params);
+      },
+      setglobal: function (cm, params) {
+        // setCfg is passed through to setOption
+        params.setCfg = {scope: 'global'};
+        this.set(cm, params);
+      },
+      registers: function(cm, params) {
         var regArgs = params.args;
         var registers = vimGlobalState.registerController.registers;
         var regInfo = '----------Registers----------<br><br>';

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -504,7 +504,7 @@ testVim('{', function(cm, vim, helpers) {
   helpers.doKeys('6', '{');
   helpers.assertCursorAt(0, 0);
 }, { value: 'a\n\nb\nc\n\nd' });
-testVim('paragraph motions', function(cm, vim, helpers) {
+testVim('paragraph_motions', function(cm, vim, helpers) {
   cm.setCursor(10, 0);
   helpers.doKeys('{');
   helpers.assertCursorAt(4, 0);
@@ -3708,41 +3708,83 @@ testVim('set_string', function(cm, vim, helpers) {
   eq('c', CodeMirror.Vim.getOption('testoption'));
 });
 testVim('ex_set_string', function(cm, vim, helpers) {
-  CodeMirror.Vim.defineOption('testoption', 'a', 'string');
+  CodeMirror.Vim.defineOption('testopt', 'a', 'string');
   // Test default value is set.
-  eq('a', CodeMirror.Vim.getOption('testoption'));
+  eq('a', CodeMirror.Vim.getOption('testopt'));
   try {
-    // Test fail to set 'notestoption'
-    helpers.doEx('set notestoption=b');
+    // Test fail to set 'notestopt'
+    helpers.doEx('set notestopt=b');
     fail();
   } catch (expected) {};
   // Test setOption
-  helpers.doEx('set testoption=c')
-  eq('c', CodeMirror.Vim.getOption('testoption'));
+  helpers.doEx('set testopt=c')
+  eq('c', CodeMirror.Vim.getOption('testopt'));
+  helpers.doEx('set testopt=c')
+  eq('c', CodeMirror.Vim.getOption('testopt', cm)); //local || global
+  eq('c', CodeMirror.Vim.getOption('testopt', cm, {scope: 'local'})); // local
+  eq('c', CodeMirror.Vim.getOption('testopt', cm, {scope: 'global'})); // global
+  eq('c', CodeMirror.Vim.getOption('testopt')); // global
+  // Test setOption global
+  helpers.doEx('setg testopt=d')
+  eq('c', CodeMirror.Vim.getOption('testopt', cm));
+  eq('c', CodeMirror.Vim.getOption('testopt', cm, {scope: 'local'}));
+  eq('d', CodeMirror.Vim.getOption('testopt', cm, {scope: 'global'}));
+  eq('d', CodeMirror.Vim.getOption('testopt'));
+  // Test setOption local
+  helpers.doEx('setl testopt=e')
+  eq('e', CodeMirror.Vim.getOption('testopt', cm));
+  eq('e', CodeMirror.Vim.getOption('testopt', cm, {scope: 'local'}));
+  eq('d', CodeMirror.Vim.getOption('testopt', cm, {scope: 'global'}));
+  eq('d', CodeMirror.Vim.getOption('testopt'));
 });
 testVim('ex_set_callback', function(cm, vim, helpers) {
-  var storedVal = 'a';
+  var global;
 
-  function cb(val) {
+  function cb(val, cm, cfg) {
     if (val === undefined) {
-      return storedVal;
+      // Getter
+      if (cm) {
+        return cm._local;
+      } else {
+        return global;
+      }
     } else {
-      storedVal = val;
+      // Setter
+      if (cm) {
+        cm._local = val;
+      } else {
+        global = val;
+      }
     }
   }
 
-  CodeMirror.Vim.defineOption('testcboption', undefined, 'string', cb);
+  CodeMirror.Vim.defineOption('testopt', 'a', 'string', cb);
   // Test default value is set.
-  eq('a', CodeMirror.Vim.getOption('testcboption'));
+  eq('a', CodeMirror.Vim.getOption('testopt'));
   try {
-    // Test fail to set 'notestcboption'
-    helpers.doEx('set notestcboption=b');
+    // Test fail to set 'notestopt'
+    helpers.doEx('set notestopt=b');
     fail();
   } catch (expected) {};
-  // Test setOption
-  helpers.doEx('set testcboption=c')
-  eq('c', CodeMirror.Vim.getOption('testcboption'));
-})
+  // Test setOption (Identical to the string tests, but via callback instead)
+  helpers.doEx('set testopt=c')
+  eq('c', CodeMirror.Vim.getOption('testopt', cm)); //local || global
+  eq('c', CodeMirror.Vim.getOption('testopt', cm, {scope: 'local'})); // local
+  eq('c', CodeMirror.Vim.getOption('testopt', cm, {scope: 'global'})); // global
+  eq('c', CodeMirror.Vim.getOption('testopt')); // global
+  // Test setOption global
+  helpers.doEx('setg testopt=d')
+  eq('c', CodeMirror.Vim.getOption('testopt', cm));
+  eq('c', CodeMirror.Vim.getOption('testopt', cm, {scope: 'local'}));
+  eq('d', CodeMirror.Vim.getOption('testopt', cm, {scope: 'global'}));
+  eq('d', CodeMirror.Vim.getOption('testopt'));
+  // Test setOption local
+  helpers.doEx('setl testopt=e')
+  eq('e', CodeMirror.Vim.getOption('testopt', cm));
+  eq('e', CodeMirror.Vim.getOption('testopt', cm, {scope: 'local'}));
+  eq('d', CodeMirror.Vim.getOption('testopt', cm, {scope: 'global'}));
+  eq('d', CodeMirror.Vim.getOption('testopt'));
+});
 // TODO: Reset key maps after each test.
 testVim('ex_map_key2key', function(cm, vim, helpers) {
   helpers.doEx('map a x');


### PR DESCRIPTION
@heppe please take a look. This is to enable https://github.com/codemirror/CodeMirror/pull/3196

I should probably document this better but...

setlocal and setglobal are implemented in this PR. These commands differ a little bit from desktop VIM because there isn't a distinction between buffer-local and window-local variables on CodeMirror. A window === buffer.

This PR also expands option callbacks to work for local and global options. A callback is a special type of option whose values VIM does not store. The callback is both a getter and setter, depending on whether a value is provided for the first argument. The second argument is the CodeMirror instance, which determines whether we are setting/getting the global or local instance of the option.

For a single :set/:setl/:setg call, the callback can be called at least once and at most twice, once to set the local version of the option and once to set the global version of the option.