### PR TITLE
[mobile] disable autocomplete to ensure key event support

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1146,6 +1146,7 @@
   }
 
   function disableBrowserMagic(field) {
+    field.setAttribute("autocomplete", "off");
     field.setAttribute("autocorrect", "off");
     field.setAttribute("autocapitalize", "off");
     field.setAttribute("spellcheck", "false");


### PR DESCRIPTION
See https://code.google.com/p/chromium/issues/detail?id=118639#c209

You may have a better place to put this, or want to gate it on being Chrome, etc.