### PR TITLE
[markdown mode] Include optional space character after atx style headers in formatting

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -72,7 +72,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   ,   ulRE = /^[*\-+]\s+/
   ,   olRE = /^[0-9]+\.\s+/
   ,   taskListRE = /^\[(x| )\](?=\s)/ // Must follow ulRE or olRE
-  ,   atxHeaderRE = /^#+/
+  ,   atxHeaderRE = /^#+ ?/
   ,   setextHeaderRE = /^(?:\={1,}|-{1,})$/
   ,   textRE = /^[^#!\[\]*_\\<>` "'(~]+/;
 
@@ -140,7 +140,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     } else if (stream.eatSpace()) {
       return null;
     } else if (match = stream.match(atxHeaderRE)) {
-      state.header = match[0].length <= 6 ? match[0].length : 6;
+      state.header = Math.min(6, match[0].indexOf(" ") !== -1 ? match[0].length - 1 : match[0].length);
       if (modeCfg.highlightFormatting) state.formatting = "header";
       state.f = state.inline;
       return getType(state);

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -26,7 +26,7 @@
      "[comment&formatting&formatting-code ``][comment foo ` bar][comment&formatting&formatting-code ``]");
 
   FT("formatting_atxHeader",
-     "[header&header-1&formatting&formatting-header&formatting-header-1 #][header&header-1  foo # bar ][header&header-1&formatting&formatting-header&formatting-header-1 #]");
+     "[header&header-1&formatting&formatting-header&formatting-header-1 # ][header&header-1 foo # bar ][header&header-1&formatting&formatting-header&formatting-header-1 #]");
 
   FT("formatting_setextHeader",
      "foo",


### PR DESCRIPTION
This changes will make the optional space character after ATX style headers be included within the `cm-formatting` element.

As an example, this:

```html
<span class="cm-formatting cm-formatting-header cm-formatting-header-1 cm-header cm-header-1">#</span><span class="cm-header cm-header-1"> Header</span>
```

will become this:

```html
<span class="cm-formatting cm-formatting-header cm-formatting-header-1 cm-header cm-header-1"># </span><span class="cm-header cm-header-1">Header</span>
```

I know that this is a very small change but it allows for more consistent styling, since this is how quotes are handled, too. The optional space character after the `>` is included in the formatting, as well.