### PR TITLE
Add support for controlling theme with vim :colorscheme command

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -3918,6 +3918,7 @@
     // pair of commands that have a shared prefix, at least one of their
     // shortNames must not match the prefix of the other command.
     var defaultExCommandMap = [
+      { name: 'colorscheme', shortName: 'colo' },
       { name: 'map' },
       { name: 'imap', shortName: 'im' },
       { name: 'nmap', shortName: 'nm' },
@@ -4161,6 +4162,13 @@
     };
 
     var exCommands = {
+      colorscheme: function(cm, params, ctx) {
+        if (!params.args || params.args.length < 1) {
+          showConfirm(cm, cm.getOption('theme'));
+          return;
+        }
+        cm.setOption('theme', params.args[0]);
+      },
       map: function(cm, params, ctx) {
         var mapArgs = params.args;
         if (!mapArgs || mapArgs.length < 2) {


### PR DESCRIPTION
Two caveats:
  * Should probably propagate an event to the host app that the colorscheme has changed. Some apps might want to completely disable changing theme, too (but in that case at least being able to read out the theme name is still useful).
  * CodeMirror has no concept of what themes are available, so it never warns you about nonexistent themes.