### PR TITLE
[dialog addon] dialog inherits CodeMirror theme colors

### DIFF
--- a/addon/dialog/dialog.css
+++ b/addon/dialog/dialog.css
@@ -1,11 +1,11 @@
 .CodeMirror-dialog {
   position: absolute;
   left: 0; right: 0;
-  background: white;
+  background: inherit;
   z-index: 15;
   padding: .1em .8em;
   overflow: hidden;
-  color: #333;
+  color: inherit;
 }
 
 .CodeMirror-dialog-top {


### PR DESCRIPTION
Fixes https://github.com/codemirror/CodeMirror/issues/3215

@marijnh not sure why dialogs currently override colors. Just checking to make sure this won't look weird in other places