### PR TITLE
Fix bug showing imprecise value of vim 'filetype' option for mimetypes

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -463,7 +463,7 @@
       }
       // The 'filetype' option proxies to the CodeMirror 'mode' option.
       if (name === undefined) {
-        var mode = cm.getMode().name;
+        var mode = cm.getOption('mode');
         return mode == 'null' ? '' : mode;
       } else {
         var mode = name == '' ? 'null' : name;


### PR DESCRIPTION
The way I initially set it up to get the mode name did not report the mimetype form of CodeMirror's "mode" option (e.g. `text/x-csrc` as opposed to `clike`), so if `:set ft?` showed "clike" and you passed that same value into `:set ft=clike`, the extra C hooks would not be loaded. (Discussed in #3196.)