### PR TITLE
Changed the linter code to work with one instance of editor and multiple...

### DIFF
--- a/addon/lint/css-lint.js
+++ b/addon/lint/css-lint.js
@@ -15,7 +15,7 @@
 })(function(CodeMirror) {
 "use strict";
 
-CodeMirror.registerHelper("lint", "css", function(text) {
+CodeMirror.registerGlobalHelper("lint", "css", function(mode) { return mode === "css"; }, function(text) {
   var found = [];
   if (!window.CSSLint) return found;
   var results = CSSLint.verify(text), messages = results.messages, message = null;

--- a/addon/lint/javascript-lint.js
+++ b/addon/lint/javascript-lint.js
@@ -29,7 +29,7 @@
     return result;
   }
 
-  CodeMirror.registerHelper("lint", "javascript", validator);
+  CodeMirror.registerGlobalHelper("lint", "javascript", function(mode) { return mode === "javascript"; }, validator);
 
   function cleanup(error) {
     // All problems are warnings by default

--- a/addon/lint/json-lint.js
+++ b/addon/lint/json-lint.js
@@ -15,7 +15,7 @@
 })(function(CodeMirror) {
 "use strict";
 
-CodeMirror.registerHelper("lint", "json", function(text) {
+CodeMirror.registerGlobalHelper("lint", "json", function(mode) { return mode === "json"; }, function(text) {
   var found = [];
   jsonlint.parseError = function(str, hash) {
     var loc = hash.loc;


### PR DESCRIPTION
Changed the linter code to work with one instance of editor, multiple linters and multiple doc(as a side effect). 

The current lint code works fine when one does the linting per editor instance. In situations when you have one editor and are swapping docs in it, it will run into issues. 

The logic for picking up a linter for an editor picks up whatever was last registered(I think). This does not allow one to select a linter based on the mode of the editor. In addition, it is not possible to apply multiple linters to one editor. 

This patch changes the logic in css, json and javascript linters so that they register as global helpers with a predicate function which chooses them when the right mode is passed in. It also changes the lint.js code so that it runs all of the registered linters.

Pardon me if the logic for state management is a bit fishy. Feel free to change it however you want or let me know how to do it. 

Thank you!