### PR TITLE
Fixing non-firing of "close" on completion close

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -62,6 +62,7 @@
       this.cm.off("cursorActivity", this.activityFunc);
 
       if (this.widget) this.widget.close();
+      CodeMirror.signal(this.data, "close");
       CodeMirror.signal(this.cm, "endCompletion", this.cm);
     },
 


### PR DESCRIPTION
The manual says that completion should fire "pick", "close", "select" and "shown".

Here: https://github.com/codemirror/CodeMirror/blob/master/doc/manual.html#L2556

Currently only "pick" and "select" seem to be firing. This change fixes "close".