### PR TITLE
Make demo link back to addon doc

### DIFF
--- a/demo/activeline.html
+++ b/demo/activeline.html
@@ -20,7 +20,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="../doc/manual.html#addon_activeline">Active Line</a>
+    <li><a class=active href="../doc/manual.html#addon_active-line">Active Line</a>
   </ul>
 </div>
 

--- a/demo/activeline.html
+++ b/demo/activeline.html
@@ -20,7 +20,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Active Line</a>
+    <li><a class=active href="../doc/manual.html#addon_activeline">Active Line</a>
   </ul>
 </div>
 

--- a/demo/anywordhint.html
+++ b/demo/anywordhint.html
@@ -19,7 +19,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Any Word Completion</a>
+    <li><a class=active href="../doc/manual.html#addon_anywordhint">Any Word Completion</a>
   </ul>
 </div>
 

--- a/demo/bidi.html
+++ b/demo/bidi.html
@@ -19,7 +19,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Bi-directional Text</a>
+    <li><a class=active href="../doc/manual.html#addon_bidi">Bi-directional Text</a>
   </ul>
 </div>
 

--- a/demo/btree.html
+++ b/demo/btree.html
@@ -19,7 +19,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">B-Tree visualization</a>
+    <li><a class=active href="../doc/manual.html#addon_btree">B-Tree visualization</a>
   </ul>
 </div>
 

--- a/demo/buffers.html
+++ b/demo/buffers.html
@@ -20,7 +20,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Multiple Buffer & Split View</a>
+    <li><a class=active href="../doc/manual.html#addon_buffers">Multiple Buffer & Split View</a>
   </ul>
 </div>
 

--- a/demo/changemode.html
+++ b/demo/changemode.html
@@ -20,7 +20,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Mode-Changing</a>
+    <li><a class=active href="../doc/manual.html#addon_changemode">Mode-Changing</a>
   </ul>
 </div>
 

--- a/demo/closebrackets.html
+++ b/demo/closebrackets.html
@@ -20,7 +20,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Closebrackets</a>
+    <li><a class=active href="../doc/manual.html#addon_closebrackets">Closebrackets</a>
   </ul>
 </div>
 

--- a/demo/closetag.html
+++ b/demo/closetag.html
@@ -24,7 +24,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Close-Tag</a>
+    <li><a class=active href="../doc/manual.html#addon_closetag">Close-Tag</a>
   </ul>
 </div>
 

--- a/demo/complete.html
+++ b/demo/complete.html
@@ -20,7 +20,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Autocomplete</a>
+    <li><a class=active href="../doc/manual.html#addon_complete">Autocomplete</a>
   </ul>
 </div>
 

--- a/demo/complete.html
+++ b/demo/complete.html
@@ -20,7 +20,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="../doc/manual.html#addon_complete">Autocomplete</a>
+    <li><a class=active href="../doc/manual.html#addon_show-hint">Autocomplete</a>
   </ul>
 </div>
 

--- a/demo/emacs.html
+++ b/demo/emacs.html
@@ -26,7 +26,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Emacs bindings</a>
+    <li><a class=active href="../doc/manual.html#addon_emacs">Emacs bindings</a>
   </ul>
 </div>
 

--- a/demo/folding.html
+++ b/demo/folding.html
@@ -32,7 +32,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Code Folding</a>
+    <li><a class=active href="../doc/manual.html#addon_folding">Code Folding</a>
   </ul>
 </div>
 

--- a/demo/folding.html
+++ b/demo/folding.html
@@ -32,7 +32,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="../doc/manual.html#addon_folding">Code Folding</a>
+    <li><a class=active href="../doc/manual.html#addon_foldcode">Code Folding</a>
   </ul>
 </div>
 

--- a/demo/fullscreen.html
+++ b/demo/fullscreen.html
@@ -20,7 +20,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Full Screen Editing</a>
+    <li><a class=active href="../doc/manual.html#addon_fullscreen">Full Screen Editing</a>
   </ul>
 </div>
 

--- a/demo/hardwrap.html
+++ b/demo/hardwrap.html
@@ -20,7 +20,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Hard-wrapping</a>
+    <li><a class=active href="../doc/manual.html#addon_hardwrap">Hard-wrapping</a>
   </ul>
 </div>
 

--- a/demo/html5complete.html
+++ b/demo/html5complete.html
@@ -30,7 +30,7 @@
       <li><a href="https://github.com/codemirror/codemirror">Code</a>
     </ul>
     <ul>
-      <li><a class=active href="../doc/manual.html#addon_html5complete">HTML completion</a>
+      <li><a class=active href="../doc/manual.html#addon_html-hint">HTML completion</a>
     </ul>
   </div>
 

--- a/demo/html5complete.html
+++ b/demo/html5complete.html
@@ -30,7 +30,7 @@
       <li><a href="https://github.com/codemirror/codemirror">Code</a>
     </ul>
     <ul>
-      <li><a class=active href="#">HTML completion</a>
+      <li><a class=active href="../doc/manual.html#addon_html5complete">HTML completion</a>
     </ul>
   </div>
 

--- a/demo/indentwrap.html
+++ b/demo/indentwrap.html
@@ -20,7 +20,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Indented wrapped line</a>
+    <li><a class=active href="../doc/manual.html#addon_indentwrap">Indented wrapped line</a>
   </ul>
 </div>
 

--- a/demo/lint.html
+++ b/demo/lint.html
@@ -28,7 +28,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Linter</a>
+    <li><a class=active href="../doc/manual.html#addon_lint">Linter</a>
   </ul>
 </div>
 

--- a/demo/loadmode.html
+++ b/demo/loadmode.html
@@ -20,7 +20,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Lazy Mode Loading</a>
+    <li><a class=active href="../doc/manual.html#addon_loadmode">Lazy Mode Loading</a>
   </ul>
 </div>
 

--- a/demo/marker.html
+++ b/demo/marker.html
@@ -21,7 +21,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Breakpoint</a>
+    <li><a class=active href="../doc/manual.html#addon_marker">Breakpoint</a>
   </ul>
 </div>
 

--- a/demo/markselection.html
+++ b/demo/markselection.html
@@ -23,7 +23,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Selection Marking</a>
+    <li><a class=active href="../doc/manual.html#addon_markselection">Selection Marking</a>
   </ul>
 </div>
 

--- a/demo/markselection.html
+++ b/demo/markselection.html
@@ -23,7 +23,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="../doc/manual.html#addon_markselection">Selection Marking</a>
+    <li><a class=active href="../doc/manual.html#addon_mark-selection">Selection Marking</a>
   </ul>
 </div>
 

--- a/demo/matchhighlighter.html
+++ b/demo/matchhighlighter.html
@@ -25,7 +25,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="../doc/manual.html#addon_matchhighlighter">Match Highlighter</a>
+    <li><a class=active href="../doc/manual.html#addon_match-highlighter">Match Highlighter</a>
   </ul>
 </div>
 

--- a/demo/matchhighlighter.html
+++ b/demo/matchhighlighter.html
@@ -25,7 +25,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Match Highlighter</a>
+    <li><a class=active href="../doc/manual.html#addon_matchhighlighter">Match Highlighter</a>
   </ul>
 </div>
 

--- a/demo/matchtags.html
+++ b/demo/matchtags.html
@@ -21,7 +21,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Tag Matcher</a>
+    <li><a class=active href="../doc/manual.html#addon_matchtags">Tag Matcher</a>
   </ul>
 </div>
 

--- a/demo/merge.html
+++ b/demo/merge.html
@@ -36,7 +36,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">merge view</a>
+    <li><a class=active href="../doc/manual.html#addon_merge">merge view</a>
   </ul>
 </div>
 

--- a/demo/multiplex.html
+++ b/demo/multiplex.html
@@ -21,7 +21,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Multiplexing Parser</a>
+    <li><a class=active href="../doc/manual.html#addon_multiplex">Multiplexing Parser</a>
   </ul>
 </div>
 

--- a/demo/mustache.html
+++ b/demo/mustache.html
@@ -21,7 +21,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="../doc/manual.html#addon_mustache">Overlay Parser</a>
+    <li><a class=active href="../doc/manual.html#addon_overlay">Overlay Parser</a>
   </ul>
 </div>
 

--- a/demo/mustache.html
+++ b/demo/mustache.html
@@ -21,7 +21,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Overlay Parser</a>
+    <li><a class=active href="../doc/manual.html#addon_mustache">Overlay Parser</a>
   </ul>
 </div>
 

--- a/demo/panel.html
+++ b/demo/panel.html
@@ -48,7 +48,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Panel</a>
+    <li><a class=active href="../doc/manual.html#addon_panel">Panel</a>
   </ul>
 </div>
 

--- a/demo/placeholder.html
+++ b/demo/placeholder.html
@@ -22,7 +22,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Placeholder</a>
+    <li><a class=active href="../doc/manual.html#addon_placeholder">Placeholder</a>
   </ul>
 </div>
 

--- a/demo/preview.html
+++ b/demo/preview.html
@@ -33,7 +33,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">HTML5 preview</a>
+    <li><a class=active href="../doc/manual.html#addon_preview">HTML5 preview</a>
   </ul>
 </div>
 

--- a/demo/requirejs.html
+++ b/demo/requirejs.html
@@ -22,7 +22,7 @@
       <li><a href="https://github.com/codemirror/codemirror">Code</a>
     </ul>
     <ul>
-      <li><a class=active href="#">HTML completion</a>
+      <li><a class=active href="../doc/manual.html#addon_requirejs">HTML completion</a>
     </ul>
   </div>
 

--- a/demo/resize.html
+++ b/demo/resize.html
@@ -22,7 +22,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Autoresize</a>
+    <li><a class=active href="../doc/manual.html#addon_resize">Autoresize</a>
   </ul>
 </div>
 

--- a/demo/rulers.html
+++ b/demo/rulers.html
@@ -19,7 +19,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Ruler demo</a>
+    <li><a class=active href="../doc/manual.html#addon_rulers">Ruler demo</a>
   </ul>
 </div>
 

--- a/demo/rulers.html
+++ b/demo/rulers.html
@@ -19,7 +19,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="../doc/manual.html#addon_rulers">Ruler demo</a>
+    <li><a class=active href="../doc/manual.html#addon_rulers">Rulers</a>
   </ul>
 </div>
 

--- a/demo/runmode.html
+++ b/demo/runmode.html
@@ -17,7 +17,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Mode Runner</a>
+    <li><a class=active href="../doc/manual.html#addon_runmode">Mode Runner</a>
   </ul>
 </div>
 

--- a/demo/search.html
+++ b/demo/search.html
@@ -27,7 +27,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Search/Replace</a>
+    <li><a class=active href="../doc/manual.html#addon_search">Search/Replace</a>
   </ul>
 </div>
 

--- a/demo/simplemode.html
+++ b/demo/simplemode.html
@@ -24,7 +24,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Simple Mode</a>
+    <li><a class=active href="../doc/manual.html#addon_simplemode">Simple Mode</a>
   </ul>
 </div>
 

--- a/demo/simplescrollbars.html
+++ b/demo/simplescrollbars.html
@@ -20,7 +20,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Simple Scrollbar</a>
+    <li><a class=active href="../doc/manual.html#addon_simplescrollbars">Simple Scrollbar</a>
   </ul>
 </div>
 

--- a/demo/spanaffectswrapping_shim.html
+++ b/demo/spanaffectswrapping_shim.html
@@ -13,7 +13,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Automatically derive odd wrapping behavior for your browser</a>
+    <li><a class=active href="../doc/manual.html#addon_spanaffectswrapping_shim">Automatically derive odd wrapping behavior for your browser</a>
   </ul>
 </div>
 

--- a/demo/sublime.html
+++ b/demo/sublime.html
@@ -33,7 +33,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Sublime bindings</a>
+    <li><a class=active href="../doc/manual.html#addon_sublime">Sublime bindings</a>
   </ul>
 </div>
 

--- a/demo/tern.html
+++ b/demo/tern.html
@@ -35,7 +35,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Tern</a>
+    <li><a class=active href="../doc/manual.html#addon_tern">Tern</a>
   </ul>
 </div>
 

--- a/demo/theme.html
+++ b/demo/theme.html
@@ -55,7 +55,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Theme</a>
+    <li><a class=active href="../doc/manual.html#addon_theme">Theme</a>
   </ul>
 </div>
 

--- a/demo/trailingspace.html
+++ b/demo/trailingspace.html
@@ -24,7 +24,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Trailing Whitespace</a>
+    <li><a class=active href="../doc/manual.html#addon_trailingspace">Trailing Whitespace</a>
   </ul>
 </div>
 

--- a/demo/variableheight.html
+++ b/demo/variableheight.html
@@ -28,7 +28,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Variable Height</a>
+    <li><a class=active href="../doc/manual.html#addon_variableheight">Variable Height</a>
   </ul>
 </div>
 

--- a/demo/vim.html
+++ b/demo/vim.html
@@ -26,7 +26,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Vim bindings</a>
+    <li><a class=active href="../doc/manual.html#addon_vim">Vim bindings</a>
   </ul>
 </div>
 

--- a/demo/visibletabs.html
+++ b/demo/visibletabs.html
@@ -24,7 +24,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Visible tabs</a>
+    <li><a class=active href="../doc/manual.html#addon_visibletabs">Visible tabs</a>
   </ul>
 </div>
 

--- a/demo/widget.html
+++ b/demo/widget.html
@@ -22,7 +22,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">Inline Widget</a>
+    <li><a class=active href="../doc/manual.html#addon_widget">Inline Widget</a>
   </ul>
 </div>
 

--- a/demo/xmlcomplete.html
+++ b/demo/xmlcomplete.html
@@ -22,7 +22,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="#">XML Autocomplete</a>
+    <li><a class=active href="../doc/manual.html#addon_xmlcomplete">XML Autocomplete</a>
   </ul>
 </div>
 

--- a/demo/xmlcomplete.html
+++ b/demo/xmlcomplete.html
@@ -22,7 +22,7 @@
     <li><a href="https://github.com/codemirror/codemirror">Code</a>
   </ul>
   <ul>
-    <li><a class=active href="../doc/manual.html#addon_xmlcomplete">XML Autocomplete</a>
+    <li><a class=active href="../doc/manual.html#addon_xml-hint">XML Autocomplete</a>
   </ul>
 </div>
 


### PR DESCRIPTION
All demos currently have an a.active link with `href="#"`, which is of fairly limited value.

This proposed patch links back to the related addon section in the manual, which is the most useful purpose I could think of for that link.

Currently the link, when clicked, *does nothing*.

As always, there were some exceptions to the rule:

* Some demo filenames did not match the `id` in the manual.
* Some demos cover multiple addons (folding demo covers addons foldcode and foldgutter).

I fixed these manually.

There are some demos which are not in the demo folder. I have left those alone.
