### PR TITLE
Add addon/help/help.js with tests and documentation

### DIFF
--- a/addon/help/help.js
+++ b/addon/help/help.js
@@ -1,0 +1,115 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+(function (mod) {
+  if (typeof exports == 'object' && typeof module == 'object') // CommonJS
+    mod(require('../../lib/codemirror'));
+  else if (typeof define == 'function' && define.amd) // AMD
+    define(['../../lib/codemirror'], mod);
+  else
+    // Plain browser env
+    mod(CodeMirror);
+}) (function (CodeMirror) {
+  'use strict';
+  // Keep state across calls to setupHelpTypes, so that Editor buffer won't get overwritten.
+  var buffers = {
+  };
+  var setupHelpTypes = function(cm, options) {
+    var bufferNames = Object.keys(options);
+    var wrap = cm.getWrapperElement();
+    var sel = document.body.querySelector('select.CodeMirror-help');
+    sel && sel.parentElement.removeChild(sel);
+    sel = document.createElement('select');
+    sel.className = 'CodeMirror-help';
+    bufferNames.forEach(function(name) {
+      var optHelp = document.createElement('option');
+      optHelp.text = name;
+      var doc = CodeMirror.Doc(options[name], 'javascript');
+      buffers[name] = doc;
+      doc.markText(doc.posFromIndex(0),
+                   doc.posFromIndex(doc.getValue().length), {
+                     // inclusiveLeft: true,
+                     // inclusiveRight: true,
+                     // Did not seem to work (using CTRL-Z to test).
+                     // Perhaps this is due to readOnly clearing undo history?
+                     addToHistory: true,
+                     readOnly: true });
+      sel.add(optHelp, null);
+    });
+    var optEditor = document.createElement('option');
+    optEditor.text = 'Editor';
+    sel.add(optEditor, null);
+    CodeMirror.on(sel, 'change', function () {
+      var name = sel.options[sel.selectedIndex].value;
+      var buf = buffers[name];
+      var old = cm.swapDoc(buf);
+    });
+    // Added for testing, since change is not emitted by programmatic
+    // sel.value change, even with focus before and blur after.
+    CodeMirror.on(sel, 'click', function () {
+      var name = sel.options[sel.selectedIndex].value;
+      var buf = buffers[name];
+      var old = cm.swapDoc(buf);
+    });
+    wrap.parentElement.appendChild(sel);
+    var old = cm.swapDoc(buffers[sel.value]);
+    if (!buffers['Editor']) {
+      buffers['Editor'] = old;
+    }
+  };
+  var getCommandsHelp = function(cm) {
+    try {
+      return JSON.stringify(Object.keys(CodeMirror.commands).sort(), null, 2);
+    }
+    catch (ex) {
+      return JSON.stringify(ex, Object.getOwnPropertyNames(ex), 2);
+    }
+  };
+  var getDefaultsHelp = function(cm) {
+    try {
+      return JSON.stringify(CodeMirror.defaults, Object.keys(CodeMirror.defaults).sort(), 2);
+    }
+    catch (ex) {
+      return JSON.stringify(ex, Object.getOwnPropertyNames(ex), 2);
+    }
+  };
+  var getKeyMapHelp = function(cm) {
+    try {
+      var keyMapName = cm.getOption('keyMap');
+      var keyMapHelp = JSON.stringify(keyMapName) + ': ' + JSON.stringify(CodeMirror.keyMap[keyMapName], Object.keys(CodeMirror.keyMap[keyMapName]).sort(), 2);
+      while (keyMapName = CodeMirror.keyMap[keyMapName].fallthrough) {
+        keyMapHelp += ',\n' + JSON.stringify(keyMapName) + ': ' + JSON.stringify(CodeMirror.keyMap[keyMapName], Object.keys(CodeMirror.keyMap[keyMapName]).sort(), 2);
+      }
+      return keyMapHelp;
+    }
+    catch (ex) {
+      return JSON.stringify(ex, Object.getOwnPropertyNames(ex), 2);
+    }
+  };
+  var getOptionsHelp = function(cm) {
+    try {
+      return JSON.stringify(cm.options, Object.keys(cm.options).sort(), 2);
+    }
+    catch (ex) {
+      return JSON.stringify(ex, Object.getOwnPropertyNames(ex), 2);
+    }
+  };
+  CodeMirror.commands.allHelp = function (cm) {
+    setupHelpTypes(cm, {
+      '*commands Help*': getCommandsHelp(cm),
+      '*defaults Help*': getDefaultsHelp(cm),
+      '*keyMap Help*': getKeyMapHelp(cm),
+      '*options Help*': getOptionsHelp(cm)});
+  };
+  CodeMirror.commands.commandsHelp = function (cm) {
+    setupHelpTypes(cm, { '*commands Help*': getCommandsHelp(cm) });
+  };
+  CodeMirror.commands.defaultsHelp = function (cm) {
+    setupHelpTypes(cm, { '*defaults Help*': getDefaultsHelp(cm) });
+  };
+  CodeMirror.commands.keyMapHelp = function (cm) {
+    setupHelpTypes(cm, { '*keyMap Help*': getKeyMapHelp(cm) });
+  };
+  CodeMirror.commands.optionsHelp = function (cm) {
+    setupHelpTypes(cm, { '*options Help*': getOptionsHelp(cm) });
+  };
+});

--- a/addon/help/help_test.js
+++ b/addon/help/help_test.js
@@ -1,0 +1,40 @@
+(function () {
+  namespace = 'addon_help_';
+  var editorText = 'Initial editor content.';
+  [
+    'commands',
+    'defaults',
+    'keyMap',
+    'options'
+  ].forEach(function (command) {
+    testCM(command + 'Help', function (cm) {
+      cm.setValue(editorText);
+      cm.execCommand([command + 'Help']);
+      is(cm.getValue() != editorText);
+      var wrap = cm.getWrapperElement();
+      var sel = wrap.parentElement.querySelector('select');
+      eq(sel.className, 'CodeMirror-help');
+      eq(sel.value, '*' + command + ' Help*');
+      eq(sel.options[1].value, 'Editor');
+      eq(sel.options.length, 2);
+    });
+  });
+  testCM('allHelp', function (cm) {
+    cm.setValue(editorText);
+    cm.execCommand(['allHelp']);
+    is(cm.getValue() != editorText);
+    var wrap = cm.getWrapperElement();
+    var sel = wrap.parentElement.querySelector('select');
+    eq(sel.className, 'CodeMirror-help');
+    eq(sel.value, '*commands Help*');
+    eq(sel.options[0].value, '*commands Help*');
+    eq(sel.options[1].value, '*defaults Help*');
+    eq(sel.options[2].value, '*keyMap Help*');
+    eq(sel.options[3].value, '*options Help*');
+    eq(sel.options[4].value, 'Editor');
+    eq(sel.options.length, 5);
+    sel.selectedIndex = 4;
+    sel.click();
+    is(cm.getValue() == editorText, "initial editor content is unchanged");
+  });
+}) ();

--- a/demo/help.html
+++ b/demo/help.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html>
+  <head>
+    <title>CodeMirror: Help Demo</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../doc/docs.css">
+    <link rel="stylesheet" href="../addon/fold/foldgutter.css">
+    <link rel="stylesheet" href="../addon/dialog/dialog.css">
+    <link rel="stylesheet" href="../lib/codemirror.css">
+    <script src="../lib/codemirror.js"></script>
+    <script src="../addon/edit/closetag.js"></script>
+    <script src="../addon/fold/xml-fold.js"></script>
+    <script src="../addon/fold/foldgutter.js"></script>
+    <script src="../addon/fold/foldcode.js"></script>
+    <script src="../mode/xml/xml.js"></script>
+    <script src="../mode/javascript/javascript.js"></script>
+    <script src="../mode/css/css.js"></script>
+    <script src="../mode/htmlmixed/htmlmixed.js"></script>
+    <script src="../addon/help/help.js"></script>
+    <script src="../keymap/vim.js"></script>
+    <script src="../keymap/emacs.js"></script>
+    <script src="../keymap/sublime.js"></script>
+    <script src="../addon/search/search.js"></script>
+    <script src="../addon/search/searchcursor.js"></script>
+    <script src="../addon/dialog/dialog.js"></script>
+    <style type="text/css">
+      .CodeMirror {border-top: 1px solid #888; border-bottom: 1px solid #888; /*height: auto; viewportMargin: Infinity*/}
+    </style>
+  </head>
+  <body>
+    <div id="nav">
+      <a href="http://codemirror.net"><h1>CodeMirror</h1><img id="logo" src="../doc/logo.png"></a>
+      <ul>
+        <li><a href="../index.html">Home</a>
+        </li><li><a href="../doc/manual.html">Manual</a>
+        </li><li><a href="https://github.com/codemirror/codemirror">Code</a>
+        </li></ul>
+      <ul>
+        <li><a class="active" href="../doc/manual.html#addon_help">Help</a>
+        </li></ul>
+    </div>
+    <article>
+      <h2>Help Demo</h2>
+      <h3>Pick keyMap</h3>
+      <div>
+        <input type="radio" name="keyMap" class="keyMap" id="default">default</input>
+        <input type="radio" name="keyMap" class="keyMap" id="emacs">Emacs</input>
+        <input type="radio" name="keyMap" class="keyMap" id="sublime">Sublime</input>
+        <input type="radio" name="keyMap" class="keyMap" id="vim">Vim</input>
+      </div>
+      <h3>Get Help in Buffers</h3>
+      <div>
+        <button class="help" id="allHelp">All</button>
+        <button class="help" id="commandsHelp">Commands</button>
+        <button class="help" id="defaultsHelp">Defaults</button>
+        <button class="help" id="keyMapHelp">KeyMap</button>
+        <button class="help" id="optionsHelp">Options</button>
+      </div>
+      <form><textarea id="code" name="code"></textarea></form>
+      <script type="text/javascript">
+        window.onload = function(event) {
+          document.getElementById("code").value = "<html>\n  " + document.documentElement.innerHTML + "\n</html>";
+          var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
+            extraKeys: {
+              'Ctrl-F1': 'allHelp'
+            },
+            foldGutter: true,
+            gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
+            lineNumbers: true,
+            mode: 'htmlmixed'
+          });
+          Array.prototype.forEach.call(document.querySelectorAll('input.keyMap'),
+                                       function(button) {
+            button.onclick = function(event) {
+              editor.setOption('keyMap', event.target.id);
+            }
+          });
+          Array.prototype.forEach.call(document.querySelectorAll('button.help'),
+                                       function(button) {
+            button.onclick = function(event) {
+              editor.execCommand(event.target.id);
+            }
+          });
+        };
+      </script>
+    </article>
+  </body>
+</html>

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2891,6 +2891,23 @@ editor.setOption("extraKeys", {
       implementation of the
       (multi-file) <a href="http://ternjs.net/doc/demo.html">demonstration
       on the Tern website</a>.</dd>
+
+      <dt id="addon_help"><a href="../addon/help/help.js"><code>help/help.js</code></a></dt>
+      <dd>Adds five CodeMirror commands which display editor help in additional editor buffers:
+      <dl>
+        <dt id="command_allhelp"><code><strong>"allHelp"</strong></code></dt>
+        <dd>Creates editor buffers for all the help types described below.
+        All information is provided as pretty-printed JSON with object keys
+        and array elements sorted alphabetically for quicker user lookup.</dd>
+        <dt id="command_commandshelp"><code><strong>"commandsHelp"</strong></code></dt>
+        <dd>Creates buffer *commands Help* displaying CodeMirror.commands.</dd>
+        <dt id="command_defaultshelp"><code><strong>"defaultsHelp"</strong></code></dt>
+        <dd>Creates buffer *defaults Help* displaying CodeMirror.defaults.</dd>
+        <dt id="command_keymaphelp"><code><strong>"keyMapHelp"</strong></code></dt>
+        <dd>Creates buffer *keyMap Help* displaying all active keymaps of the given CodeMirror instance. All fallthrough keymaps are displayed in order.</dd>
+        <dt id="command_optionshelp"><code><strong>"optionsHelp"</strong></code></dt>
+        <dd>Creates buffer *options Help* displaying all options of the given CodeMirror instance.</dd>
+      </dl> Don't miss the <a href="../demo/help.html">demo</a>, but be aware of help content possibly varying between CodeMirror versions.</dd>
     </dl>
 </section>
 

--- a/test/index.html
+++ b/test/index.html
@@ -15,6 +15,7 @@
 <script src="../addon/edit/matchbrackets.js"></script>
 <script src="../addon/hint/sql-hint.js"></script>
 <script src="../addon/comment/comment.js"></script>
+<script src="../addon/help/help.js"></script>
 <script src="../mode/css/css.js"></script>
 <script src="../mode/clike/clike.js"></script>
 <!-- clike must be after css or vim and sublime tests will fail -->
@@ -113,6 +114,7 @@
     <script src="../mode/xml/test.js"></script>
     <script src="../mode/xquery/test.js"></script>
     <script src="../addon/mode/multiplex_test.js"></script>
+    <script src="../addon/help/help_test.js"></script>
     <script src="emacs_test.js"></script>
     <script src="sql-hint-test.js"></script>
     <script src="sublime_test.js"></script>


### PR DESCRIPTION
This is a squashed commit of a merge --no-commit from my gh-pages branch.

It includes the addon, the associated manual.html update, and a new help_test.js module already hooked into the test suite.

The tests were passing locally.

You can look at the demo at http://anaran.github.io/CodeMirror/demo/help.html, the documentation at http://anaran.github.io/CodeMirror/doc/manual.html#addon_help, and the new tests at http://anaran.github.io/CodeMirror/test/#addon_help_,verbose

gh-pages (hosting all the links above) will become an integration branch for this pull request along with #3242.

Now I wonder what I may have missed...

anaran