### PR TITLE
Adding an option to disable auto-completion of keywords

### DIFF
--- a/addon/hint/sql-hint.js
+++ b/addon/hint/sql-hint.js
@@ -212,6 +212,7 @@
   CodeMirror.registerHelper("hint", "sql", function(editor, options) {
     tables = (options && options.tables) || {};
     var defaultTableName = options && options.defaultTable;
+    var disableKeywords = options && options.disableKeywords;
     defaultTable = defaultTableName && getItem(tables, defaultTableName);
     keywords = keywords || getKeywords(editor);
 
@@ -244,7 +245,9 @@
     } else {
       addMatches(result, search, tables, function(w) {return w;});
       addMatches(result, search, defaultTable, function(w) {return w;});
-      addMatches(result, search, keywords, function(w) {return w.toUpperCase();});
+      if(!disableKeywords) {
+        addMatches(result, search, keywords, function(w) {return w.toUpperCase();});
+      }
     }
 
     return {list: result, from: Pos(cur.line, start), to: Pos(cur.line, end)};


### PR DESCRIPTION
It's sort of distracting to have the editor auto-complete 'AS', 'SELECT', 'FROM', etc. So this option lets you disable it.