### PR TITLE
Workaround for  #3261 Selection problem in IE11, when leaving an iframe while selecting

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -87,6 +87,7 @@
       focused: false,
       suppressEdits: false, // used to disable editing during key handlers when in readOnly mode
       pasteIncoming: false, cutIncoming: false, // help recognize paste/cut edits in input.poll
+      selectingText: false,
       draggingText: false,
       highlight: new Delayed(), // stores highlight worker timeout
       keySeq: null,  // Unfinished key sequence
@@ -1116,28 +1117,28 @@
   }
 
   function triggerElectric(cm, inserted) {
-    // When an 'electric' character is inserted, immediately trigger a reindent
+      // When an 'electric' character is inserted, immediately trigger a reindent
     if (!cm.options.electricChars || !cm.options.smartIndent) return;
     var sel = cm.doc.sel;
 
     for (var i = sel.ranges.length - 1; i >= 0; i--) {
       var range = sel.ranges[i];
       if (range.head.ch > 100 || (i && sel.ranges[i - 1].head.line == range.head.line)) continue;
-      var mode = cm.getModeAt(range.head);
-      var indented = false;
-      if (mode.electricChars) {
-        for (var j = 0; j < mode.electricChars.length; j++)
-          if (inserted.indexOf(mode.electricChars.charAt(j)) > -1) {
+        var mode = cm.getModeAt(range.head);
+        var indented = false;
+        if (mode.electricChars) {
+          for (var j = 0; j < mode.electricChars.length; j++)
+            if (inserted.indexOf(mode.electricChars.charAt(j)) > -1) {
             indented = indentLine(cm, range.head.line, "smart");
-            break;
-          }
-      } else if (mode.electricInput) {
+              break;
+            }
+        } else if (mode.electricInput) {
         if (mode.electricInput.test(getLine(cm.doc, range.head.line).text.slice(0, range.head.ch)))
           indented = indentLine(cm, range.head.line, "smart");
-      }
+        }
       if (indented) signalLater(cm, "electricInput", cm, range.head.line);
+      }
     }
-  }
 
   function copyableRanges(cm) {
     var text = [], ranges = [];
@@ -3567,7 +3568,8 @@
     var sel = cm.doc.sel, modifier = mac ? e.metaKey : e.ctrlKey, contained;
     if (cm.options.dragDrop && dragAndDrop && !isReadOnly(cm) &&
         type == "single" && (contained = sel.contains(start)) > -1 &&
-        !sel.ranges[contained].empty())
+        !sel.ranges[contained].empty() &&
+        !cm.state.selectingText)
       leftButtonStartDrag(cm, e, start, modifier);
     else
       leftButtonSelect(cm, e, start, type, modifier);
@@ -3606,6 +3608,12 @@
   function leftButtonSelect(cm, e, start, type, addNew) {
     var display = cm.display, doc = cm.doc;
     e_preventDefault(e);
+
+    // #3261: make sure, that we're not starting a second selection
+    if (cm.state.selectingText) {
+      cm.state.selectingText(e);
+      return;
+    }
 
     var ourRange, ourIndex, startSel = doc.sel, ranges = startSel.ranges;
     if (addNew && !e.shiftKey) {
@@ -3727,6 +3735,7 @@
     }
 
     function done(e) {
+      cm.state.selectingText = false;
       counter = Infinity;
       e_preventDefault(e);
       display.input.focus();
@@ -3740,6 +3749,7 @@
       else extend(e);
     });
     var up = operation(cm, done);
+    cm.state.selectingText = up;
     on(document, "mousemove", move);
     on(document, "mouseup", up);
   }

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -87,7 +87,6 @@
       focused: false,
       suppressEdits: false, // used to disable editing during key handlers when in readOnly mode
       pasteIncoming: false, cutIncoming: false, // help recognize paste/cut edits in input.poll
-      selectingText: false,
       draggingText: false,
       highlight: new Delayed(), // stores highlight worker timeout
       keySeq: null,  // Unfinished key sequence
@@ -1117,28 +1116,28 @@
   }
 
   function triggerElectric(cm, inserted) {
-      // When an 'electric' character is inserted, immediately trigger a reindent
+    // When an 'electric' character is inserted, immediately trigger a reindent
     if (!cm.options.electricChars || !cm.options.smartIndent) return;
     var sel = cm.doc.sel;
 
     for (var i = sel.ranges.length - 1; i >= 0; i--) {
       var range = sel.ranges[i];
       if (range.head.ch > 100 || (i && sel.ranges[i - 1].head.line == range.head.line)) continue;
-        var mode = cm.getModeAt(range.head);
-        var indented = false;
-        if (mode.electricChars) {
-          for (var j = 0; j < mode.electricChars.length; j++)
-            if (inserted.indexOf(mode.electricChars.charAt(j)) > -1) {
+      var mode = cm.getModeAt(range.head);
+      var indented = false;
+      if (mode.electricChars) {
+        for (var j = 0; j < mode.electricChars.length; j++)
+          if (inserted.indexOf(mode.electricChars.charAt(j)) > -1) {
             indented = indentLine(cm, range.head.line, "smart");
-              break;
-            }
-        } else if (mode.electricInput) {
+            break;
+          }
+      } else if (mode.electricInput) {
         if (mode.electricInput.test(getLine(cm.doc, range.head.line).text.slice(0, range.head.ch)))
           indented = indentLine(cm, range.head.line, "smart");
-        }
-      if (indented) signalLater(cm, "electricInput", cm, range.head.line);
       }
+      if (indented) signalLater(cm, "electricInput", cm, range.head.line);
     }
+  }
 
   function copyableRanges(cm) {
     var text = [], ranges = [];
@@ -3568,8 +3567,7 @@
     var sel = cm.doc.sel, modifier = mac ? e.metaKey : e.ctrlKey, contained;
     if (cm.options.dragDrop && dragAndDrop && !isReadOnly(cm) &&
         type == "single" && (contained = sel.contains(start)) > -1 &&
-        !sel.ranges[contained].empty() &&
-        !cm.state.selectingText)
+        !sel.ranges[contained].empty())
       leftButtonStartDrag(cm, e, start, modifier);
     else
       leftButtonSelect(cm, e, start, type, modifier);
@@ -3608,12 +3606,6 @@
   function leftButtonSelect(cm, e, start, type, addNew) {
     var display = cm.display, doc = cm.doc;
     e_preventDefault(e);
-
-    // #3261: make sure, that we're not starting a second selection
-    if (cm.state.selectingText) {
-      cm.state.selectingText(e);
-      return;
-    }
 
     var ourRange, ourIndex, startSel = doc.sel, ranges = startSel.ranges;
     if (addNew && !e.shiftKey) {
@@ -3735,7 +3727,6 @@
     }
 
     function done(e) {
-      cm.state.selectingText = false;
       counter = Infinity;
       e_preventDefault(e);
       display.input.focus();
@@ -3749,7 +3740,6 @@
       else extend(e);
     });
     var up = operation(cm, done);
-    cm.state.selectingText = up;
     on(document, "mousemove", move);
     on(document, "mouseup", up);
   }

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -87,6 +87,7 @@
       focused: false,
       suppressEdits: false, // used to disable editing during key handlers when in readOnly mode
       pasteIncoming: false, cutIncoming: false, // help recognize paste/cut edits in input.poll
+      selectingText: false,
       draggingText: false,
       highlight: new Delayed(), // stores highlight worker timeout
       keySeq: null,  // Unfinished key sequence
@@ -3567,7 +3568,8 @@
     var sel = cm.doc.sel, modifier = mac ? e.metaKey : e.ctrlKey, contained;
     if (cm.options.dragDrop && dragAndDrop && !isReadOnly(cm) &&
         type == "single" && (contained = sel.contains(start)) > -1 &&
-        !sel.ranges[contained].empty())
+        !sel.ranges[contained].empty() &&
+        !cm.state.selectingText)
       leftButtonStartDrag(cm, e, start, modifier);
     else
       leftButtonSelect(cm, e, start, type, modifier);
@@ -3606,6 +3608,12 @@
   function leftButtonSelect(cm, e, start, type, addNew) {
     var display = cm.display, doc = cm.doc;
     e_preventDefault(e);
+
+    // #3261: make sure, that we're not starting a second selection
+    if (cm.state.selectingText) {
+      cm.state.selectingText(e);
+      return;
+    }
 
     var ourRange, ourIndex, startSel = doc.sel, ranges = startSel.ranges;
     if (addNew && !e.shiftKey) {
@@ -3727,6 +3735,7 @@
     }
 
     function done(e) {
+      cm.state.selectingText = false;
       counter = Infinity;
       e_preventDefault(e);
       display.input.focus();
@@ -3740,6 +3749,7 @@
       else extend(e);
     });
     var up = operation(cm, done);
+    cm.state.selectingText = up;
     on(document, "mousemove", move);
     on(document, "mouseup", up);
   }


### PR DESCRIPTION
If the mouse leaves the iframe during text selection, the MouseEvents are no longer sent to Codemirror. If the user lets go of the left mouse button, CodeMirror does not know that the text selection has stopped.

Chrome and Firefox allow to check the states of the mouse buttons on mouse move. Codemirror does this and stops the text selection. This does not work on any version of IE.

Workaround for IE: Check on each left click, if text is currently being selected. If yes, the selection is finished. This is not perfect, but prevents Codemirror from starting a second text selection and going crazy.
