### PR TITLE
[monokai theme] Add support for cm-header

### DIFF
--- a/theme/monokai.css
+++ b/theme/monokai.css
@@ -24,6 +24,7 @@
 .cm-s-monokai span.cm-def {color: #fd971f;}
 .cm-s-monokai span.cm-bracket {color: #f8f8f2;}
 .cm-s-monokai span.cm-tag {color: #f92672;}
+.cm-s-monokai span.cm-header {color: #ae81ff;}
 .cm-s-monokai span.cm-link {color: #ae81ff;}
 .cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
 


### PR DESCRIPTION
Matches color for `cm-link` style