### PR TITLE
[markdown mode] Make markdown mode a whole lot more CommonMark compliant

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -68,12 +68,12 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   ,   strong   = 'strong'
   ,   strikethrough = 'strikethrough';
 
-  var hrRE = /^([*\-=_])(?:\s*\1){2,}\s*$/
+  var hrRE = /^([*\-_])(?:\s*\1){2,}\s*$/
   ,   ulRE = /^[*\-+]\s+/
-  ,   olRE = /^[0-9]+\.\s+/
+  ,   olRE = /^[0-9]+([.)])\s+/
   ,   taskListRE = /^\[(x| )\](?=\s)/ // Must follow ulRE or olRE
-  ,   atxHeaderRE = /^#+ ?/
-  ,   setextHeaderRE = /^(?:\={1,}|-{1,})$/
+  ,   atxHeaderRE = /^(#+)(?: |$)/
+  ,   setextHeaderRE = /^ *(?:\={1,}|-{1,})\s*$/
   ,   textRE = /^[^#!\[\]*_\\<>` "'(~]+/;
 
   function switchInline(stream, state, f) {
@@ -100,6 +100,8 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     state.strikethrough = false;
     // Reset state.quote
     state.quote = 0;
+    // Reset state.indentedCode
+    state.indentedCode = false;
     if (!htmlFound && state.f == htmlBlock) {
       state.f = inlineNormal;
       state.block = blockNormal;
@@ -116,7 +118,11 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
     var sol = stream.sol();
 
-    var prevLineIsList = state.list !== false;
+    var prevLineIsList = state.list !== false,
+        prevLineIsIndentedCode = state.indentedCode;
+
+    state.indentedCode = false;
+
     if (prevLineIsList) {
       if (state.indentationDiff >= 0) { // Continued list
         if (state.indentationDiff < 4) { // Only adjust indentation if *not* a code block
@@ -134,17 +140,22 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
     var match = null;
     if (state.indentationDiff >= 4) {
-      state.indentation -= 4;
       stream.skipToEnd();
-      return code;
+      if (prevLineIsIndentedCode || !state.prevLineHasContent) {
+        state.indentation -= 4;
+        state.indentedCode = true;
+        return code;
+      } else {
+        return null;
+      }
     } else if (stream.eatSpace()) {
       return null;
-    } else if (match = stream.match(atxHeaderRE)) {
-      state.header = Math.min(6, match[0].indexOf(" ") !== -1 ? match[0].length - 1 : match[0].length);
+    } else if ((match = stream.match(atxHeaderRE)) && match[1].length <= 6) {
+      state.header = match[1].length;
       if (modeCfg.highlightFormatting) state.formatting = "header";
       state.f = state.inline;
       return getType(state);
-    } else if (state.prevLineHasContent && (match = stream.match(setextHeaderRE))) {
+    } else if (state.prevLineHasContent && !state.quote && !prevLineIsList && !prevLineIsIndentedCode && (match = stream.match(setextHeaderRE))) {
       state.header = match[0].charAt(0) == '=' ? 1 : 2;
       if (modeCfg.highlightFormatting) state.formatting = "header";
       state.f = state.inline;
@@ -702,6 +713,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
         list: s.list,
         listDepth: s.listDepth,
         quote: s.quote,
+        indentedCode: s.indentedCode,
         trailingSpace: s.trailingSpace,
         trailingSpaceNewLine: s.trailingSpaceNewLine,
         md_inside: s.md_inside

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -85,13 +85,6 @@
      "    [comment foo]",
      "bar");
 
-  // Code blocks using 4 spaces with internal indentation
-  MT("codeBlocksUsing4SpacesIndentation",
-     " foo",
-     "    [comment bar]",
-     "        [comment hello]",
-     "    [comment world]");
-
   // Code blocks should end even after extra indented lines
   MT("codeBlocksWithTrailingIndentedLine",
      "    [comment foo]",
@@ -103,6 +96,12 @@
   // Code blocks using 1 tab (regardless of CodeMirror.indentWithTabs value)
   MT("codeBlocksUsing1Tab",
      "\t[comment foo]");
+
+  // No code blocks directly after paragraph
+  // http://spec.commonmark.org/0.19/#example-65
+  MT("noCodeBlocksAfterParagraph",
+     "Foo",
+     "    Bar");
 
   // Inline code using backticks
   MT("inlineCodeUsingBackticks",
@@ -166,10 +165,13 @@
   MT("atxH6",
      "[header&header-6 ###### foo]");
 
-  // H6 - 7x '#' should still be H6, per Dingus
-  // http://daringfireball.net/projects/markdown/dingus
-  MT("atxH6NotH7",
-     "[header&header-6 ####### foo]");
+  // http://spec.commonmark.org/0.19/#example-24
+  MT("noAtxH7",
+     "####### foo");
+
+  // http://spec.commonmark.org/0.19/#example-25
+  MT("noAtxH1WithoutSpace",
+     "#5 bolt");
 
   // Inline styles should be parsed inside headers
   MT("atxH1inline",
@@ -201,6 +203,25 @@
   MT("setextH2",
      "foo",
      "[header&header-2 ---]");
+
+  // http://spec.commonmark.org/0.19/#example-45
+  MT("setextH2AllowSpaces",
+     "foo",
+     "   [header&header-2 ----      ]");
+
+  // http://spec.commonmark.org/0.19/#example-44
+  MT("noSetextAfterIndentedCodeBlock",
+     "     [comment foo]",
+     "[hr ---]");
+
+  // http://spec.commonmark.org/0.19/#example-51
+  MT("noSetextAfterQuote",
+     "[quote&quote-1 > foo]",
+     "[hr ---]");
+
+  MT("noSetextAfterList",
+     "[variable-2 - foo]",
+     "[hr ---]");
 
   // Single-line blockquote with trailing space
   MT("blockquoteSpace",
@@ -296,6 +317,11 @@
   MT("listAfterHeader",
      "[header&header-1 # foo]",
      "[variable-2 - bar]");
+
+  // hr after list
+  MT("hrAfterList",
+     "[variable-2 - foo]",
+     "[hr -----]");
 
   // Formatting in lists (*)
   MT("listAsteriskFormatting",


### PR DESCRIPTION
I know we used to use the [Markdown Dingus](http://daringfireball.net/projects/markdown/dingus) for defining what our mode does, but now that [CommonMark](http://commonmark.org) exists, which is focused on "A strongly specified, highly compatible implementation of Markdown" and defines all kinds of edge cases (that's basically what their spec is all about), I think we should just go with that.

This PR makes some adjustments so we can get reasonable CommonMark compliance.

Notable changes:
* `===` will no longer give a horizontal ruler
  This is explicitly mentioned in [CommonMark](http://spec.commonmark.org/0.19/#example-6) to not result in a hr.
* `####### (7 hashes)` will no longer give a `header-6` header, but nothing.
  This is explicitly mentioned in [CommonMark](http://spec.commonmark.org/0.19/#example-24) to not result in a hr, even though your test case referred to the Dingus where this apparently means `h6` anyway.
* `1)` and so on also indicate an ordered list (http://spec.commonmark.org/0.19/#ordered-list-marker)
* A setext header can be surrounded by spaces (http://spec.commonmark.org/0.19/#example-45)
* Way better handling of indented code (e.g., an indented line after a paragraph, with no blank line in between, is not code)
* Setext cannot be below indented code, a quote or a list. It's interpreted as an hr if possible.