### PR TITLE
Fix of wrong hinting after typing dot and continuing writing string…

### DIFF
--- a/addon/hint/sql-hint.js
+++ b/addon/hint/sql-hint.js
@@ -231,6 +231,11 @@
       token.end = cur.ch;
       token.string = token.string.slice(0, cur.ch - token.start);
     }
+	// Checking for schema or table before current token 
+	var prevToken = editor.getTokenAt({ line: cur.line, ch: token.start });
+	if (prevToken.string == ".") {
+	  token.string = prevToken.string + token.string;
+	}
 
     if (token.string.match(/^[.`\w@]\w*$/)) {
       search = token.string;


### PR DESCRIPTION
Fix of wrong hinting after typing dot and continuing writing strings like schema.table or schema.table.field and not pressing enter (for example, if there are a lot of similar tables).