### PR TITLE
[markdown] Don't adjust indentation for blockquotes (closes #3287)

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -161,7 +161,6 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       state.f = state.inline;
       return getType(state);
     } else if (stream.eat('>')) {
-      state.indentation++;
       state.quote = sol ? 1 : state.quote + 1;
       if (modeCfg.highlightFormatting) state.formatting = "quote";
       stream.eatSpace();

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -272,6 +272,13 @@
      "",
      "hello");
 
+  // Header with leading space after continued blockquote (#3287, negative indentation)
+  MT("headerAfterContinuedBlockquote",
+     "[quote&quote-1 > foo]",
+     "[quote&quote-1 bar]",
+     "",
+     " [header&header-1 # hello]");
+
   // Check list types
 
   MT("listAsterisk",


### PR DESCRIPTION
It looks like a piece of code that adjusts indentation [snuck in from the original version of the mode](https://github.com/codemirror/CodeMirror/blame/495de327b7982eb0da3bb93fcd5a0941f177dff7/mode/markdown/markdown.js#L164). Removing this fixes #3287 .