### PR TITLE
[vim] ensure newly mapped commands take precedence

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -4726,7 +4726,7 @@
     }
 
     function _mapCommand(command) {
-      defaultKeymap.push(command);
+      defaultKeymap.unshift(command);
     }
 
     function mapCommand(keys, type, name, args, extra) {


### PR DESCRIPTION
- Use 'unshift' instead of 'push' to ensure newly mapped commands come first (and hence take precedence over previously mapped commands)