### PR TITLE
Initialize docs before creating tern server instance

### DIFF
--- a/addon/tern/tern.js
+++ b/addon/tern/tern.js
@@ -59,6 +59,7 @@
     this.options = options || {};
     var plugins = this.options.plugins || (this.options.plugins = {});
     if (!plugins.doc_comment) plugins.doc_comment = true;
+    this.docs = Object.create(null);
     if (this.options.useWorker) {
       this.server = new WorkerServer(this);
     } else {
@@ -69,7 +70,6 @@
         plugins: plugins
       });
     }
-    this.docs = Object.create(null);
     this.trackChange = function(doc, change) { trackChange(self, doc, change); };
 
     this.cachedArgHints = null;


### PR DESCRIPTION
This PR initialize docs before creating tern server instance, because in some case, tern server creation call getFile which use docs.

I have this case by using requirejs tern plugin + custom plugin which defines requirejs modules : 

```json
{
    "!name": "delite",
    "!define": {
      "!requirejs": {
        "delite/register": {
          "!type": "fn(tag: string, superclasses: [], props: ?) -> fn()",
      }
    }
  }
```