### PR TITLE
Fix scrolling issue when height: auto

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -771,8 +771,9 @@
   function setDocumentHeight(cm, measure) {
     cm.display.sizer.style.minHeight = measure.docHeight + "px";
     var total = measure.docHeight + cm.display.barHeight;
+    var scrollHeight = cm.display.scroller.clientHeight;
     cm.display.heightForcer.style.top = total + "px";
-    cm.display.gutters.style.height = Math.max(total + scrollGap(cm), measure.clientHeight) + "px";
+    cm.display.gutters.style.height = Math.max(total + scrollGap(cm), scrollHeight) + "px";
   }
 
   // Read the actual heights of the rendered lines, and update their

--- a/test/scroll_test.js
+++ b/test/scroll_test.js
@@ -102,4 +102,15 @@
     cm.replaceSelection("\n");
     is(cm.cursorCoords(null, "window").bottom < displayBottom(cm, false));
   }, {lineWrapping: true});
+
+  testCM("height_auto_with_gutter_expect_no_scroll_after_line_delete", function(cm) {
+    cm.setSize(null, "auto");
+    cm.setValue("x\nx");
+    cm.execCommand("goDocEnd");
+    cm.execCommand("deleteLine");
+    cm.execCommand("delCharBefore");
+    is(cm.getScrollInfo().top === 0);
+    cm.scrollTo(null, 10);
+    is(cm.getScrollInfo().top === 0);
+  }, {lineNumbers: true});
 })();


### PR DESCRIPTION
After deleting a line with height: auto set,
the codemirror would scroll even though it shouldn't

fixes https://github.com/codemirror/CodeMirror/issues/3361