### PR TITLE
Update tern.css

### DIFF
--- a/addon/tern/tern.css
+++ b/addon/tern/tern.css
@@ -1,6 +1,7 @@
 .CodeMirror-Tern-completion {
   padding-left: 22px;
   position: relative;
+  line-height: 1.5;
 }
 .CodeMirror-Tern-completion:before {
   position: absolute;


### PR DESCRIPTION
I noticed that the image that accompanies auto-completion suggestions when the tern addon is active gets cut slightly because the default line height is slightly smaller than the image height.
This change ensures that that the image is fully shown.