### PR TITLE
Emacs Keymap: Fix handling of non-integer line numbers in goto-line.

### DIFF
--- a/keymap/emacs.js
+++ b/keymap/emacs.js
@@ -377,7 +377,7 @@
 
       getInput(cm, "Goto line", function(str) {
         var num;
-        if (str && !isNaN(num = Number(str)) && num == num|0 && num > 0)
+        if (str && !isNaN(num = Number(str)) && num == (num|0) && num > 0)
           cm.setCursor(num - 1);
       });
     },

--- a/test/emacs_test.js
+++ b/test/emacs_test.js
@@ -138,4 +138,10 @@
     cm.triggerOnKeyDown(fakeEvent("Ctrl-S"));
     is(saved, "hi");
   }, {value: "hi", keyMap: "emacs"});
+
+  testCM("gotoInvalidLineFloat", function(cm) {
+    cm.openDialog = function(_, cb) { cb("2.2"); };
+    cm.triggerOnKeyDown(fakeEvent("Alt-G"));
+    cm.triggerOnKeyDown(fakeEvent("G"));
+  }, {value: "1\n2\n3\n4", keyMap: "emacs"});
 })();


### PR DESCRIPTION
This fixes cases such as `Alt-G`, `G`, "2.2", which would previously lead to a `TypeError`.