### PR TITLE
Erlang Mode: Remove duplicate if branches.

### DIFF
--- a/mode/erlang/erlang.js
+++ b/mode/erlang/erlang.js
@@ -220,16 +220,12 @@ CodeMirror.defineMode("erlang", function(cmCfg) {
         }else{
           return rval(state,stream,"function");
         }
-      }else if (is_member(w,operatorAtomWords)) {
-        return rval(state,stream,"operator");
       }else if (lookahead(stream) == ":") {
         if (w == "erlang") {
           return rval(state,stream,"builtin");
         } else {
           return rval(state,stream,"function");
         }
-      }else if (is_member(w,["true","false"])) {
-        return rval(state,stream,"boolean");
       }else if (is_member(w,["true","false"])) {
         return rval(state,stream,"boolean");
       }else{


### PR DESCRIPTION
Unless I'm missing something, the two branches in question are duplicates of branches further up and hence unreachable. Not a bug per se, but a potential readability/maintenance problem.