### PR TITLE
Use displayName if it exists for completion display text

### DIFF
--- a/addon/tern/tern.js
+++ b/addon/tern/tern.js
@@ -216,7 +216,7 @@
         var completion = data.completions[i], className = typeToIcon(completion.type);
         if (data.guess) className += " " + cls + "guess";
         completions.push({text: completion.name + after,
-                          displayText: completion.name,
+                          displayText: completion.displayName ? completion.displayName : completion.name,
                           className: className,
                           data: completion});
       }


### PR DESCRIPTION
Tern completion for required module returns name (module wuith quote) and displayName (module without quote). This PR gives the capability to display completion for required module without quote.