### PR TITLE
Add a .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+**/.*
+node_modules
+components
+bin
+demo
+doc
+test
+index.html
+package.json
+mode/*/*test.js
+mode/*/*.html


### PR DESCRIPTION
The .npmignore file will keep certain files/directories out of the package when installing CodeMirror with npm. I reused the same ignore list found in bower.json.