### PR TITLE
[sublime keymap] Fix scrollLine[Up/Down] bindings

### DIFF
--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -55,7 +55,9 @@
   cmds[map["Alt-Left"] = "goSubwordLeft"] = function(cm) { moveSubword(cm, -1); };
   cmds[map["Alt-Right"] = "goSubwordRight"] = function(cm) { moveSubword(cm, 1); };
 
-  cmds[map[ctrl + "Up"] = "scrollLineUp"] = function(cm) {
+  var scrollLineCombo = mac ? "Ctrl-Alt-" : "Ctrl-";
+
+  cmds[map[scrollLineCombo + "Up"] = "scrollLineUp"] = function(cm) {
     var info = cm.getScrollInfo();
     if (!cm.somethingSelected()) {
       var visibleBottomLine = cm.lineAtHeight(info.top + info.clientHeight, "local");
@@ -64,7 +66,7 @@
     }
     cm.scrollTo(null, info.top - cm.defaultTextHeight());
   };
-  cmds[map[ctrl + "Down"] = "scrollLineDown"] = function(cm) {
+  cmds[map[scrollLineCombo + "Down"] = "scrollLineDown"] = function(cm) {
     var info = cm.getScrollInfo();
     if (!cm.somethingSelected()) {
       var visibleTopLine = cm.lineAtHeight(info.top, "local")+1;


### PR DESCRIPTION
In current CodeMirror on OSX, hitting cmd + up or down only scrolls the viewport (using scrollLineUp or Down) instead of jumping to the start or end of the entire buffer.

In Sublime OSX, the default key for scrolling one line up or down is Ctrl-Alt-Up/Down. In Windows/Linux, it is just Ctrl-Up/Down.