### PR TITLE
[travis] Use stable node and container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - 0.10
+  - stable
+sudo: false


### PR DESCRIPTION
Should improve test robustness as well as speed - specifying `sudo: false` will let Travis use its new container-based infrastructure.