### PR TITLE
Added name properties to pre defined keymaps

### DIFF
--- a/keymap/emacs.js
+++ b/keymap/emacs.js
@@ -398,7 +398,8 @@
     "Ctrl-X H": "selectAll",
 
     "Ctrl-Q Tab": repeated("insertTab"),
-    "Ctrl-U": addPrefixMap
+    "Ctrl-U": addPrefixMap,
+    "name": "emacs"
   });
 
   var prefixMap = {"Ctrl-G": clearPrefix};

--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -14,7 +14,7 @@
 })(function(CodeMirror) {
   "use strict";
 
-  var map = CodeMirror.keyMap.sublime = {fallthrough: "default"};
+  var map = CodeMirror.keyMap.sublime = {fallthrough: "default", name: "sublime"};
   var cmds = CodeMirror.commands;
   var Pos = CodeMirror.Pos;
   var mac = CodeMirror.keyMap["default"] == CodeMirror.keyMap.macDefault;

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5661,7 +5661,7 @@
     "Ctrl-G": "findNext", "Shift-Ctrl-G": "findPrev", "Shift-Ctrl-F": "replace", "Shift-Ctrl-R": "replaceAll",
     "Ctrl-[": "indentLess", "Ctrl-]": "indentMore",
     "Ctrl-U": "undoSelection", "Shift-Ctrl-U": "redoSelection", "Alt-U": "redoSelection",
-    "name": "pcDefault"
+    "name": "pcDefault",
     fallthrough: "basic"
   };
   // Very basic readline/emacs-style bindings, which are standard on Mac.

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5647,7 +5647,8 @@
     "Delete": "delCharAfter", "Backspace": "delCharBefore", "Shift-Backspace": "delCharBefore",
     "Tab": "defaultTab", "Shift-Tab": "indentAuto",
     "Enter": "newlineAndIndent", "Insert": "toggleOverwrite",
-    "Esc": "singleSelection"
+    "Esc": "singleSelection",
+    "name": "basic"
   };
   // Note that the save and find-related commands aren't defined by
   // default. User code or addons can define them. Unknown commands
@@ -5660,6 +5661,7 @@
     "Ctrl-G": "findNext", "Shift-Ctrl-G": "findPrev", "Shift-Ctrl-F": "replace", "Shift-Ctrl-R": "replaceAll",
     "Ctrl-[": "indentLess", "Ctrl-]": "indentMore",
     "Ctrl-U": "undoSelection", "Shift-Ctrl-U": "redoSelection", "Alt-U": "redoSelection",
+    "name": "pcDefault"
     fallthrough: "basic"
   };
   // Very basic readline/emacs-style bindings, which are standard on Mac.
@@ -5667,7 +5669,8 @@
     "Ctrl-F": "goCharRight", "Ctrl-B": "goCharLeft", "Ctrl-P": "goLineUp", "Ctrl-N": "goLineDown",
     "Alt-F": "goWordRight", "Alt-B": "goWordLeft", "Ctrl-A": "goLineStart", "Ctrl-E": "goLineEnd",
     "Ctrl-V": "goPageDown", "Shift-Ctrl-V": "goPageUp", "Ctrl-D": "delCharAfter", "Ctrl-H": "delCharBefore",
-    "Alt-D": "delWordAfter", "Alt-Backspace": "delWordBefore", "Ctrl-K": "killLine", "Ctrl-T": "transposeChars"
+    "Alt-D": "delWordAfter", "Alt-Backspace": "delWordBefore", "Ctrl-K": "killLine", "Ctrl-T": "transposeChars",
+    "name": "emacsy"
   };
   keyMap.macDefault = {
     "Cmd-A": "selectAll", "Cmd-D": "deleteLine", "Cmd-Z": "undo", "Shift-Cmd-Z": "redo", "Cmd-Y": "redo",
@@ -5677,6 +5680,7 @@
     "Cmd-G": "findNext", "Shift-Cmd-G": "findPrev", "Cmd-Alt-F": "replace", "Shift-Cmd-Alt-F": "replaceAll",
     "Cmd-[": "indentLess", "Cmd-]": "indentMore", "Cmd-Backspace": "delWrappedLineLeft", "Cmd-Delete": "delWrappedLineRight",
     "Cmd-U": "undoSelection", "Shift-Cmd-U": "redoSelection", "Ctrl-Up": "goDocStart", "Ctrl-Down": "goDocEnd",
+    "name": "macDefault",
     fallthrough: ["basic", "emacsy"]
   };
   keyMap["default"] = mac ? keyMap.macDefault : keyMap.pcDefault;


### PR DESCRIPTION
`cm.removeKeyMap()`, as per documentation, depends on the `name` property of the active keymap in order to remove it if a string is passed as an argument. Most predefined keymaps did not have a `name` property, leading to unexpected behaviour.

>cm.removeKeyMap(map: object)
>Disable a keymap added with addKeyMap. Either pass in the key map object itself, or a string, which will be compared against *the name property of the active key maps*.

