### PR TITLE
dont exit poll() when ime composing

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1398,7 +1398,7 @@
       // will be the case when there is a lot of text in the textarea,
       // in which case reading its value would be expensive.
       if (this.contextMenuPending || !cm.state.focused ||
-          (hasSelection(input) && !prevInput) ||
+          (hasSelection(input) && !prevInput && !this.composing) ||
           isReadOnly(cm) || cm.options.disableInput || cm.state.keySeq)
         return false;
 


### PR DESCRIPTION
related #1823 

we have problem when composing korean because poll() method keep exit when korean first letter composing in IE11

IE11 make selection when korean letter is composing(we need several key type to make one letter) 

I think this maybe solution

how about this?