### PR TITLE
Preserve newline LF/CRLF for each line

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -331,7 +331,7 @@
   // other lines onto it.
   function lineLength(line) {
     if (line.height == 0) return 0;
-    var len = line.text.length, merged, cur = line;
+    var len = line.text.length - getLineSep(line.text).length, merged, cur = line;
     while (merged = collapsedSpanAtStart(cur)) {
       var found = merged.find(0, true);
       cur = found.from.line;
@@ -340,9 +340,9 @@
     cur = line;
     while (merged = collapsedSpanAtEnd(cur)) {
       var found = merged.find(0, true);
-      len -= cur.text.length - found.from.ch;
+      len -= cur.text.length - getLineSep(cur.text).length - found.from.ch;
       cur = found.to.line;
-      len += cur.text.length - found.to.ch;
+      len += cur.text.length - getLineSep(cur.text).length - found.to.ch;
     }
     return len;
   }
@@ -1095,7 +1095,7 @@
     var textLines = splitLines(inserted), multiPaste = null;
     // When pasing N lines into N selections, insert one line per selection
     if (paste && sel.ranges.length > 1) {
-      if (lastCopied && lastCopied.join("\n") == inserted)
+      if (lastCopied && lastCopied.join("") == inserted)
         multiPaste = sel.ranges.length % lastCopied.length == 0 && map(lastCopied, splitLines);
       else if (textLines.length == sel.ranges.length)
         multiPaste = map(textLines, function(l) { return [l]; });
@@ -1244,7 +1244,7 @@
           if (input.inaccurateSelection) {
             input.prevInput = "";
             input.inaccurateSelection = false;
-            te.value = lastCopied.join("\n");
+            te.value = lastCopied.join("");
             selectInput(te);
           }
         } else if (!cm.options.lineWiseCopyCut) {
@@ -1256,7 +1256,7 @@
             cm.setSelections(ranges.ranges, null, sel_dontScroll);
           } else {
             input.prevInput = "";
-            te.value = ranges.text.join("\n");
+            te.value = lastCopied.join("");
             selectInput(te);
           }
         }
@@ -1609,12 +1609,12 @@
         if (e.clipboardData && !ios) {
           e.preventDefault();
           e.clipboardData.clearData();
-          e.clipboardData.setData("text/plain", lastCopied.join("\n"));
+          e.clipboardData.setData("text/plain", lastCopied.join(""));
         } else {
           // Old-fashioned briefly-focus-a-textarea hack
           var kludge = hiddenTextarea(), te = kludge.firstChild;
           cm.display.lineSpace.insertBefore(kludge, cm.display.lineSpace.firstChild);
-          te.value = lastCopied.join("\n");
+          te.value = lastCopied.join("");
           var hadFocus = document.activeElement;
           selectInput(te);
           setTimeout(function() {
@@ -1936,7 +1936,7 @@
         if (markerID) {
           var found = cm.findMarks(Pos(fromLine, 0), Pos(toLine + 1, 0), recognizeMarker(+markerID));
           if (found.length && (range = found[0].find()))
-            text += getBetween(cm.doc, range.from, range.to).join("\n");
+            text += getBetween(cm.doc, range.from, range.to).join("");
           return;
         }
         if (node.getAttribute("contenteditable") == "false") return;
@@ -1948,7 +1948,7 @@
         var val = node.nodeValue;
         if (!val) return;
         if (closing) {
-          text += "\n";
+          text += "\n"; // TODO: support CR/CRLF too
           closing = false;
         }
         text += val;
@@ -3797,6 +3797,7 @@
           text[i] = reader.result;
           if (++read == n) {
             pos = clipPos(cm.doc, pos);
+            // TODO: support CR/CRLF too
             var change = {from: pos, to: pos, text: splitLines(text.join("\n")), origin: "paste"};
             makeChange(cm.doc, change);
             setSelectionReplaceHistory(cm.doc, simpleSelection(pos, changeEnd(change)));
@@ -4736,7 +4737,7 @@
       if (next == null) {
         if (!boundToLine && findNextLine()) {
           if (visually) ch = (dir < 0 ? lineRight : lineLeft)(lineObj);
-          else ch = dir < 0 ? lineObj.text.length : 0;
+          else ch = dir < 0 ? (lineObj.text.length - getLineSep(lineObj.text).length) : 0;
         } else return (possible = false);
       } else ch = next;
       return true;
@@ -5624,7 +5625,7 @@
                               Pos(cur.line, cur.ch - 2), cur, "+transpose");
             } else if (cur.line > cm.doc.first) {
               var prev = getLine(cm.doc, cur.line - 1).text;
-              if (prev)
+              if (prev) // TODO: handle CR/CRLF too
                 cm.replaceRange(line.charAt(0) + "\n" + prev.charAt(prev.length - 1),
                                 Pos(cur.line - 1, prev.length - 1), Pos(cur.line, 1), "+transpose");
             }
@@ -5636,10 +5637,11 @@
     },
     newlineAndIndent: function(cm) {
       runInOp(cm, function() {
-        var len = cm.listSelections().length;
+        var len = cm.listSelections().length, ln;
         for (var i = 0; i < len; i++) {
           var range = cm.listSelections()[i];
-          cm.replaceRange("\n", range.anchor, range.head, "+input");
+          var lineSep = getLineSep(range.start.line) || '\n';
+          cm.replaceRange(lineSep, range.anchor, range.head, "+input");
           cm.indentLine(range.from().line + 1, null, true);
           ensureCursorVisible(cm);
         }
@@ -5856,11 +5858,16 @@
   };
 
   StringStream.prototype = {
-    eol: function() {return this.pos >= this.string.length;},
+    eol: function() {
+      return this.pos > this.string.length-2 ||
+        (this.pos == this.string.length-1 && 
+        (this.string.charCodeAt(this.pos)==13 || this.string.charCodeAt(this.pos)==10)) ||
+        (this.pos == this.string.length-1 &&
+        this.string.charCodeAt(this.pos)==13 && this.string.charCodeAt(this.pos+1)==10);},
     sol: function() {return this.pos == this.lineStart;},
     peek: function() {return this.string.charAt(this.pos) || undefined;},
     next: function() {
-      if (this.pos < this.string.length)
+      if (!this.eol())
         return this.string.charAt(this.pos++);
     },
     eat: function(match) {
@@ -7283,8 +7290,7 @@
 
     getValue: function(lineSep) {
       var lines = getLines(this, this.first, this.first + this.size);
-      if (lineSep === false) return lines;
-      return lines.join(lineSep || "\n");
+      return joinSep(lines, lineSep);
     },
     setValue: docMethodOp(function(code) {
       var top = Pos(this.first, 0), last = this.first + this.size - 1;
@@ -7299,11 +7305,18 @@
     },
     getRange: function(from, to, lineSep) {
       var lines = getBetween(this, clipPos(this, from), clipPos(this, to));
-      if (lineSep === false) return lines;
-      return lines.join(lineSep || "\n");
+      return joinSep(lines, lineSep);
     },
 
-    getLine: function(line) {var l = this.getLineHandle(line); return l && l.text;},
+    getLine: function(line) {
+      var l = this.getLineHandle(line);
+      return l && stripSep(l.text);
+    },
+
+    getLineFull: function(line) {
+      var l = this.getLineHandle(line);
+      return l && l.text;
+    },
 
     getLineHandle: function(line) {if (isLine(this, line)) return getLine(this, line);},
     getLineNumber: function(line) {return lineNo(line);},
@@ -7365,14 +7378,13 @@
         var sel = getBetween(this, ranges[i].from(), ranges[i].to());
         lines = lines ? lines.concat(sel) : sel;
       }
-      if (lineSep === false) return lines;
-      else return lines.join(lineSep || "\n");
+      return joinSep(lines);
     },
     getSelections: function(lineSep) {
       var parts = [], ranges = this.sel.ranges;
       for (var i = 0; i < ranges.length; i++) {
         var sel = getBetween(this, ranges[i].from(), ranges[i].to());
-        if (lineSep !== false) sel = sel.join(lineSep || "\n");
+        sel = joinSep(sel, lineSep);
         parts[i] = sel;
       }
       return parts;
@@ -7730,6 +7742,35 @@
     var order = line.order;
     if (order == null) order = line.order = bidiOrdering(line.text);
     return order;
+  }
+
+  // Strip EOL separators from the end of line text
+  function stripSep(text) {
+    var sep = getLineSep(text);
+    if (!sep) return text;
+    return text.slice(0, text.length - sep.length);
+  }
+
+  // Detect specific EOL charaters at the end of line text
+  function getLineSep(text) {
+    if (!text) return '';
+    if (text.charCodeAt(text.length-1) == 13) return '\r';
+    if (text.charCodeAt(text.length-1) == 10) {
+      if (text.length>1 && text.charCodeAt(text.length-2) == 13)
+        return '\r\n';
+      else
+        return '\n';
+    }
+    return '';
+  }
+
+  // Join lines, optionally replacing EOL separators with given string
+  // (false strips separators altogether) 
+  function joinSep(lines, lineSep) {
+    if (!lineSep && lineSep !== false) return lines.join("");
+    for (var i = 0; i < lines.length; i++) { lines[i] = stripSep(lines[i]); }
+    if (!lineSep) return lines;
+    return lines.join(lineSep);
   }
 
   // HISTORY
@@ -8386,25 +8427,11 @@
     return badBidiRects = (r1.right - r0.right < 3);
   }
 
-  // See if "".split is the broken IE version, if so, provide an
-  // alternative way to split lines.
-  var splitLines = CodeMirror.splitLines = "\n\nb".split(/\n/).length != 3 ? function(string) {
-    var pos = 0, result = [], l = string.length;
-    while (pos <= l) {
-      var nl = string.indexOf("\n", pos);
-      if (nl == -1) nl = string.length;
-      var line = string.slice(pos, string.charAt(nl - 1) == "\r" ? nl - 1 : nl);
-      var rt = line.indexOf("\r");
-      if (rt != -1) {
-        result.push(line.slice(0, rt));
-        pos += rt + 1;
-      } else {
-        result.push(line);
-        pos = nl + 1;
-      }
-    }
-    return result;
-  } : function(string){return string.split(/\r\n?|\n/);};
+  // line terminators are included into the line
+  var splitLines = CodeMirror.splitLines = function(string){
+    var lines = string.match(/[^\r\n]*(?:\r?\n|$)/g);
+    return lines;
+  };
 
   var hasSelection = window.getSelection ? function(te) {
     try { return te.selectionStart != te.selectionEnd; }
@@ -8472,7 +8499,7 @@
   function lineLeft(line) { var order = getOrder(line); return order ? bidiLeft(order[0]) : 0; }
   function lineRight(line) {
     var order = getOrder(line);
-    if (!order) return line.text.length;
+    if (!order) return line.text.length - getLineSep(line.text).length;
     return bidiRight(lst(order));
   }
 
@@ -8491,7 +8518,7 @@
       lineN = null;
     }
     var order = getOrder(line);
-    var ch = !order ? line.text.length : order[0].level % 2 ? lineLeft(line) : lineRight(line);
+    var ch = !order ? line.text.length - getLineSep(line.text).length : order[0].level % 2 ? lineLeft(line) : lineRight(line);
     return Pos(lineN == null ? lineNo(line) : lineN, ch);
   }
   function lineStartSmart(cm, pos) {
@@ -8534,9 +8561,12 @@
   }
 
   function moveInLine(line, pos, dir, byUnit) {
-    if (!byUnit) return pos + dir;
-    do pos += dir;
-    while (pos > 0 && isExtendingChar(line.text.charAt(pos)));
+    var lineSep = getLineSep(line.text);
+    pos += dir;
+    // skip over EOL either direction
+    while (pos < line.text.length && pos > line.text.length-lineSep.length) pos += dir;
+    if (!byUnit) return pos;
+    while (pos > 0 && isExtendingChar(line.text.charAt(pos))) pos += dir;
     return pos;
   }
 
@@ -8570,8 +8600,9 @@
 
   function moveLogically(line, start, dir, byUnit) {
     var target = start + dir;
-    if (byUnit) while (target > 0 && isExtendingChar(line.text.charAt(target))) target += dir;
-    return target < 0 || target > line.text.length ? null : target;
+    var lineSep = getLineSep(line.text);
+    if (byUnit) while (target > 0 && target < line.text.length - lineSep.length && isExtendingChar(line.text.charAt(target))) target += dir;
+    return target < 0 || target > line.text.length - lineSep.length ? null : target;
   }
 
   // Bidirectional ordering algorithm

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5637,7 +5637,7 @@
     },
     newlineAndIndent: function(cm) {
       runInOp(cm, function() {
-        var len = cm.listSelections().length, ln;
+        var len = cm.listSelections().length;
         for (var i = 0; i < len; i++) {
           var range = cm.listSelections()[i];
           var lineSep = getLineSep(range.start.line) || '\n';
@@ -5860,7 +5860,7 @@
   StringStream.prototype = {
     eol: function() {
       return this.pos > this.string.length-2 ||
-        (this.pos == this.string.length-1 && 
+        (this.pos == this.string.length-1 &&
         (this.string.charCodeAt(this.pos)==13 || this.string.charCodeAt(this.pos)==10)) ||
         (this.pos == this.string.length-1 &&
         this.string.charCodeAt(this.pos)==13 && this.string.charCodeAt(this.pos+1)==10);},
@@ -7378,7 +7378,7 @@
         var sel = getBetween(this, ranges[i].from(), ranges[i].to());
         lines = lines ? lines.concat(sel) : sel;
       }
-      return joinSep(lines);
+      return joinSep(lines, lineSep);
     },
     getSelections: function(lineSep) {
       var parts = [], ranges = this.sel.ranges;

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -7766,7 +7766,7 @@
   }
 
   // Join lines, optionally replacing EOL separators with given string
-  // (false strips separators altogether) 
+  // (false strips separators altogether)
   function joinSep(lines, lineSep) {
     if (!lineSep && lineSep !== false) return lines.join("");
     for (var i = 0; i < lines.length; i++) { lines[i] = stripSep(lines[i]); }
@@ -8565,7 +8565,6 @@
   }
 
   function moveInLine(line, pos, dir, byUnit) {
-    var lineSep = getLineSep(line.text);
     pos += dir;
     // skip over EOL either direction
     while (pos < line.text.length && pos > line.contentLength()) pos += dir;

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -278,7 +278,7 @@
       }
 
       if (wrapping)
-        return widgetsHeight + (Math.ceil(line.text.length / perLine) || 1) * th;
+        return widgetsHeight + (Math.ceil(line.contentLength() / perLine) || 1) * th;
       else
         return widgetsHeight + th;
     };
@@ -331,7 +331,7 @@
   // other lines onto it.
   function lineLength(line) {
     if (line.height == 0) return 0;
-    var len = line.text.length - getLineSep(line.text).length, merged, cur = line;
+    var len = line.contentLength(), merged, cur = line;
     while (merged = collapsedSpanAtStart(cur)) {
       var found = merged.find(0, true);
       cur = found.from.line;
@@ -340,9 +340,9 @@
     cur = line;
     while (merged = collapsedSpanAtEnd(cur)) {
       var found = merged.find(0, true);
-      len -= cur.text.length - getLineSep(cur.text).length - found.from.ch;
+      len -= cur.contentLength() - found.from.ch;
       cur = found.to.line;
-      len += cur.text.length - getLineSep(cur.text).length - found.to.ch;
+      len += cur.contentLength() - found.to.ch;
     }
     return len;
   }
@@ -1109,7 +1109,7 @@
         if (deleted && deleted > 0) // Handle deletion
           from = Pos(from.line, from.ch - deleted);
         else if (cm.state.overwrite && !paste) // Handle overwrite
-          to = Pos(to.line, Math.min(getLine(doc, to.line).text.length, to.ch + lst(textLines).length));
+          to = Pos(to.line, Math.min(getLine(doc, to.line).contentLength(), to.ch + lst(textLines).length));
       }
       var updateInput = cm.curOp.updateInput;
       var changeEvent = {from: from, to: to, text: multiPaste ? multiPaste[i % multiPaste.length] : textLines,
@@ -1767,7 +1767,7 @@
       }
 
       var newText = splitLines(domTextBetween(cm, fromNode, toNode, fromLine, toLine));
-      var oldText = getBetween(cm.doc, Pos(fromLine, 0), Pos(toLine, getLine(cm.doc, toLine).text.length));
+      var oldText = getBetween(cm.doc, Pos(fromLine, 0), Pos(toLine, getLine(cm.doc, toLine).contentLength()));
       while (newText.length > 1 && oldText.length > 1) {
         if (lst(newText) == lst(oldText)) { newText.pop(); oldText.pop(); toLine--; }
         else if (newText[0] == oldText[0]) { newText.shift(); oldText.shift(); fromLine++; }
@@ -1875,7 +1875,7 @@
       offset = 0;
       if (!node) {
         var line = lineView.rest ? lst(lineView.rest) : lineView.line;
-        return badPos(Pos(lineNo(line), line.text.length), bad);
+        return badPos(Pos(lineNo(line), line.contentLength()), bad);
       }
     }
 
@@ -2049,8 +2049,8 @@
   function clipPos(doc, pos) {
     if (pos.line < doc.first) return Pos(doc.first, 0);
     var last = doc.first + doc.size - 1;
-    if (pos.line > last) return Pos(last, getLine(doc, last).text.length);
-    return clipToLen(pos, getLine(doc, pos.line).text.length);
+    if (pos.line > last) return Pos(last, getLine(doc, last).contentLength());
+    return clipToLen(pos, getLine(doc, pos.line).contentLength());
   }
   function clipToLen(pos, linelen) {
     var ch = pos.ch;
@@ -2224,7 +2224,7 @@
               if (newPos.ch < 0) {
                 if (newPos.line > doc.first) newPos = clipPos(doc, Pos(newPos.line - 1));
                 else newPos = null;
-              } else if (newPos.ch > line.text.length) {
+              } else if (newPos.ch > line.contentLength()) {
                 if (newPos.line < doc.first + doc.size - 1) newPos = Pos(newPos.line + 1, 0);
                 else newPos = null;
               }
@@ -2309,7 +2309,7 @@
 
     function drawForLine(line, fromArg, toArg) {
       var lineObj = getLine(doc, line);
-      var lineLen = lineObj.text.length;
+      var lineLen = lineObj.contentLength();
       var start, end;
       function coords(ch, bias) {
         return charCoords(cm, Pos(line, ch), "div", lineObj, bias);
@@ -2349,7 +2349,7 @@
     } else {
       var fromLine = getLine(doc, sFrom.line), toLine = getLine(doc, sTo.line);
       var singleVLine = visualLine(fromLine) == visualLine(toLine);
-      var leftEnd = drawForLine(sFrom.line, sFrom.ch, singleVLine ? fromLine.text.length + 1 : null).end;
+      var leftEnd = drawForLine(sFrom.line, sFrom.ch, singleVLine ? fromLine.contentLength() + 1 : null).end;
       var rightStart = drawForLine(sTo.line, singleVLine ? 0 : null, sTo.ch).start;
       if (singleVLine) {
         if (leftEnd.top < rightStart.top - 2) {
@@ -2840,7 +2840,7 @@
     if (y < 0) return PosWithInfo(doc.first, 0, true, -1);
     var lineN = lineAtHeight(doc, y), last = doc.first + doc.size - 1;
     if (lineN > last)
-      return PosWithInfo(doc.first + doc.size - 1, getLine(doc, last).text.length, true, 1);
+      return PosWithInfo(doc.first + doc.size - 1, getLine(doc, last).contentLength(), true, 1);
     if (x < 0) x = 0;
 
     var lineObj = getLine(doc, lineN);
@@ -2869,7 +2869,7 @@
       return sp.left;
     }
 
-    var bidi = getOrder(lineObj), dist = lineObj.text.length;
+    var bidi = getOrder(lineObj), dist = lineObj.contentLength();
     var from = lineLeft(lineObj), to = lineRight(lineObj);
     var fromX = getX(from), fromOutside = wrongLine, toX = getX(to), toOutside = wrongLine;
 
@@ -4737,7 +4737,7 @@
       if (next == null) {
         if (!boundToLine && findNextLine()) {
           if (visually) ch = (dir < 0 ? lineRight : lineLeft)(lineObj);
-          else ch = dir < 0 ? (lineObj.text.length - getLineSep(lineObj.text).length) : 0;
+          else ch = dir < 0 ? lineObj.contentLength() : 0;
         } else return (possible = false);
       } else ch = next;
       return true;
@@ -5503,7 +5503,7 @@
     killLine: function(cm) {
       deleteNearSelection(cm, function(range) {
         if (range.empty()) {
-          var len = getLine(cm.doc, range.head.line).text.length;
+          var len = getLine(cm.doc, range.head.line).contentLength();
           if (range.head.ch == len && range.head.line < cm.lastLine())
             return {from: range.head, to: Pos(range.head.line + 1, 0)};
           else
@@ -6513,7 +6513,7 @@
       var end = span.marker.find(1, true);
       return lineIsHiddenInner(doc, end.line, getMarkedSpanFor(end.line.markedSpans, span.marker));
     }
-    if (span.marker.inclusiveRight && span.to == line.text.length)
+    if (span.marker.inclusiveRight && (span.to == line.text.length || span.to == line.contentLength()))
       return true;
     for (var sp, i = 0; i < line.markedSpans.length; ++i) {
       sp = line.markedSpans[i];
@@ -6611,6 +6611,7 @@
   };
   eventMixin(Line);
   Line.prototype.lineNo = function() { return lineNo(this); };
+  Line.prototype.contentLength = function() { return this.text.length - getLineSep(this.text).length; };
 
   // Change the content (text, markers) of a line. Automatically
   // invalidates cached information and tries to re-estimate the
@@ -7531,7 +7532,7 @@
     posFromIndex: function(off) {
       var ch, lineNo = this.first;
       this.iter(function(line) {
-        var sz = line.text.length + 1;
+        var sz = line.text.length;
         if (sz > off) { ch = off; return true; }
         off -= sz;
         ++lineNo;
@@ -7543,7 +7544,7 @@
       var index = coords.ch;
       if (coords.line < this.first || coords.ch < 0) return 0;
       this.iter(this.first, coords.line, function (line) {
-        index += line.text.length + 1;
+        index += line.text.length;
       });
       return index;
     },
@@ -8430,6 +8431,9 @@
   // line terminators are included into the line
   var splitLines = CodeMirror.splitLines = function(string){
     var lines = string.match(/[^\r\n]*(?:\r?\n|$)/g);
+    // for input not ending with a linebreak this regexp adds a redundant empty entry
+    if (lines.length>1 && !lines[lines.length-1] && ('\r\n').indexOf(lines[lines.length-2].slice(-1))<0)
+      lines.splice(lines.length-1, 1); 
     return lines;
   };
 
@@ -8499,7 +8503,7 @@
   function lineLeft(line) { var order = getOrder(line); return order ? bidiLeft(order[0]) : 0; }
   function lineRight(line) {
     var order = getOrder(line);
-    if (!order) return line.text.length - getLineSep(line.text).length;
+    if (!order) return line.contentLength();
     return bidiRight(lst(order));
   }
 
@@ -8518,7 +8522,7 @@
       lineN = null;
     }
     var order = getOrder(line);
-    var ch = !order ? line.text.length - getLineSep(line.text).length : order[0].level % 2 ? lineLeft(line) : lineRight(line);
+    var ch = !order ? line.contentLength() : order[0].level % 2 ? lineLeft(line) : lineRight(line);
     return Pos(lineN == null ? lineNo(line) : lineN, ch);
   }
   function lineStartSmart(cm, pos) {
@@ -8564,7 +8568,7 @@
     var lineSep = getLineSep(line.text);
     pos += dir;
     // skip over EOL either direction
-    while (pos < line.text.length && pos > line.text.length-lineSep.length) pos += dir;
+    while (pos < line.text.length && pos > line.contentLength()) pos += dir;
     if (!byUnit) return pos;
     while (pos > 0 && isExtendingChar(line.text.charAt(pos))) pos += dir;
     return pos;
@@ -8600,9 +8604,8 @@
 
   function moveLogically(line, start, dir, byUnit) {
     var target = start + dir;
-    var lineSep = getLineSep(line.text);
-    if (byUnit) while (target > 0 && target < line.text.length - lineSep.length && isExtendingChar(line.text.charAt(target))) target += dir;
-    return target < 0 || target > line.text.length - lineSep.length ? null : target;
+    if (byUnit) while (target > 0 && target < line.contentLength() && isExtendingChar(line.text.charAt(target))) target += dir;
+    return target < 0 || target > line.contentLength() ? null : target;
   }
 
   // Bidirectional ordering algorithm

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -8433,7 +8433,7 @@
     var lines = string.match(/[^\r\n]*(?:\r?\n|$)/g);
     // for input not ending with a linebreak this regexp adds a redundant empty entry
     if (lines.length>1 && !lines[lines.length-1] && ('\r\n').indexOf(lines[lines.length-2].slice(-1))<0)
-      lines.splice(lines.length-1, 1); 
+      lines.splice(lines.length-1, 1);
     return lines;
   };
 


### PR DESCRIPTION
Implements #3395 

The idea is to store EOL characters inside of `CodeMirror.Line.text`. And four broad areas needed careful adjustments:

1. Operations like getValue, getRange and similar will no longer `join("\n")`, instead they `join("")`. Of course, it's more complicated -- when `lineSep` optional argument is provided, the native EOLs need to be replaced with a given `lineSep`. That logic is in the new function `joinSep(lines, lineSep)`.

2. Cursor movement left-right need to skip over now-explicitly-present EOLs when moving in either direction. Given that EOLs can be either of `\n`, `\r\n` and `\r`, a new function `getLineSep(lineText)` is introduced. It's a cheap call, not allocating any objects and simply checking the last two characters. Several places where lineObj.text.length is used have been adjusted to account for the EOL length.

3. Highlight modes may not be prepared for EOLs, so StringStream is adjusted to skip over those. Again, care has been taken to avoid creating string objects unnecessarily.

4. Position/index conversion functions previously calculated offsets by aggregating over `line.text.length+1` where `+1` is for the EOL character. The new logic should just aggregate over `line.text.length`.

I've tested it with `/codemirror/demo/preview.html` -- it works exactly as before (at least in Chrome on desktop). Will try with more use cases.