### PR TITLE
[vim] Make it easier to override color on blinking cursor

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -63,21 +63,22 @@
   -webkit-animation: blink 1.06s steps(1) infinite;
   -moz-animation: blink 1.06s steps(1) infinite;
   animation: blink 1.06s steps(1) infinite;
+  background-color: #7e7;
 }
 @-moz-keyframes blink {
-  0% { background: #7e7; }
-  50% { background: none; }
-  100% { background: #7e7; }
+  0% {}
+  50% { background-color: transparent; }
+  100% {}
 }
 @-webkit-keyframes blink {
-  0% { background: #7e7; }
-  50% { background: none; }
-  100% { background: #7e7; }
+  0% {}
+  50% { background-color: transparent; }
+  100% {}
 }
 @keyframes blink {
-  0% { background: #7e7; }
-  50% { background: none; }
-  100% { background: #7e7; }
+  0% {}
+  50% { background-color: transparent; }
+  100% {}
 }
 
 /* Can style cursor different in overwrite (non-insert) mode */


### PR DESCRIPTION
Right now, if you want to change the color of the cursor in vim mode, you need to both

1. Modify the background color of `.CodeMirror.cm-fat-cursor div.CodeMirror-cursor`
2. Reassign the vendored animation properties of `.cm-animate-fat-cursor` to an animation with a new custom color.

This change makes the latter easier, by just animating to transparent and using whatever the default background color of `.cm-animate-fat-cursor` is, which is much easier to override.