### PR TITLE
Avoid passing array as 'this' argument to operation callbacks

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2978,7 +2978,7 @@
     var callbacks = group.delayedCallbacks, i = 0;
     do {
       for (; i < callbacks.length; i++)
-        callbacks[i]();
+        (0,callbacks[i])();
       for (var j = 0; j < group.ops.length; j++) {
         var op = group.ops[j];
         if (op.cursorActivityHandlers)


### PR DESCRIPTION
Small suggestion to avoid possible bugs related to unintended array value captured in 'this' argument.