### PR TITLE
Allow users to define their own lint event instead of just 'change' event.

### DIFF
--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -161,7 +161,7 @@
     if (options.onUpdateLinting) options.onUpdateLinting(annotationsNotSorted, annotations, cm);
   }
 
-  function onChange(cm) {
+  function onLintEvent(cm) {
     var state = cm.state.lint;
     if (!state) return;
     clearTimeout(state.timeout);
@@ -187,7 +187,7 @@
   CodeMirror.defineOption("lint", false, function(cm, val, old) {
     if (old && old != CodeMirror.Init) {
       clearMarks(cm);
-      cm.off("change", onChange);
+      cm.off(cm.state.lint.options.event, onLintEvent);
       CodeMirror.off(cm.getWrapperElement(), "mouseover", cm.state.lint.onMouseOver);
       clearTimeout(cm.state.lint.timeout);
       delete cm.state.lint;
@@ -197,7 +197,10 @@
       var gutters = cm.getOption("gutters"), hasLintGutter = false;
       for (var i = 0; i < gutters.length; ++i) if (gutters[i] == GUTTER_ID) hasLintGutter = true;
       var state = cm.state.lint = new LintState(cm, parseOptions(cm, val), hasLintGutter);
-      cm.on("change", onChange);
+      if (!state.options.event) {
+        state.options.event = "change";
+      }
+      cm.on(state.options.event, onLintEvent);
       if (state.options.tooltips != false)
         CodeMirror.on(cm.getWrapperElement(), "mouseover", state.onMouseOver);
 

--- a/demo/lint.html
+++ b/demo/lint.html
@@ -164,7 +164,9 @@ li.last {
     lineNumbers: true,
     mode: "css",
     gutters: ["CodeMirror-lint-markers"],
-    lint: true
+    lint: {
+      event: "change"
+    }
   });
 </script>
 


### PR DESCRIPTION
This patch changes the codemirror's lint addon to allow users to define an event on which lint should be done. Instead of the hard-coded change event, a user can define their own event and trigger that in order to get lint messages.