### PR TITLE
Remove duplicate color hex sign

### DIFF
--- a/theme/yeti.css
+++ b/theme/yeti.css
@@ -59,7 +59,7 @@
   color: #9fb96e;
 }
 .cm-s-yeti span.cm-atom {
-  color:##a074c4;
+  color: #a074c4;
 }
 .cm-s-yeti span.cm-meta {
   color: #96c0d8;


### PR DESCRIPTION
The CSS for the Yeti theme is invalid - there is a duplicate # sign for a hex color on line 62.