### PR TITLE
Standardize theme CSS

### DIFF
--- a/theme/3024-day.css
+++ b/theme/3024-day.css
@@ -8,34 +8,34 @@
 
 */
 
-.cm-s-3024-day.CodeMirror {background: #f7f7f7; color: #3a3432;}
-.cm-s-3024-day div.CodeMirror-selected {background: #d6d5d4;}
+.cm-s-3024-day.CodeMirror { background: #f7f7f7; color: #3a3432; }
+.cm-s-3024-day div.CodeMirror-selected { background: #d6d5d4; }
 
 .cm-s-3024-day .CodeMirror-line::selection, .cm-s-3024-day .CodeMirror-line > span::selection, .cm-s-3024-day .CodeMirror-line > span > span::selection { background: #d6d5d4; }
 .cm-s-3024-day .CodeMirror-line::-moz-selection, .cm-s-3024-day .CodeMirror-line > span::-moz-selection, .cm-s-3024-day .CodeMirror-line > span > span::selection { background: #d9d9d9; }
 
-.cm-s-3024-day .CodeMirror-gutters {background: #f7f7f7; border-right: 0px;}
+.cm-s-3024-day .CodeMirror-gutters { background: #f7f7f7; border-right: 0px; }
 .cm-s-3024-day .CodeMirror-guttermarker { color: #db2d20; }
 .cm-s-3024-day .CodeMirror-guttermarker-subtle { color: #807d7c; }
-.cm-s-3024-day .CodeMirror-linenumber {color: #807d7c;}
+.cm-s-3024-day .CodeMirror-linenumber { color: #807d7c; }
 
-.cm-s-3024-day .CodeMirror-cursor {border-left: 1px solid #5c5855 !important;}
+.cm-s-3024-day .CodeMirror-cursor { border-left: 1px solid #5c5855 !important; }
 
-.cm-s-3024-day span.cm-comment {color: #cdab53;}
-.cm-s-3024-day span.cm-atom {color: #a16a94;}
-.cm-s-3024-day span.cm-number {color: #a16a94;}
+.cm-s-3024-day span.cm-comment { color: #cdab53; }
+.cm-s-3024-day span.cm-atom { color: #a16a94; }
+.cm-s-3024-day span.cm-number { color: #a16a94; }
 
-.cm-s-3024-day span.cm-property, .cm-s-3024-day span.cm-attribute {color: #01a252;}
-.cm-s-3024-day span.cm-keyword {color: #db2d20;}
-.cm-s-3024-day span.cm-string {color: #fded02;}
+.cm-s-3024-day span.cm-property, .cm-s-3024-day span.cm-attribute { color: #01a252; }
+.cm-s-3024-day span.cm-keyword { color: #db2d20; }
+.cm-s-3024-day span.cm-string { color: #fded02; }
 
-.cm-s-3024-day span.cm-variable {color: #01a252;}
-.cm-s-3024-day span.cm-variable-2 {color: #01a0e4;}
-.cm-s-3024-day span.cm-def {color: #e8bbd0;}
-.cm-s-3024-day span.cm-bracket {color: #3a3432;}
-.cm-s-3024-day span.cm-tag {color: #db2d20;}
-.cm-s-3024-day span.cm-link {color: #a16a94;}
-.cm-s-3024-day span.cm-error {background: #db2d20; color: #5c5855;}
+.cm-s-3024-day span.cm-variable { color: #01a252; }
+.cm-s-3024-day span.cm-variable-2 { color: #01a0e4; }
+.cm-s-3024-day span.cm-def { color: #e8bbd0; }
+.cm-s-3024-day span.cm-bracket { color: #3a3432; }
+.cm-s-3024-day span.cm-tag { color: #db2d20; }
+.cm-s-3024-day span.cm-link { color: #a16a94; }
+.cm-s-3024-day span.cm-error { background: #db2d20; color: #5c5855; }
 
-.cm-s-3024-day .CodeMirror-activeline-background {background: #e8f2ff !important;}
-.cm-s-3024-day .CodeMirror-matchingbracket { text-decoration: underline; color: #a16a94 !important;}
+.cm-s-3024-day .CodeMirror-activeline-background { background: #e8f2ff !important; }
+.cm-s-3024-day .CodeMirror-matchingbracket { text-decoration: underline; color: #a16a94 !important; }

--- a/theme/3024-day.css
+++ b/theme/3024-day.css
@@ -9,7 +9,7 @@
 */
 
 .cm-s-3024-day.CodeMirror {background: #f7f7f7; color: #3a3432;}
-.cm-s-3024-day div.CodeMirror-selected {background: #d6d5d4 !important;}
+.cm-s-3024-day div.CodeMirror-selected {background: #d6d5d4;}
 
 .cm-s-3024-day .CodeMirror-line::selection, .cm-s-3024-day .CodeMirror-line > span::selection, .cm-s-3024-day .CodeMirror-line > span > span::selection { background: #d6d5d4; }
 .cm-s-3024-day .CodeMirror-line::-moz-selection, .cm-s-3024-day .CodeMirror-line > span::-moz-selection, .cm-s-3024-day .CodeMirror-line > span > span::selection { background: #d9d9d9; }

--- a/theme/3024-night.css
+++ b/theme/3024-night.css
@@ -8,32 +8,32 @@
 
 */
 
-.cm-s-3024-night.CodeMirror {background: #090300; color: #d6d5d4;}
-.cm-s-3024-night div.CodeMirror-selected {background: #3a3432;}
+.cm-s-3024-night.CodeMirror { background: #090300; color: #d6d5d4; }
+.cm-s-3024-night div.CodeMirror-selected { background: #3a3432; }
 .cm-s-3024-night .CodeMirror-line::selection, .cm-s-3024-night .CodeMirror-line > span::selection, .cm-s-3024-night .CodeMirror-line > span > span::selection { background: rgba(58, 52, 50, .99); }
 .cm-s-3024-night .CodeMirror-line::-moz-selection, .cm-s-3024-night .CodeMirror-line > span::-moz-selection, .cm-s-3024-night .CodeMirror-line > span > span::-moz-selection { background: rgba(58, 52, 50, .99); }
-.cm-s-3024-night .CodeMirror-gutters {background: #090300; border-right: 0px;}
+.cm-s-3024-night .CodeMirror-gutters { background: #090300; border-right: 0px; }
 .cm-s-3024-night .CodeMirror-guttermarker { color: #db2d20; }
 .cm-s-3024-night .CodeMirror-guttermarker-subtle { color: #5c5855; }
-.cm-s-3024-night .CodeMirror-linenumber {color: #5c5855;}
+.cm-s-3024-night .CodeMirror-linenumber { color: #5c5855; }
 
-.cm-s-3024-night .CodeMirror-cursor {border-left: 1px solid #807d7c !important;}
+.cm-s-3024-night .CodeMirror-cursor { border-left: 1px solid #807d7c !important; }
 
-.cm-s-3024-night span.cm-comment {color: #cdab53;}
-.cm-s-3024-night span.cm-atom {color: #a16a94;}
-.cm-s-3024-night span.cm-number {color: #a16a94;}
+.cm-s-3024-night span.cm-comment { color: #cdab53; }
+.cm-s-3024-night span.cm-atom { color: #a16a94; }
+.cm-s-3024-night span.cm-number { color: #a16a94; }
 
-.cm-s-3024-night span.cm-property, .cm-s-3024-night span.cm-attribute {color: #01a252;}
-.cm-s-3024-night span.cm-keyword {color: #db2d20;}
-.cm-s-3024-night span.cm-string {color: #fded02;}
+.cm-s-3024-night span.cm-property, .cm-s-3024-night span.cm-attribute { color: #01a252; }
+.cm-s-3024-night span.cm-keyword { color: #db2d20; }
+.cm-s-3024-night span.cm-string { color: #fded02; }
 
-.cm-s-3024-night span.cm-variable {color: #01a252;}
-.cm-s-3024-night span.cm-variable-2 {color: #01a0e4;}
-.cm-s-3024-night span.cm-def {color: #e8bbd0;}
-.cm-s-3024-night span.cm-bracket {color: #d6d5d4;}
-.cm-s-3024-night span.cm-tag {color: #db2d20;}
-.cm-s-3024-night span.cm-link {color: #a16a94;}
-.cm-s-3024-night span.cm-error {background: #db2d20; color: #807d7c;}
+.cm-s-3024-night span.cm-variable { color: #01a252; }
+.cm-s-3024-night span.cm-variable-2 { color: #01a0e4; }
+.cm-s-3024-night span.cm-def { color: #e8bbd0; }
+.cm-s-3024-night span.cm-bracket { color: #d6d5d4; }
+.cm-s-3024-night span.cm-tag { color: #db2d20; }
+.cm-s-3024-night span.cm-link { color: #a16a94; }
+.cm-s-3024-night span.cm-error { background: #db2d20; color: #807d7c; }
 
-.cm-s-3024-night .CodeMirror-activeline-background {background: #2F2F2F !important;}
-.cm-s-3024-night .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}
+.cm-s-3024-night .CodeMirror-activeline-background { background: #2F2F2F !important; }
+.cm-s-3024-night .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/3024-night.css
+++ b/theme/3024-night.css
@@ -9,7 +9,7 @@
 */
 
 .cm-s-3024-night.CodeMirror {background: #090300; color: #d6d5d4;}
-.cm-s-3024-night div.CodeMirror-selected {background: #3a3432 !important;}
+.cm-s-3024-night div.CodeMirror-selected {background: #3a3432;}
 .cm-s-3024-night .CodeMirror-line::selection, .cm-s-3024-night .CodeMirror-line > span::selection, .cm-s-3024-night .CodeMirror-line > span > span::selection { background: rgba(58, 52, 50, .99); }
 .cm-s-3024-night .CodeMirror-line::-moz-selection, .cm-s-3024-night .CodeMirror-line > span::-moz-selection, .cm-s-3024-night .CodeMirror-line > span > span::-moz-selection { background: rgba(58, 52, 50, .99); }
 .cm-s-3024-night .CodeMirror-gutters {background: #090300; border-right: 0px;}

--- a/theme/ambiance.css
+++ b/theme/ambiance.css
@@ -2,7 +2,7 @@
 
 /* Color scheme */
 
-.cm-s-ambiance .cm-header {color: blue;}
+.cm-s-ambiance .cm-header { color: blue; }
 .cm-s-ambiance .cm-quote { color: #24C2C7; }
 
 .cm-s-ambiance .cm-keyword { color: #cda869; }
@@ -13,7 +13,7 @@
 .cm-s-ambiance .cm-variable-2 { color: #eed1b3; }
 .cm-s-ambiance .cm-variable-3 { color: #faded3; }
 .cm-s-ambiance .cm-property { color: #eed1b3; }
-.cm-s-ambiance .cm-operator {color: #fa8d6a;}
+.cm-s-ambiance .cm-operator { color: #fa8d6a; }
 .cm-s-ambiance .cm-comment { color: #555; font-style:italic; }
 .cm-s-ambiance .cm-string { color: #8f9d6a; }
 .cm-s-ambiance .cm-string-2 { color: #9d937c; }
@@ -21,8 +21,8 @@
 .cm-s-ambiance .cm-qualifier { color: yellow; }
 .cm-s-ambiance .cm-builtin { color: #9999cc; }
 .cm-s-ambiance .cm-bracket { color: #24C2C7; }
-.cm-s-ambiance .cm-tag { color: #fee4ff }
-.cm-s-ambiance .cm-attribute {  color: #9B859D; }
+.cm-s-ambiance .cm-tag { color: #fee4ff; }
+.cm-s-ambiance .cm-attribute { color: #9B859D; }
 .cm-s-ambiance .cm-hr { color: pink; }
 .cm-s-ambiance .cm-link { color: #F4C20B; }
 .cm-s-ambiance .cm-special { color: #FF9D00; }

--- a/theme/ambiance.css
+++ b/theme/ambiance.css
@@ -31,8 +31,8 @@
 .cm-s-ambiance .CodeMirror-matchingbracket { color: #0f0; }
 .cm-s-ambiance .CodeMirror-nonmatchingbracket { color: #f22; }
 
-.cm-s-ambiance .CodeMirror-selected { background: rgba(255, 255, 255, 0.15); }
-.cm-s-ambiance.CodeMirror-focused .CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
+.cm-s-ambiance div.CodeMirror-selected { background: rgba(255, 255, 255, 0.15); }
+.cm-s-ambiance.CodeMirror-focused div.CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
 .cm-s-ambiance .CodeMirror-line::selection, .cm-s-ambiance .CodeMirror-line > span::selection, .cm-s-ambiance .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
 .cm-s-ambiance .CodeMirror-line::-moz-selection, .cm-s-ambiance .CodeMirror-line > span::-moz-selection, .cm-s-ambiance .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
 

--- a/theme/base16-dark.css
+++ b/theme/base16-dark.css
@@ -9,7 +9,7 @@
 */
 
 .cm-s-base16-dark.CodeMirror {background: #151515; color: #e0e0e0;}
-.cm-s-base16-dark div.CodeMirror-selected {background: #303030 !important;}
+.cm-s-base16-dark div.CodeMirror-selected {background: #303030;}
 .cm-s-base16-dark .CodeMirror-line::selection, .cm-s-base16-dark .CodeMirror-line > span::selection, .cm-s-base16-dark .CodeMirror-line > span > span::selection { background: rgba(48, 48, 48, .99); }
 .cm-s-base16-dark .CodeMirror-line::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(48, 48, 48, .99); }
 .cm-s-base16-dark .CodeMirror-gutters {background: #151515; border-right: 0px;}

--- a/theme/base16-dark.css
+++ b/theme/base16-dark.css
@@ -8,31 +8,31 @@
 
 */
 
-.cm-s-base16-dark.CodeMirror {background: #151515; color: #e0e0e0;}
-.cm-s-base16-dark div.CodeMirror-selected {background: #303030;}
+.cm-s-base16-dark.CodeMirror { background: #151515; color: #e0e0e0; }
+.cm-s-base16-dark div.CodeMirror-selected { background: #303030; }
 .cm-s-base16-dark .CodeMirror-line::selection, .cm-s-base16-dark .CodeMirror-line > span::selection, .cm-s-base16-dark .CodeMirror-line > span > span::selection { background: rgba(48, 48, 48, .99); }
 .cm-s-base16-dark .CodeMirror-line::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(48, 48, 48, .99); }
-.cm-s-base16-dark .CodeMirror-gutters {background: #151515; border-right: 0px;}
+.cm-s-base16-dark .CodeMirror-gutters { background: #151515; border-right: 0px; }
 .cm-s-base16-dark .CodeMirror-guttermarker { color: #ac4142; }
 .cm-s-base16-dark .CodeMirror-guttermarker-subtle { color: #505050; }
-.cm-s-base16-dark .CodeMirror-linenumber {color: #505050;}
-.cm-s-base16-dark .CodeMirror-cursor {border-left: 1px solid #b0b0b0 !important;}
+.cm-s-base16-dark .CodeMirror-linenumber { color: #505050; }
+.cm-s-base16-dark .CodeMirror-cursor { border-left: 1px solid #b0b0b0 !important; }
 
-.cm-s-base16-dark span.cm-comment {color: #8f5536;}
-.cm-s-base16-dark span.cm-atom {color: #aa759f;}
-.cm-s-base16-dark span.cm-number {color: #aa759f;}
+.cm-s-base16-dark span.cm-comment { color: #8f5536; }
+.cm-s-base16-dark span.cm-atom { color: #aa759f; }
+.cm-s-base16-dark span.cm-number { color: #aa759f; }
 
-.cm-s-base16-dark span.cm-property, .cm-s-base16-dark span.cm-attribute {color: #90a959;}
-.cm-s-base16-dark span.cm-keyword {color: #ac4142;}
-.cm-s-base16-dark span.cm-string {color: #f4bf75;}
+.cm-s-base16-dark span.cm-property, .cm-s-base16-dark span.cm-attribute { color: #90a959; }
+.cm-s-base16-dark span.cm-keyword { color: #ac4142; }
+.cm-s-base16-dark span.cm-string { color: #f4bf75; }
 
-.cm-s-base16-dark span.cm-variable {color: #90a959;}
-.cm-s-base16-dark span.cm-variable-2 {color: #6a9fb5;}
-.cm-s-base16-dark span.cm-def {color: #d28445;}
-.cm-s-base16-dark span.cm-bracket {color: #e0e0e0;}
-.cm-s-base16-dark span.cm-tag {color: #ac4142;}
-.cm-s-base16-dark span.cm-link {color: #aa759f;}
-.cm-s-base16-dark span.cm-error {background: #ac4142; color: #b0b0b0;}
+.cm-s-base16-dark span.cm-variable { color: #90a959; }
+.cm-s-base16-dark span.cm-variable-2 { color: #6a9fb5; }
+.cm-s-base16-dark span.cm-def { color: #d28445; }
+.cm-s-base16-dark span.cm-bracket { color: #e0e0e0; }
+.cm-s-base16-dark span.cm-tag { color: #ac4142; }
+.cm-s-base16-dark span.cm-link { color: #aa759f; }
+.cm-s-base16-dark span.cm-error { background: #ac4142; color: #b0b0b0; }
 
-.cm-s-base16-dark .CodeMirror-activeline-background {background: #202020 !important;}
-.cm-s-base16-dark .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}
+.cm-s-base16-dark .CodeMirror-activeline-background { background: #202020 !important; }
+.cm-s-base16-dark .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/base16-light.css
+++ b/theme/base16-light.css
@@ -8,31 +8,31 @@
 
 */
 
-.cm-s-base16-light.CodeMirror {background: #f5f5f5; color: #202020;}
-.cm-s-base16-light div.CodeMirror-selected {background: #e0e0e0;}
+.cm-s-base16-light.CodeMirror { background: #f5f5f5; color: #202020; }
+.cm-s-base16-light div.CodeMirror-selected { background: #e0e0e0; }
 .cm-s-base16-light .CodeMirror-line::selection, .cm-s-base16-light .CodeMirror-line > span::selection, .cm-s-base16-light .CodeMirror-line > span > span::selection { background: #e0e0e0; }
 .cm-s-base16-light .CodeMirror-line::-moz-selection, .cm-s-base16-light .CodeMirror-line > span::-moz-selection, .cm-s-base16-light .CodeMirror-line > span > span::-moz-selection { background: #e0e0e0; }
-.cm-s-base16-light .CodeMirror-gutters {background: #f5f5f5; border-right: 0px;}
+.cm-s-base16-light .CodeMirror-gutters { background: #f5f5f5; border-right: 0px; }
 .cm-s-base16-light .CodeMirror-guttermarker { color: #ac4142; }
 .cm-s-base16-light .CodeMirror-guttermarker-subtle { color: #b0b0b0; }
-.cm-s-base16-light .CodeMirror-linenumber {color: #b0b0b0;}
-.cm-s-base16-light .CodeMirror-cursor {border-left: 1px solid #505050 !important;}
+.cm-s-base16-light .CodeMirror-linenumber { color: #b0b0b0; }
+.cm-s-base16-light .CodeMirror-cursor { border-left: 1px solid #505050 !important; }
 
-.cm-s-base16-light span.cm-comment {color: #8f5536;}
-.cm-s-base16-light span.cm-atom {color: #aa759f;}
-.cm-s-base16-light span.cm-number {color: #aa759f;}
+.cm-s-base16-light span.cm-comment { color: #8f5536; }
+.cm-s-base16-light span.cm-atom { color: #aa759f; }
+.cm-s-base16-light span.cm-number { color: #aa759f; }
 
-.cm-s-base16-light span.cm-property, .cm-s-base16-light span.cm-attribute {color: #90a959;}
-.cm-s-base16-light span.cm-keyword {color: #ac4142;}
-.cm-s-base16-light span.cm-string {color: #f4bf75;}
+.cm-s-base16-light span.cm-property, .cm-s-base16-light span.cm-attribute { color: #90a959; }
+.cm-s-base16-light span.cm-keyword { color: #ac4142; }
+.cm-s-base16-light span.cm-string { color: #f4bf75; }
 
-.cm-s-base16-light span.cm-variable {color: #90a959;}
-.cm-s-base16-light span.cm-variable-2 {color: #6a9fb5;}
-.cm-s-base16-light span.cm-def {color: #d28445;}
-.cm-s-base16-light span.cm-bracket {color: #202020;}
-.cm-s-base16-light span.cm-tag {color: #ac4142;}
-.cm-s-base16-light span.cm-link {color: #aa759f;}
-.cm-s-base16-light span.cm-error {background: #ac4142; color: #505050;}
+.cm-s-base16-light span.cm-variable { color: #90a959; }
+.cm-s-base16-light span.cm-variable-2 { color: #6a9fb5; }
+.cm-s-base16-light span.cm-def { color: #d28445; }
+.cm-s-base16-light span.cm-bracket { color: #202020; }
+.cm-s-base16-light span.cm-tag { color: #ac4142; }
+.cm-s-base16-light span.cm-link { color: #aa759f; }
+.cm-s-base16-light span.cm-error { background: #ac4142; color: #505050; }
 
-.cm-s-base16-light .CodeMirror-activeline-background {background: #DDDCDC !important;}
-.cm-s-base16-light .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}
+.cm-s-base16-light .CodeMirror-activeline-background { background: #DDDCDC !important; }
+.cm-s-base16-light .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/base16-light.css
+++ b/theme/base16-light.css
@@ -9,7 +9,7 @@
 */
 
 .cm-s-base16-light.CodeMirror {background: #f5f5f5; color: #202020;}
-.cm-s-base16-light div.CodeMirror-selected {background: #e0e0e0 !important;}
+.cm-s-base16-light div.CodeMirror-selected {background: #e0e0e0;}
 .cm-s-base16-light .CodeMirror-line::selection, .cm-s-base16-light .CodeMirror-line > span::selection, .cm-s-base16-light .CodeMirror-line > span > span::selection { background: #e0e0e0; }
 .cm-s-base16-light .CodeMirror-line::-moz-selection, .cm-s-base16-light .CodeMirror-line > span::-moz-selection, .cm-s-base16-light .CodeMirror-line > span > span::-moz-selection { background: #e0e0e0; }
 .cm-s-base16-light .CodeMirror-gutters {background: #f5f5f5; border-right: 0px;}

--- a/theme/blackboard.css
+++ b/theme/blackboard.css
@@ -15,7 +15,7 @@
 .cm-s-blackboard .cm-number { color: #D8FA3C; }
 .cm-s-blackboard .cm-def { color: #8DA6CE; }
 .cm-s-blackboard .cm-variable { color: #FF6400; }
-.cm-s-blackboard .cm-operator { color: #FBDE2D;}
+.cm-s-blackboard .cm-operator { color: #FBDE2D; }
 .cm-s-blackboard .cm-comment { color: #AEAEAE; }
 .cm-s-blackboard .cm-string { color: #61CE3C; }
 .cm-s-blackboard .cm-string-2 { color: #61CE3C; }
@@ -28,5 +28,5 @@
 .cm-s-blackboard .cm-link { color: #8DA6CE; }
 .cm-s-blackboard .cm-error { background: #9D1E15; color: #F8F8F8; }
 
-.cm-s-blackboard .CodeMirror-activeline-background {background: #3C3636 !important;}
-.cm-s-blackboard .CodeMirror-matchingbracket {outline:1px solid grey;color:white !important}
+.cm-s-blackboard .CodeMirror-activeline-background { background: #3C3636 !important; }
+.cm-s-blackboard .CodeMirror-matchingbracket { outline:1px solid grey;color:white !important; }

--- a/theme/blackboard.css
+++ b/theme/blackboard.css
@@ -1,7 +1,7 @@
 /* Port of TextMate's Blackboard theme */
 
 .cm-s-blackboard.CodeMirror { background: #0C1021; color: #F8F8F8; }
-.cm-s-blackboard .CodeMirror-selected { background: #253B76 !important; }
+.cm-s-blackboard div.CodeMirror-selected { background: #253B76; }
 .cm-s-blackboard .CodeMirror-line::selection, .cm-s-blackboard .CodeMirror-line > span::selection, .cm-s-blackboard .CodeMirror-line > span > span::selection { background: rgba(37, 59, 118, .99); }
 .cm-s-blackboard .CodeMirror-line::-moz-selection, .cm-s-blackboard .CodeMirror-line > span::-moz-selection, .cm-s-blackboard .CodeMirror-line > span > span::-moz-selection { background: rgba(37, 59, 118, .99); }
 .cm-s-blackboard .CodeMirror-gutters { background: #0C1021; border-right: 0; }

--- a/theme/cobalt.css
+++ b/theme/cobalt.css
@@ -1,5 +1,5 @@
 .cm-s-cobalt.CodeMirror { background: #002240; color: white; }
-.cm-s-cobalt div.CodeMirror-selected { background: #b36539 !important; }
+.cm-s-cobalt div.CodeMirror-selected { background: #b36539; }
 .cm-s-cobalt .CodeMirror-line::selection, .cm-s-cobalt .CodeMirror-line > span::selection, .cm-s-cobalt .CodeMirror-line > span > span::selection { background: rgba(179, 101, 57, .99); }
 .cm-s-cobalt .CodeMirror-line::-moz-selection, .cm-s-cobalt .CodeMirror-line > span::-moz-selection, .cm-s-cobalt .CodeMirror-line > span > span::-moz-selection { background: rgba(179, 101, 57, .99); }
 .cm-s-cobalt .CodeMirror-gutters { background: #002240; border-right: 1px solid #aaa; }

--- a/theme/cobalt.css
+++ b/theme/cobalt.css
@@ -21,5 +21,5 @@
 .cm-s-cobalt span.cm-link { color: #845dc4; }
 .cm-s-cobalt span.cm-error { color: #9d1e15; }
 
-.cm-s-cobalt .CodeMirror-activeline-background {background: #002D57 !important;}
-.cm-s-cobalt .CodeMirror-matchingbracket {outline:1px solid grey;color:white !important}
+.cm-s-cobalt .CodeMirror-activeline-background { background: #002D57 !important; }
+.cm-s-cobalt .CodeMirror-matchingbracket { outline:1px solid grey;color:white !important; }

--- a/theme/colorforth.css
+++ b/theme/colorforth.css
@@ -30,4 +30,4 @@
 
 .cm-s-colorforth span.cm-compilation { background: rgba(255, 255, 255, 0.12); }
 
-.cm-s-colorforth .CodeMirror-activeline-background {background: #253540 !important;}
+.cm-s-colorforth .CodeMirror-activeline-background { background: #253540 !important; }

--- a/theme/colorforth.css
+++ b/theme/colorforth.css
@@ -26,7 +26,7 @@
 .cm-s-colorforth span.cm-attribute   { color: #FFF700; }
 .cm-s-colorforth span.cm-error       { color: #f00; }
 
-.cm-s-colorforth .CodeMirror-selected { background: #333d53 !important; }
+.cm-s-colorforth div.CodeMirror-selected { background: #333d53; }
 
 .cm-s-colorforth span.cm-compilation { background: rgba(255, 255, 255, 0.12); }
 

--- a/theme/dracula.css
+++ b/theme/dracula.css
@@ -16,7 +16,7 @@
 .cm-s-dracula .CodeMirror-gutters { color: #282a36; }
 .cm-s-dracula .CodeMirror-cursor { border-left: solid thin #f8f8f0 !important; }
 .cm-s-dracula .CodeMirror-linenumber { color: #6D8A88; }
-.cm-s-dracula.CodeMirror-focused .CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
+.cm-s-dracula.CodeMirror-focused div.CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
 .cm-s-dracula .CodeMirror-line::selection, .cm-s-dracula .CodeMirror-line > span::selection, .cm-s-dracula .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
 .cm-s-dracula .CodeMirror-line::-moz-selection, .cm-s-dracula .CodeMirror-line > span::-moz-selection, .cm-s-dracula .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
 .cm-s-dracula span.cm-comment { color: #6272a4; }

--- a/theme/dracula.css
+++ b/theme/dracula.css
@@ -37,5 +37,5 @@
 .cm-s-dracula span.cm-builtin { color: #50fa7b; }
 .cm-s-dracula span.cm-variable-3 { color: #50fa7b; }
 
-.cm-s-dracula .CodeMirror-activeline-background {background: rgba(255,255,255,0.1) !important;}
-.cm-s-dracula .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}
+.cm-s-dracula .CodeMirror-activeline-background { background: rgba(255,255,255,0.1) !important; }
+.cm-s-dracula .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/dracula.css
+++ b/theme/dracula.css
@@ -13,75 +13,29 @@
   color: #f8f8f2 !important;
   border: none;
 }
-.cm-s-dracula .CodeMirror-gutters{
-  color: #282a36;
-}
-.cm-s-dracula .CodeMirror-cursor {
-  border-left: solid thin #f8f8f0 !important;
-}
-.cm-s-dracula .CodeMirror-linenumber {
-  color: #6D8A88;
-}
-.cm-s-dracula.CodeMirror-focused .CodeMirror-selected {
-  background: rgba(255, 255, 255, 0.10);
-}
-.cm-s-dracula .CodeMirror-line::selection, .cm-s-dracula .CodeMirror-line > span::selection, .cm-s-dracula .CodeMirror-line > span > span::selection {
-  background: rgba(255, 255, 255, 0.10);
-}
-.cm-s-dracula .CodeMirror-line::-moz-selection, .cm-s-dracula .CodeMirror-line > span::-moz-selection, .cm-s-dracula .CodeMirror-line > span > span::-moz-selection {
-  background: rgba(255, 255, 255, 0.10);
-}
-.cm-s-dracula span.cm-comment {
-  color: #6272a4;
-}
-.cm-s-dracula span.cm-string, .cm-s-dracula span.cm-string-2 {
-  color: #f1fa8c;
-}
-.cm-s-dracula span.cm-number {
-  color: #bd93f9;
-}
-.cm-s-dracula span.cm-variable {
-  color: #50fa7b;
-}
-.cm-s-dracula span.cm-variable-2 {
-  color: white;
-}
-.cm-s-dracula span.cm-def {
-  color: #ffb86c;
-}
-.cm-s-dracula span.cm-keyword {
-  color: #ff79c6;
-}
-.cm-s-dracula span.cm-operator {
-  color: #ff79c6;
-}
-.cm-s-dracula span.cm-keyword {
-  color: #ff79c6;
-}
-.cm-s-dracula span.cm-atom {
-  color: #bd93f9;
-}
-.cm-s-dracula span.cm-meta {
-  color: #f8f8f2;
-}
-.cm-s-dracula span.cm-tag {
-  color: #ff79c6;
-}
-.cm-s-dracula span.cm-attribute {
-  color: #50fa7b;
-}
-.cm-s-dracula span.cm-qualifier {
-  color: #50fa7b;
-}
-.cm-s-dracula span.cm-property {
-  color: #66d9ef;
-}
-.cm-s-dracula span.cm-builtin {
-  color: #50fa7b;
-}
-.cm-s-dracula span.cm-variable-3 {
-  color: #50fa7b;
-}
+.cm-s-dracula .CodeMirror-gutters { color: #282a36; }
+.cm-s-dracula .CodeMirror-cursor { border-left: solid thin #f8f8f0 !important; }
+.cm-s-dracula .CodeMirror-linenumber { color: #6D8A88; }
+.cm-s-dracula.CodeMirror-focused .CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
+.cm-s-dracula .CodeMirror-line::selection, .cm-s-dracula .CodeMirror-line > span::selection, .cm-s-dracula .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
+.cm-s-dracula .CodeMirror-line::-moz-selection, .cm-s-dracula .CodeMirror-line > span::-moz-selection, .cm-s-dracula .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
+.cm-s-dracula span.cm-comment { color: #6272a4; }
+.cm-s-dracula span.cm-string, .cm-s-dracula span.cm-string-2 { color: #f1fa8c; }
+.cm-s-dracula span.cm-number { color: #bd93f9; }
+.cm-s-dracula span.cm-variable { color: #50fa7b; }
+.cm-s-dracula span.cm-variable-2 { color: white; }
+.cm-s-dracula span.cm-def { color: #ffb86c; }
+.cm-s-dracula span.cm-keyword { color: #ff79c6; }
+.cm-s-dracula span.cm-operator { color: #ff79c6; }
+.cm-s-dracula span.cm-keyword { color: #ff79c6; }
+.cm-s-dracula span.cm-atom { color: #bd93f9; }
+.cm-s-dracula span.cm-meta { color: #f8f8f2; }
+.cm-s-dracula span.cm-tag { color: #ff79c6; }
+.cm-s-dracula span.cm-attribute { color: #50fa7b; }
+.cm-s-dracula span.cm-qualifier { color: #50fa7b; }
+.cm-s-dracula span.cm-property { color: #66d9ef; }
+.cm-s-dracula span.cm-builtin { color: #50fa7b; }
+.cm-s-dracula span.cm-variable-3 { color: #50fa7b; }
 
 .cm-s-dracula .CodeMirror-activeline-background {background: rgba(255,255,255,0.1) !important;}
 .cm-s-dracula .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}

--- a/theme/eclipse.css
+++ b/theme/eclipse.css
@@ -1,23 +1,23 @@
-.cm-s-eclipse span.cm-meta {color: #FF1717;}
+.cm-s-eclipse span.cm-meta { color: #FF1717; }
 .cm-s-eclipse span.cm-keyword { line-height: 1em; font-weight: bold; color: #7F0055; }
-.cm-s-eclipse span.cm-atom {color: #219;}
-.cm-s-eclipse span.cm-number {color: #164;}
-.cm-s-eclipse span.cm-def {color: #00f;}
-.cm-s-eclipse span.cm-variable {color: black;}
-.cm-s-eclipse span.cm-variable-2 {color: #0000C0;}
-.cm-s-eclipse span.cm-variable-3 {color: #0000C0;}
-.cm-s-eclipse span.cm-property {color: black;}
-.cm-s-eclipse span.cm-operator {color: black;}
-.cm-s-eclipse span.cm-comment {color: #3F7F5F;}
-.cm-s-eclipse span.cm-string {color: #2A00FF;}
-.cm-s-eclipse span.cm-string-2 {color: #f50;}
-.cm-s-eclipse span.cm-qualifier {color: #555;}
-.cm-s-eclipse span.cm-builtin {color: #30a;}
-.cm-s-eclipse span.cm-bracket {color: #cc7;}
-.cm-s-eclipse span.cm-tag {color: #170;}
-.cm-s-eclipse span.cm-attribute {color: #00c;}
-.cm-s-eclipse span.cm-link {color: #219;}
-.cm-s-eclipse span.cm-error {color: #f00;}
+.cm-s-eclipse span.cm-atom { color: #219; }
+.cm-s-eclipse span.cm-number { color: #164; }
+.cm-s-eclipse span.cm-def { color: #00f; }
+.cm-s-eclipse span.cm-variable { color: black; }
+.cm-s-eclipse span.cm-variable-2 { color: #0000C0; }
+.cm-s-eclipse span.cm-variable-3 { color: #0000C0; }
+.cm-s-eclipse span.cm-property { color: black; }
+.cm-s-eclipse span.cm-operator { color: black; }
+.cm-s-eclipse span.cm-comment { color: #3F7F5F; }
+.cm-s-eclipse span.cm-string { color: #2A00FF; }
+.cm-s-eclipse span.cm-string-2 { color: #f50; }
+.cm-s-eclipse span.cm-qualifier { color: #555; }
+.cm-s-eclipse span.cm-builtin { color: #30a; }
+.cm-s-eclipse span.cm-bracket { color: #cc7; }
+.cm-s-eclipse span.cm-tag { color: #170; }
+.cm-s-eclipse span.cm-attribute { color: #00c; }
+.cm-s-eclipse span.cm-link { color: #219; }
+.cm-s-eclipse span.cm-error { color: #f00; }
 
-.cm-s-eclipse .CodeMirror-activeline-background {background: #e8f2ff !important;}
-.cm-s-eclipse .CodeMirror-matchingbracket {outline:1px solid grey; color:black !important;}
+.cm-s-eclipse .CodeMirror-activeline-background { background: #e8f2ff !important; }
+.cm-s-eclipse .CodeMirror-matchingbracket { outline:1px solid grey; color:black !important; }

--- a/theme/elegant.css
+++ b/theme/elegant.css
@@ -1,13 +1,13 @@
-.cm-s-elegant span.cm-number, .cm-s-elegant span.cm-string, .cm-s-elegant span.cm-atom {color: #762;}
-.cm-s-elegant span.cm-comment {color: #262; font-style: italic; line-height: 1em;}
-.cm-s-elegant span.cm-meta {color: #555; font-style: italic; line-height: 1em;}
-.cm-s-elegant span.cm-variable {color: black;}
-.cm-s-elegant span.cm-variable-2 {color: #b11;}
-.cm-s-elegant span.cm-qualifier {color: #555;}
-.cm-s-elegant span.cm-keyword {color: #730;}
-.cm-s-elegant span.cm-builtin {color: #30a;}
-.cm-s-elegant span.cm-link {color: #762;}
-.cm-s-elegant span.cm-error {background-color: #fdd;}
+.cm-s-elegant span.cm-number, .cm-s-elegant span.cm-string, .cm-s-elegant span.cm-atom { color: #762; }
+.cm-s-elegant span.cm-comment { color: #262; font-style: italic; line-height: 1em; }
+.cm-s-elegant span.cm-meta { color: #555; font-style: italic; line-height: 1em; }
+.cm-s-elegant span.cm-variable { color: black; }
+.cm-s-elegant span.cm-variable-2 { color: #b11; }
+.cm-s-elegant span.cm-qualifier { color: #555; }
+.cm-s-elegant span.cm-keyword { color: #730; }
+.cm-s-elegant span.cm-builtin { color: #30a; }
+.cm-s-elegant span.cm-link { color: #762; }
+.cm-s-elegant span.cm-error { background-color: #fdd; }
 
-.cm-s-elegant .CodeMirror-activeline-background {background: #e8f2ff !important;}
-.cm-s-elegant .CodeMirror-matchingbracket {outline:1px solid grey; color:black !important;}
+.cm-s-elegant .CodeMirror-activeline-background { background: #e8f2ff !important; }
+.cm-s-elegant .CodeMirror-matchingbracket { outline:1px solid grey; color:black !important; }

--- a/theme/erlang-dark.css
+++ b/theme/erlang-dark.css
@@ -30,5 +30,5 @@
 .cm-s-erlang-dark span.cm-variable-3 { color: #ccc; }
 .cm-s-erlang-dark span.cm-error      { color: #9d1e15; }
 
-.cm-s-erlang-dark .CodeMirror-activeline-background {background: #013461 !important;}
-.cm-s-erlang-dark .CodeMirror-matchingbracket {outline:1px solid grey; color:white !important;}
+.cm-s-erlang-dark .CodeMirror-activeline-background { background: #013461 !important; }
+.cm-s-erlang-dark .CodeMirror-matchingbracket { outline:1px solid grey; color:white !important; }

--- a/theme/erlang-dark.css
+++ b/theme/erlang-dark.css
@@ -1,5 +1,5 @@
 .cm-s-erlang-dark.CodeMirror { background: #002240; color: white; }
-.cm-s-erlang-dark div.CodeMirror-selected { background: #b36539 !important; }
+.cm-s-erlang-dark div.CodeMirror-selected { background: #b36539; }
 .cm-s-erlang-dark .CodeMirror-line::selection, .cm-s-erlang-dark .CodeMirror-line > span::selection, .cm-s-erlang-dark .CodeMirror-line > span > span::selection { background: rgba(179, 101, 57, .99); }
 .cm-s-erlang-dark .CodeMirror-line::-moz-selection, .cm-s-erlang-dark .CodeMirror-line > span::-moz-selection, .cm-s-erlang-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(179, 101, 57, .99); }
 .cm-s-erlang-dark .CodeMirror-gutters { background: #002240; border-right: 1px solid #aaa; }

--- a/theme/icecoder.css
+++ b/theme/icecoder.css
@@ -2,41 +2,41 @@
 ICEcoder default theme by Matt Pass, used in code editor available at https://icecoder.net
 */
 
-.cm-s-icecoder {color: #666; background: #141612}
+.cm-s-icecoder { color: #666; background: #141612; }
 
-.cm-s-icecoder span.cm-keyword {color: #eee; font-weight:bold}  /* off-white 1 */
-.cm-s-icecoder span.cm-atom {color: #e1c76e}                    /* yellow */
-.cm-s-icecoder span.cm-number {color: #6cb5d9}                  /* blue */
-.cm-s-icecoder span.cm-def {color: #b9ca4a}                     /* green */
+.cm-s-icecoder span.cm-keyword { color: #eee; font-weight:bold; }  /* off-white 1 */
+.cm-s-icecoder span.cm-atom { color: #e1c76e; }                    /* yellow */
+.cm-s-icecoder span.cm-number { color: #6cb5d9; }                  /* blue */
+.cm-s-icecoder span.cm-def { color: #b9ca4a; }                     /* green */
 
-.cm-s-icecoder span.cm-variable {color: #6cb5d9}                /* blue */
-.cm-s-icecoder span.cm-variable-2 {color: #cc1e5c}              /* pink */
-.cm-s-icecoder span.cm-variable-3 {color: #f9602c}              /* orange */
+.cm-s-icecoder span.cm-variable { color: #6cb5d9; }                /* blue */
+.cm-s-icecoder span.cm-variable-2 { color: #cc1e5c; }              /* pink */
+.cm-s-icecoder span.cm-variable-3 { color: #f9602c; }              /* orange */
 
-.cm-s-icecoder span.cm-property {color: #eee}                   /* off-white 1 */
-.cm-s-icecoder span.cm-operator {color: #9179bb}                /* purple */
-.cm-s-icecoder span.cm-comment {color: #97a3aa}                 /* grey-blue */
+.cm-s-icecoder span.cm-property { color: #eee; }                   /* off-white 1 */
+.cm-s-icecoder span.cm-operator { color: #9179bb; }                /* purple */
+.cm-s-icecoder span.cm-comment { color: #97a3aa; }                 /* grey-blue */
 
-.cm-s-icecoder span.cm-string {color: #b9ca4a}                  /* green */
-.cm-s-icecoder span.cm-string-2 {color: #6cb5d9}                /* blue */
+.cm-s-icecoder span.cm-string { color: #b9ca4a; }                  /* green */
+.cm-s-icecoder span.cm-string-2 { color: #6cb5d9; }                /* blue */
 
-.cm-s-icecoder span.cm-meta {color: #555}                       /* grey */
+.cm-s-icecoder span.cm-meta { color: #555; }                       /* grey */
 
-.cm-s-icecoder span.cm-qualifier {color: #555}                  /* grey */
-.cm-s-icecoder span.cm-builtin {color: #214e7b}                 /* bright blue */
-.cm-s-icecoder span.cm-bracket {color: #cc7}                    /* grey-yellow */
+.cm-s-icecoder span.cm-qualifier { color: #555; }                  /* grey */
+.cm-s-icecoder span.cm-builtin { color: #214e7b; }                 /* bright blue */
+.cm-s-icecoder span.cm-bracket { color: #cc7; }                    /* grey-yellow */
 
-.cm-s-icecoder span.cm-tag {color: #e8e8e8}                     /* off-white 2 */
-.cm-s-icecoder span.cm-attribute {color: #099}                  /* teal */
+.cm-s-icecoder span.cm-tag { color: #e8e8e8; }                     /* off-white 2 */
+.cm-s-icecoder span.cm-attribute { color: #099; }                  /* teal */
 
-.cm-s-icecoder span.cm-header {color: #6a0d6a}                  /* purple-pink */
-.cm-s-icecoder span.cm-quote {color: #186718}                   /* dark green */
-.cm-s-icecoder span.cm-hr {color: #888}                         /* mid-grey */
-.cm-s-icecoder span.cm-link {color: #e1c76e}                    /* yellow */
-.cm-s-icecoder span.cm-error {color: #d00}                      /* red */
+.cm-s-icecoder span.cm-header { color: #6a0d6a; }                  /* purple-pink */
+.cm-s-icecoder span.cm-quote { color: #186718; }                   /* dark green */
+.cm-s-icecoder span.cm-hr { color: #888; }                         /* mid-grey */
+.cm-s-icecoder span.cm-link { color: #e1c76e; }                    /* yellow */
+.cm-s-icecoder span.cm-error { color: #d00; }                      /* red */
 
-.cm-s-icecoder .CodeMirror-cursor {border-left: 1px solid white !important}
-.cm-s-icecoder div.CodeMirror-selected {color: #fff !important; background: #037}
-.cm-s-icecoder .CodeMirror-gutters {background: #141612; min-width: 41px; border-right: 0}
-.cm-s-icecoder .CodeMirror-linenumber {color: #555; cursor: default}
-.cm-s-icecoder .CodeMirror-matchingbracket {border: 1px solid grey; color: black !important}
+.cm-s-icecoder .CodeMirror-cursor { border-left: 1px solid white !important; }
+.cm-s-icecoder div.CodeMirror-selected { color: #fff !important; background: #037; }
+.cm-s-icecoder .CodeMirror-gutters { background: #141612; min-width: 41px; border-right: 0; }
+.cm-s-icecoder .CodeMirror-linenumber { color: #555; cursor: default; }
+.cm-s-icecoder .CodeMirror-matchingbracket { border: 1px solid grey; color: black !important; }

--- a/theme/icecoder.css
+++ b/theme/icecoder.css
@@ -36,7 +36,7 @@ ICEcoder default theme by Matt Pass, used in code editor available at https://ic
 .cm-s-icecoder span.cm-error {color: #d00}                      /* red */
 
 .cm-s-icecoder .CodeMirror-cursor {border-left: 1px solid white !important}
-.cm-s-icecoder .CodeMirror-selected {color: #fff !important; background: #037 !important}
+.cm-s-icecoder div.CodeMirror-selected {color: #fff !important; background: #037}
 .cm-s-icecoder .CodeMirror-gutters {background: #141612; min-width: 41px; border-right: 0}
 .cm-s-icecoder .CodeMirror-linenumber {color: #555; cursor: default}
 .cm-s-icecoder .CodeMirror-matchingbracket {border: 1px solid grey; color: black !important}

--- a/theme/lesser-dark.css
+++ b/theme/lesser-dark.css
@@ -6,7 +6,7 @@ Ported to CodeMirror by Peter Kroon
   line-height: 1.3em;
 }
 .cm-s-lesser-dark.CodeMirror { background: #262626; color: #EBEFE7; text-shadow: 0 -1px 1px #262626; }
-.cm-s-lesser-dark div.CodeMirror-selected {background: #45443B !important;} /* 33322B*/
+.cm-s-lesser-dark div.CodeMirror-selected {background: #45443B;} /* 33322B*/
 .cm-s-lesser-dark .CodeMirror-line::selection, .cm-s-lesser-dark .CodeMirror-line > span::selection, .cm-s-lesser-dark .CodeMirror-line > span > span::selection { background: rgba(69, 68, 59, .99); }
 .cm-s-lesser-dark .CodeMirror-line::-moz-selection, .cm-s-lesser-dark .CodeMirror-line > span::-moz-selection, .cm-s-lesser-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(69, 68, 59, .99); }
 .cm-s-lesser-dark .CodeMirror-cursor { border-left: 1px solid white !important; }

--- a/theme/lesser-dark.css
+++ b/theme/lesser-dark.css
@@ -6,7 +6,7 @@ Ported to CodeMirror by Peter Kroon
   line-height: 1.3em;
 }
 .cm-s-lesser-dark.CodeMirror { background: #262626; color: #EBEFE7; text-shadow: 0 -1px 1px #262626; }
-.cm-s-lesser-dark div.CodeMirror-selected {background: #45443B;} /* 33322B*/
+.cm-s-lesser-dark div.CodeMirror-selected { background: #45443B; } /* 33322B*/
 .cm-s-lesser-dark .CodeMirror-line::selection, .cm-s-lesser-dark .CodeMirror-line > span::selection, .cm-s-lesser-dark .CodeMirror-line > span > span::selection { background: rgba(69, 68, 59, .99); }
 .cm-s-lesser-dark .CodeMirror-line::-moz-selection, .cm-s-lesser-dark .CodeMirror-line > span::-moz-selection, .cm-s-lesser-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(69, 68, 59, .99); }
 .cm-s-lesser-dark .CodeMirror-cursor { border-left: 1px solid white !important; }
@@ -19,29 +19,29 @@ Ported to CodeMirror by Peter Kroon
 .cm-s-lesser-dark .CodeMirror-guttermarker-subtle { color: #777; }
 .cm-s-lesser-dark .CodeMirror-linenumber { color: #777; }
 
-.cm-s-lesser-dark span.cm-header {color: #a0a;}
-.cm-s-lesser-dark span.cm-quote {color: #090;}
+.cm-s-lesser-dark span.cm-header { color: #a0a; }
+.cm-s-lesser-dark span.cm-quote { color: #090; }
 .cm-s-lesser-dark span.cm-keyword { color: #599eff; }
 .cm-s-lesser-dark span.cm-atom { color: #C2B470; }
 .cm-s-lesser-dark span.cm-number { color: #B35E4D; }
-.cm-s-lesser-dark span.cm-def {color: white;}
+.cm-s-lesser-dark span.cm-def { color: white; }
 .cm-s-lesser-dark span.cm-variable { color:#D9BF8C; }
 .cm-s-lesser-dark span.cm-variable-2 { color: #669199; }
 .cm-s-lesser-dark span.cm-variable-3 { color: white; }
-.cm-s-lesser-dark span.cm-property {color: #92A75C;}
-.cm-s-lesser-dark span.cm-operator {color: #92A75C;}
+.cm-s-lesser-dark span.cm-property { color: #92A75C; }
+.cm-s-lesser-dark span.cm-operator { color: #92A75C; }
 .cm-s-lesser-dark span.cm-comment { color: #666; }
 .cm-s-lesser-dark span.cm-string { color: #BCD279; }
-.cm-s-lesser-dark span.cm-string-2 {color: #f50;}
+.cm-s-lesser-dark span.cm-string-2 { color: #f50; }
 .cm-s-lesser-dark span.cm-meta { color: #738C73; }
-.cm-s-lesser-dark span.cm-qualifier {color: #555;}
+.cm-s-lesser-dark span.cm-qualifier { color: #555; }
 .cm-s-lesser-dark span.cm-builtin { color: #ff9e59; }
 .cm-s-lesser-dark span.cm-bracket { color: #EBEFE7; }
 .cm-s-lesser-dark span.cm-tag { color: #669199; }
-.cm-s-lesser-dark span.cm-attribute {color: #00c;}
-.cm-s-lesser-dark span.cm-hr {color: #999;}
-.cm-s-lesser-dark span.cm-link {color: #00c;}
+.cm-s-lesser-dark span.cm-attribute { color: #00c; }
+.cm-s-lesser-dark span.cm-hr { color: #999; }
+.cm-s-lesser-dark span.cm-link { color: #00c; }
 .cm-s-lesser-dark span.cm-error { color: #9d1e15; }
 
-.cm-s-lesser-dark .CodeMirror-activeline-background {background: #3C3A3A !important;}
-.cm-s-lesser-dark .CodeMirror-matchingbracket {outline:1px solid grey; color:white !important;}
+.cm-s-lesser-dark .CodeMirror-activeline-background { background: #3C3A3A !important; }
+.cm-s-lesser-dark .CodeMirror-matchingbracket { outline:1px solid grey; color:white !important; }

--- a/theme/liquibyte.css
+++ b/theme/liquibyte.css
@@ -20,7 +20,7 @@
 	text-decoration-style: dotted;
 }
 .cm-s-liquibyte .CodeMirror-gutters { background-color: #262626; border-right: 1px solid #505050; padding-right: 0.8em; }
-.cm-s-liquibyte .CodeMirror-gutter-elt div{ font-size: 1.2em; }
+.cm-s-liquibyte .CodeMirror-gutter-elt div { font-size: 1.2em; }
 .cm-s-liquibyte .CodeMirror-guttermarker {  }
 .cm-s-liquibyte .CodeMirror-guttermarker-subtle {  }
 .cm-s-liquibyte .CodeMirror-linenumber { color: #606060; padding-left: 0;}

--- a/theme/liquibyte.css
+++ b/theme/liquibyte.css
@@ -47,7 +47,7 @@
 .cm-s-liquibyte span.cm-attribute   { color: #c080ff; font-weight: bold; }
 .cm-s-liquibyte span.cm-error       { color: #f00; }
 
-.cm-s-liquibyte .CodeMirror-selected { background-color: rgba(255, 0, 0, 0.25) !important; }
+.cm-s-liquibyte div.CodeMirror-selected { background-color: rgba(255, 0, 0, 0.25); }
 
 .cm-s-liquibyte span.cm-compilation { background-color: rgba(255, 255, 255, 0.12); }
 

--- a/theme/liquibyte.css
+++ b/theme/liquibyte.css
@@ -23,7 +23,7 @@
 .cm-s-liquibyte .CodeMirror-gutter-elt div { font-size: 1.2em; }
 .cm-s-liquibyte .CodeMirror-guttermarker {  }
 .cm-s-liquibyte .CodeMirror-guttermarker-subtle {  }
-.cm-s-liquibyte .CodeMirror-linenumber { color: #606060; padding-left: 0;}
+.cm-s-liquibyte .CodeMirror-linenumber { color: #606060; padding-left: 0; }
 .cm-s-liquibyte .CodeMirror-cursor { border-left: 1px solid #eee !important; }
 
 .cm-s-liquibyte span.cm-comment     { color: #008000; }
@@ -51,7 +51,7 @@
 
 .cm-s-liquibyte span.cm-compilation { background-color: rgba(255, 255, 255, 0.12); }
 
-.cm-s-liquibyte .CodeMirror-activeline-background {background-color: rgba(0, 255, 0, 0.15) !important;}
+.cm-s-liquibyte .CodeMirror-activeline-background { background-color: rgba(0, 255, 0, 0.15) !important; }
 
 /* Default styles for common addons */
 div.CodeMirror span.CodeMirror-matchingbracket { color: #0f0; font-weight: bold; }

--- a/theme/material.css
+++ b/theme/material.css
@@ -16,89 +16,37 @@
   color: rgb(83,127,126);
   border: none;
 }
-.cm-s-material .CodeMirror-guttermarker, .cm-s-material .CodeMirror-guttermarker-subtle, .cm-s-material .CodeMirror-linenumber {
-  color: rgb(83,127,126);
-}
-.cm-s-material .CodeMirror-cursor {
-  border-left: 1px solid #f8f8f0 !important;
-}
-.cm-s-material .CodeMirror-selected {
-  background: rgba(255, 255, 255, 0.15);
-}
-.cm-s-material.CodeMirror-focused .CodeMirror-selected {
-  background: rgba(255, 255, 255, 0.10);
-}
-.cm-s-material .CodeMirror-line::selection, .cm-s-material .CodeMirror-line > span::selection, .cm-s-material .CodeMirror-line > span > span::selection {
-  background: rgba(255, 255, 255, 0.10);
-}
-.cm-s-material .CodeMirror-line::-moz-selection, .cm-s-material .CodeMirror-line > span::-moz-selection, .cm-s-material .CodeMirror-line > span > span::-moz-selection {
-  background: rgba(255, 255, 255, 0.10);
-}
+.cm-s-material .CodeMirror-guttermarker, .cm-s-material .CodeMirror-guttermarker-subtle, .cm-s-material .CodeMirror-linenumber { color: rgb(83,127,126); }
+.cm-s-material .CodeMirror-cursor { border-left: 1px solid #f8f8f0 !important; }
+.cm-s-material .CodeMirror-selected { background: rgba(255, 255, 255, 0.15); }
+.cm-s-material.CodeMirror-focused .CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
+.cm-s-material .CodeMirror-line::selection, .cm-s-material .CodeMirror-line > span::selection, .cm-s-material .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
+.cm-s-material .CodeMirror-line::-moz-selection, .cm-s-material .CodeMirror-line > span::-moz-selection, .cm-s-material .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
 
-.CodeMirror-activeline-background {
-  background: rgba(0, 0, 0, 0) !important;
-}
-.cm-s-material span.cm-keyword {
-  color: rgba(199, 146, 234, 1);
-}
-.cm-s-material span.cm-operator {
-  color: rgba(233, 237, 237, 1);
-}
-.cm-s-material span.cm-variable-2 {
-  color: #80CBC4;
-}
-.cm-s-material span.cm-variable-3 {
-  color: #82B1FF;
-}
-.cm-s-material span.cm-builtin {
-  color: #DECB6B;
-}
-.cm-s-material span.cm-atom {
-  color: #F77669;
-}
-.cm-s-material span.cm-number {
-  color: #F77669;
-}
-.cm-s-material span.cm-def {
-  color: rgba(233, 237, 237, 1);
-}
+.CodeMirror-activeline-background { background: rgba(0, 0, 0, 0) !important; }
+.cm-s-material span.cm-keyword { color: rgba(199, 146, 234, 1); }
+.cm-s-material span.cm-operator { color: rgba(233, 237, 237, 1); }
+.cm-s-material span.cm-variable-2 { color: #80CBC4; }
+.cm-s-material span.cm-variable-3 { color: #82B1FF; }
+.cm-s-material span.cm-builtin { color: #DECB6B; }
+.cm-s-material span.cm-atom { color: #F77669; }
+.cm-s-material span.cm-number { color: #F77669; }
+.cm-s-material span.cm-def { color: rgba(233, 237, 237, 1); }
 .cm-s-material span.cm-error {
   color: rgba(255, 255, 255, 1.0);
   background-color: #EC5F67;
 }
-.cm-s-material span.cm-string {
-  color: #C3E88D;
-}
-.cm-s-material span.cm-string-2 {
-  color: #80CBC4;
-}
-.cm-s-material span.cm-comment {
-  color: #546E7A;
-}
-.cm-s-material span.cm-variable {
-  color: #82B1FF;
-}
-.cm-s-material span.cm-tag {
-  color: #80CBC4;
-}
-.cm-s-material span.cm-meta{
-  color: #80CBC4;
-}
-.cm-s-material span.cm-attribute {
-  color: #FFCB6B;
-}
-.cm-s-material span.cm-property {
-  color: #80CBAE;
-}
-.cm-s-material span.cm-qualifier {
-  color: #DECB6B;
-}
-.cm-s-material span.cm-variable-3{
-  color: #DECB6B;
-}
-.cm-s-material span.cm-tag {
-  color: rgba(255, 83, 112, 1);
-}
+.cm-s-material span.cm-string { color: #C3E88D; }
+.cm-s-material span.cm-string-2 { color: #80CBC4; }
+.cm-s-material span.cm-comment { color: #546E7A; }
+.cm-s-material span.cm-variable { color: #82B1FF; }
+.cm-s-material span.cm-tag { color: #80CBC4; }
+.cm-s-material span.cm-meta{ color: #80CBC4; }
+.cm-s-material span.cm-attribute { color: #FFCB6B; }
+.cm-s-material span.cm-property { color: #80CBAE; }
+.cm-s-material span.cm-qualifier { color: #DECB6B; }
+.cm-s-material span.cm-variable-3{ color: #DECB6B; }
+.cm-s-material span.cm-tag { color: rgba(255, 83, 112, 1); }
 .cm-s-material .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/theme/material.css
+++ b/theme/material.css
@@ -41,11 +41,11 @@
 .cm-s-material span.cm-comment { color: #546E7A; }
 .cm-s-material span.cm-variable { color: #82B1FF; }
 .cm-s-material span.cm-tag { color: #80CBC4; }
-.cm-s-material span.cm-meta{ color: #80CBC4; }
+.cm-s-material span.cm-meta { color: #80CBC4; }
 .cm-s-material span.cm-attribute { color: #FFCB6B; }
 .cm-s-material span.cm-property { color: #80CBAE; }
 .cm-s-material span.cm-qualifier { color: #DECB6B; }
-.cm-s-material span.cm-variable-3{ color: #DECB6B; }
+.cm-s-material span.cm-variable-3 { color: #DECB6B; }
 .cm-s-material span.cm-tag { color: rgba(255, 83, 112, 1); }
 .cm-s-material .CodeMirror-matchingbracket {
   text-decoration: underline;

--- a/theme/material.css
+++ b/theme/material.css
@@ -18,8 +18,8 @@
 }
 .cm-s-material .CodeMirror-guttermarker, .cm-s-material .CodeMirror-guttermarker-subtle, .cm-s-material .CodeMirror-linenumber { color: rgb(83,127,126); }
 .cm-s-material .CodeMirror-cursor { border-left: 1px solid #f8f8f0 !important; }
-.cm-s-material .CodeMirror-selected { background: rgba(255, 255, 255, 0.15); }
-.cm-s-material.CodeMirror-focused .CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
+.cm-s-material div.CodeMirror-selected { background: rgba(255, 255, 255, 0.15); }
+.cm-s-material.CodeMirror-focused div.CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
 .cm-s-material .CodeMirror-line::selection, .cm-s-material .CodeMirror-line > span::selection, .cm-s-material .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
 .cm-s-material .CodeMirror-line::-moz-selection, .cm-s-material .CodeMirror-line > span::-moz-selection, .cm-s-material .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
 

--- a/theme/mbo.css
+++ b/theme/mbo.css
@@ -5,7 +5,7 @@
 /****************************************************************/
 
 .cm-s-mbo.CodeMirror {background: #2c2c2c; color: #ffffec;}
-.cm-s-mbo div.CodeMirror-selected {background: #716C62 !important;}
+.cm-s-mbo div.CodeMirror-selected {background: #716C62;}
 .cm-s-mbo .CodeMirror-line::selection, .cm-s-mbo .CodeMirror-line > span::selection, .cm-s-mbo .CodeMirror-line > span > span::selection { background: rgba(113, 108, 98, .99); }
 .cm-s-mbo .CodeMirror-line::-moz-selection, .cm-s-mbo .CodeMirror-line > span::-moz-selection, .cm-s-mbo .CodeMirror-line > span > span::-moz-selection { background: rgba(113, 108, 98, .99); }
 .cm-s-mbo .CodeMirror-gutters {background: #4e4e4e; border-right: 0px;}

--- a/theme/mbo.css
+++ b/theme/mbo.css
@@ -4,34 +4,34 @@
 /*   Create your own: http://tmtheme-editor.herokuapp.com       */
 /****************************************************************/
 
-.cm-s-mbo.CodeMirror {background: #2c2c2c; color: #ffffec;}
-.cm-s-mbo div.CodeMirror-selected {background: #716C62;}
+.cm-s-mbo.CodeMirror { background: #2c2c2c; color: #ffffec; }
+.cm-s-mbo div.CodeMirror-selected { background: #716C62; }
 .cm-s-mbo .CodeMirror-line::selection, .cm-s-mbo .CodeMirror-line > span::selection, .cm-s-mbo .CodeMirror-line > span > span::selection { background: rgba(113, 108, 98, .99); }
 .cm-s-mbo .CodeMirror-line::-moz-selection, .cm-s-mbo .CodeMirror-line > span::-moz-selection, .cm-s-mbo .CodeMirror-line > span > span::-moz-selection { background: rgba(113, 108, 98, .99); }
-.cm-s-mbo .CodeMirror-gutters {background: #4e4e4e; border-right: 0px;}
+.cm-s-mbo .CodeMirror-gutters { background: #4e4e4e; border-right: 0px; }
 .cm-s-mbo .CodeMirror-guttermarker { color: white; }
 .cm-s-mbo .CodeMirror-guttermarker-subtle { color: grey; }
-.cm-s-mbo .CodeMirror-linenumber {color: #dadada;}
-.cm-s-mbo .CodeMirror-cursor {border-left: 1px solid #ffffec !important;}
+.cm-s-mbo .CodeMirror-linenumber { color: #dadada; }
+.cm-s-mbo .CodeMirror-cursor { border-left: 1px solid #ffffec !important; }
 
-.cm-s-mbo span.cm-comment {color: #95958a;}
-.cm-s-mbo span.cm-atom {color: #00a8c6;}
-.cm-s-mbo span.cm-number {color: #00a8c6;}
+.cm-s-mbo span.cm-comment { color: #95958a; }
+.cm-s-mbo span.cm-atom { color: #00a8c6; }
+.cm-s-mbo span.cm-number { color: #00a8c6; }
 
-.cm-s-mbo span.cm-property, .cm-s-mbo span.cm-attribute {color: #9ddfe9;}
-.cm-s-mbo span.cm-keyword {color: #ffb928;}
-.cm-s-mbo span.cm-string {color: #ffcf6c;}
-.cm-s-mbo span.cm-string.cm-property {color: #ffffec;}
+.cm-s-mbo span.cm-property, .cm-s-mbo span.cm-attribute { color: #9ddfe9; }
+.cm-s-mbo span.cm-keyword { color: #ffb928; }
+.cm-s-mbo span.cm-string { color: #ffcf6c; }
+.cm-s-mbo span.cm-string.cm-property { color: #ffffec; }
 
-.cm-s-mbo span.cm-variable {color: #ffffec;}
-.cm-s-mbo span.cm-variable-2 {color: #00a8c6;}
-.cm-s-mbo span.cm-def {color: #ffffec;}
-.cm-s-mbo span.cm-bracket {color: #fffffc; font-weight: bold;}
-.cm-s-mbo span.cm-tag {color: #9ddfe9;}
-.cm-s-mbo span.cm-link {color: #f54b07;}
-.cm-s-mbo span.cm-error {border-bottom: #636363; color: #ffffec;}
-.cm-s-mbo span.cm-qualifier {color: #ffffec;}
+.cm-s-mbo span.cm-variable { color: #ffffec; }
+.cm-s-mbo span.cm-variable-2 { color: #00a8c6; }
+.cm-s-mbo span.cm-def { color: #ffffec; }
+.cm-s-mbo span.cm-bracket { color: #fffffc; font-weight: bold; }
+.cm-s-mbo span.cm-tag { color: #9ddfe9; }
+.cm-s-mbo span.cm-link { color: #f54b07; }
+.cm-s-mbo span.cm-error { border-bottom: #636363; color: #ffffec; }
+.cm-s-mbo span.cm-qualifier { color: #ffffec; }
 
-.cm-s-mbo .CodeMirror-activeline-background {background: #494b41 !important;}
-.cm-s-mbo .CodeMirror-matchingbracket {color: #222 !important;}
-.cm-s-mbo .CodeMirror-matchingtag {background: rgba(255, 255, 255, .37);}
+.cm-s-mbo .CodeMirror-activeline-background { background: #494b41 !important; }
+.cm-s-mbo .CodeMirror-matchingbracket { color: #222 !important; }
+.cm-s-mbo .CodeMirror-matchingtag { background: rgba(255, 255, 255, .37); }

--- a/theme/mdn-like.css
+++ b/theme/mdn-like.css
@@ -8,7 +8,7 @@
 
 */
 .cm-s-mdn-like.CodeMirror { color: #999; background-color: #fff; }
-.cm-s-mdn-like .CodeMirror-selected { background: #cfc !important; }
+.cm-s-mdn-like div.CodeMirror-selected { background: #cfc; }
 .cm-s-mdn-like .CodeMirror-line::selection, .cm-s-mdn-like .CodeMirror-line > span::selection, .cm-s-mdn-like .CodeMirror-line > span > span::selection { background: #cfc; }
 .cm-s-mdn-like .CodeMirror-line::-moz-selection, .cm-s-mdn-like .CodeMirror-line > span::-moz-selection, .cm-s-mdn-like .CodeMirror-line > span > span::-moz-selection { background: #cfc; }
 

--- a/theme/mdn-like.css
+++ b/theme/mdn-like.css
@@ -16,7 +16,7 @@
 .cm-s-mdn-like .CodeMirror-linenumber { color: #aaa; padding-left: 8px; }
 div.cm-s-mdn-like .CodeMirror-cursor { border-left: 2px solid #222; }
 
-.cm-s-mdn-like .cm-keyword {  color: #6262FF; }
+.cm-s-mdn-like .cm-keyword { color: #6262FF; }
 .cm-s-mdn-like .cm-atom { color: #F90; }
 .cm-s-mdn-like .cm-number { color:  #ca7841; }
 .cm-s-mdn-like .cm-def { color: #8DA6CE; }
@@ -37,10 +37,10 @@ div.cm-s-mdn-like .CodeMirror-cursor { border-left: 2px solid #222; }
 .cm-s-mdn-like .cm-attribute { color: #d6bb6d; } /*?*/
 .cm-s-mdn-like .cm-header { color: #FF6400; }
 .cm-s-mdn-like .cm-hr { color: #AEAEAE; }
-.cm-s-mdn-like .cm-link {   color:#ad9361; font-style:italic; text-decoration:none; }
+.cm-s-mdn-like .cm-link { color:#ad9361; font-style:italic; text-decoration:none; }
 .cm-s-mdn-like .cm-error { border-bottom: 1px solid red; }
 
-div.cm-s-mdn-like .CodeMirror-activeline-background {background: #efefff;}
-div.cm-s-mdn-like span.CodeMirror-matchingbracket {outline:1px solid grey; color: inherit;}
+div.cm-s-mdn-like .CodeMirror-activeline-background { background: #efefff; }
+div.cm-s-mdn-like span.CodeMirror-matchingbracket { outline:1px solid grey; color: inherit; }
 
 .cm-s-mdn-like.CodeMirror { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFcAAAAyCAYAAAAp8UeFAAAHvklEQVR42s2b63bcNgyEQZCSHCdt2vd/0tWF7I+Q6XgMXiTtuvU5Pl57ZQKkKHzEAOtF5KeIJBGJ8uvL599FRFREZhFx8DeXv8trn68RuGaC8TRfo3SNp9dlDDHedyLyTUTeRWStXKPZrjtpZxaRw5hPqozRs1N8/enzIiQRWcCgy4MUA0f+XWliDhyL8Lfyvx7ei/Ae3iQFHyw7U/59pQVIMEEPEz0G7XiwdRjzSfC3UTtz9vchIntxvry5iMgfIhJoEflOz2CQr3F5h/HfeFe+GTdLaKcu9L8LTeQb/R/7GgbsfKedyNdoHsN31uRPWrfZ5wsj/NzzRQHuToIdU3ahwnsKPxXCjJITuOsi7XLc7SG/v5GdALs7wf8JjTFiB5+QvTEfRyGOfX3Lrx8wxyQi3sNq46O7QahQiCsRFgqddjBouVEHOKDgXAQHD9gJCr5sMKkEdjwsarG/ww3BMHBU7OBjXnzdyY7SfCxf5/z6ATccrwlKuwC/jhznnPF4CgVzhhVf4xp2EixcBActO75iZ8/fM9zAs2OMzKdslgXWJ9XG8PQoOAMA5fGcsvORgv0doBXyHrCwfLJAOwo71QLNkb8n2Pl6EWiR7OCibtkPaz4Kc/0NNAze2gju3zOwekALDaCFPI5vjPFmgGY5AZqyGEvH1x7QfIb8YtxMnA/b+QQ0aQDAwc6JMFg8CbQZ4qoYEEHbRwNojuK3EHwd7VALSgq+MNDKzfT58T8qdpADrgW0GmgcAS1lhzztJmkAzcPNOQbsWEALBDSlMKUG0Eq4CLAQWvEVQ9WU57gZJwZtgPO3r9oBTQ9WO8TjqXINx8R0EYpiZEUWOF3FxkbJkgU9B2f41YBrIj5ZfsQa0M5kTgiAAqM3ShXLgu8XMqcrQBvJ0CL5pnTsfMB13oB8athpAq2XOQmcGmoACCLydx7nToa23ATaSIY2ichfOdPTGxlasXMLaL0MLZAOwAKIM+y8CmicobGdCcbbK9DzN+yYGVoNNI5iUKTMyYOjPse4A8SM1MmcXgU0toOq1yO/v8FOxlASyc7TgeYaAMBJHcY1CcCwGI/TK4AmDbDyKYBBtFUkRwto8gygiQEaByFgJ00BH2M8JWwQS1nafDXQCidWyOI8AcjDCSjCLk8ngObuAm3JAHAdubAmOaK06V8MNEsKPJOhobSprwQa6gD7DclRQdqcwL4zxqgBrQcabUiBLclRDKAlWp+etPkBaNMA0AKlrHwTdEByZAA4GM+SNluSY6wAzcMNewxmgig5Ks0nkrSpBvSaQHMdKTBAnLojOdYyGpQ254602ZILPdTD1hdlggdIm74jbTp8vDwF5ZYUeLWGJpWsh6XNyXgcYwVoJQTEhhTYkxzZjiU5npU2TaB979TQehlaAVq4kaGpiPwwwLkYUuBbQwocyQTv1tA0+1UFWoJF3iv1oq+qoSk8EQdJmwHkziIF7oOZk14EGitibAdjLYYK78H5vZOhtWpoI0ATGHs0Q8OMb4Ey+2bU2UYztCtA0wFAs7TplGLRVQCcqaFdGSPCeTI1QNIC52iWNzof6Uib7xjEp07mNNoUYmVosVItHrHzRlLgBn9LFyRHaQCtVUMbtTNhoXWiTOO9k/V8BdAc1Oq0ArSQs6/5SU0hckNy9NnXqQY0PGYo5dWJ7nINaN6o958FWin27aBaWRka1r5myvLOAm0j30eBJqCxHLReVclxhxOEN2JfDWjxBtAC7MIH1fVaGdoOp4qJYDgKtKPSFNID2gSnGldrCqkFZ+5UeQXQBIRrSwocbdZYQT/2LwRahBPBXoHrB8nxaGROST62DKUbQOMMzZIC9abkuELfQzQALWTnDNAm8KHWFOJgJ5+SHIvTPcmx1xQyZRhNL5Qci689aXMEaN/uNIWkEwDAvFpOZmgsBaaGnbs1NPa1Jm32gBZAIh1pCtG7TSH4aE0y1uVY4uqoFPisGlpP2rSA5qTecWn5agK6BzSpgAyD+wFaqhnYoSZ1Vwr8CmlTQbrcO3ZaX0NAEyMbYaAlyquFoLKK3SPby9CeVUPThrSJmkCAE0CrKUQadi4DrdSlWhmah0YL9z9vClH59YGbHx1J8VZTyAjQepJjmXwAKTDQI3omc3p1U4gDUf6RfcdYfrUp5ClAi2J3Ba6UOXGo+K+bQrjjssitG2SJzshaLwMtXgRagUNpYYoVkMSBLM+9GGiJZMvduG6DRZ4qc04DMPtQQxOjEtACmhO7K1AbNbQDEggZyJwscFpAGwENhoBeUwh3bWolhe8BTYVKxQEWrSUn/uhcM5KhvUu/+eQu0Lzhi+VrK0PrZZNDQKs9cpYUuFYgMVpD4/NxenJTiMCNqdUEUf1qZWjppLT5qSkkUZbCwkbZMSuVnu80hfSkzRbQeqCZSAh6huR4VtoM2gHAlLf72smuWgE+VV7XpE25Ab2WFDgyhnSuKbs4GuGzCjR+tIoUuMFg3kgcWKLTwRqanJQ2W00hAsenfaApRC42hbCvK1SlE0HtE9BGgneJO+ELamitD1YjjOYnNYVcraGhtKkW0EqVVeDx733I2NH581k1NNxNLG0i0IJ8/NjVaOZ0tYZ2Vtr0Xv7tPV3hkWp9EFkgS/J0vosngTaSoaG06WHi+xObQkaAdlbanP8B2+2l0f90LmUAAAAASUVORK5CYII=); }

--- a/theme/midnight.css
+++ b/theme/midnight.css
@@ -5,41 +5,41 @@
 .cm-s-midnight.CodeMirror-focused span.CodeMirror-matchhighlight { background: #314D67 !important; }
 
 /*<!--activeline-->*/
-.cm-s-midnight .CodeMirror-activeline-background {background: #253540 !important;}
+.cm-s-midnight .CodeMirror-activeline-background { background: #253540 !important; }
 
 .cm-s-midnight.CodeMirror {
     background: #0F192A;
     color: #D1EDFF;
 }
 
-.cm-s-midnight.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
+.cm-s-midnight.CodeMirror { border-top: 1px solid black; border-bottom: 1px solid black; }
 
-.cm-s-midnight div.CodeMirror-selected {background: #314D67;}
+.cm-s-midnight div.CodeMirror-selected { background: #314D67; }
 .cm-s-midnight .CodeMirror-line::selection, .cm-s-midnight .CodeMirror-line > span::selection, .cm-s-midnight .CodeMirror-line > span > span::selection { background: rgba(49, 77, 103, .99); }
 .cm-s-midnight .CodeMirror-line::-moz-selection, .cm-s-midnight .CodeMirror-line > span::-moz-selection, .cm-s-midnight .CodeMirror-line > span > span::-moz-selection { background: rgba(49, 77, 103, .99); }
-.cm-s-midnight .CodeMirror-gutters {background: #0F192A; border-right: 1px solid;}
+.cm-s-midnight .CodeMirror-gutters { background: #0F192A; border-right: 1px solid; }
 .cm-s-midnight .CodeMirror-guttermarker { color: white; }
 .cm-s-midnight .CodeMirror-guttermarker-subtle { color: #d0d0d0; }
-.cm-s-midnight .CodeMirror-linenumber {color: #D0D0D0;}
+.cm-s-midnight .CodeMirror-linenumber { color: #D0D0D0; }
 .cm-s-midnight .CodeMirror-cursor {
     border-left: 1px solid #F8F8F0 !important;
 }
 
-.cm-s-midnight span.cm-comment {color: #428BDD;}
-.cm-s-midnight span.cm-atom {color: #AE81FF;}
-.cm-s-midnight span.cm-number {color: #D1EDFF;}
+.cm-s-midnight span.cm-comment { color: #428BDD; }
+.cm-s-midnight span.cm-atom { color: #AE81FF; }
+.cm-s-midnight span.cm-number { color: #D1EDFF; }
 
-.cm-s-midnight span.cm-property, .cm-s-midnight span.cm-attribute {color: #A6E22E;}
-.cm-s-midnight span.cm-keyword {color: #E83737;}
-.cm-s-midnight span.cm-string {color: #1DC116;}
+.cm-s-midnight span.cm-property, .cm-s-midnight span.cm-attribute { color: #A6E22E; }
+.cm-s-midnight span.cm-keyword { color: #E83737; }
+.cm-s-midnight span.cm-string { color: #1DC116; }
 
-.cm-s-midnight span.cm-variable {color: #FFAA3E;}
-.cm-s-midnight span.cm-variable-2 {color: #FFAA3E;}
-.cm-s-midnight span.cm-def {color: #4DD;}
-.cm-s-midnight span.cm-bracket {color: #D1EDFF;}
-.cm-s-midnight span.cm-tag {color: #449;}
-.cm-s-midnight span.cm-link {color: #AE81FF;}
-.cm-s-midnight span.cm-error {background: #F92672; color: #F8F8F0;}
+.cm-s-midnight span.cm-variable { color: #FFAA3E; }
+.cm-s-midnight span.cm-variable-2 { color: #FFAA3E; }
+.cm-s-midnight span.cm-def { color: #4DD; }
+.cm-s-midnight span.cm-bracket { color: #D1EDFF; }
+.cm-s-midnight span.cm-tag { color: #449; }
+.cm-s-midnight span.cm-link { color: #AE81FF; }
+.cm-s-midnight span.cm-error { background: #F92672; color: #F8F8F0; }
 
 .cm-s-midnight .CodeMirror-matchingbracket {
   text-decoration: underline;

--- a/theme/midnight.css
+++ b/theme/midnight.css
@@ -14,7 +14,7 @@
 
 .cm-s-midnight.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
 
-.cm-s-midnight div.CodeMirror-selected {background: #314D67 !important;}
+.cm-s-midnight div.CodeMirror-selected {background: #314D67;}
 .cm-s-midnight .CodeMirror-line::selection, .cm-s-midnight .CodeMirror-line > span::selection, .cm-s-midnight .CodeMirror-line > span > span::selection { background: rgba(49, 77, 103, .99); }
 .cm-s-midnight .CodeMirror-line::-moz-selection, .cm-s-midnight .CodeMirror-line > span::-moz-selection, .cm-s-midnight .CodeMirror-line > span > span::-moz-selection { background: rgba(49, 77, 103, .99); }
 .cm-s-midnight .CodeMirror-gutters {background: #0F192A; border-right: 1px solid;}

--- a/theme/monokai.css
+++ b/theme/monokai.css
@@ -1,34 +1,34 @@
 /* Based on Sublime Text's Monokai theme */
 
-.cm-s-monokai.CodeMirror {background: #272822; color: #f8f8f2;}
-.cm-s-monokai div.CodeMirror-selected {background: #49483E;}
+.cm-s-monokai.CodeMirror { background: #272822; color: #f8f8f2; }
+.cm-s-monokai div.CodeMirror-selected { background: #49483E; }
 .cm-s-monokai .CodeMirror-line::selection, .cm-s-monokai .CodeMirror-line > span::selection, .cm-s-monokai .CodeMirror-line > span > span::selection { background: rgba(73, 72, 62, .99); }
 .cm-s-monokai .CodeMirror-line::-moz-selection, .cm-s-monokai .CodeMirror-line > span::-moz-selection, .cm-s-monokai .CodeMirror-line > span > span::-moz-selection { background: rgba(73, 72, 62, .99); }
-.cm-s-monokai .CodeMirror-gutters {background: #272822; border-right: 0px;}
+.cm-s-monokai .CodeMirror-gutters { background: #272822; border-right: 0px; }
 .cm-s-monokai .CodeMirror-guttermarker { color: white; }
 .cm-s-monokai .CodeMirror-guttermarker-subtle { color: #d0d0d0; }
-.cm-s-monokai .CodeMirror-linenumber {color: #d0d0d0;}
-.cm-s-monokai .CodeMirror-cursor {border-left: 1px solid #f8f8f0 !important;}
+.cm-s-monokai .CodeMirror-linenumber { color: #d0d0d0; }
+.cm-s-monokai .CodeMirror-cursor { border-left: 1px solid #f8f8f0 !important; }
 
-.cm-s-monokai span.cm-comment {color: #75715e;}
-.cm-s-monokai span.cm-atom {color: #ae81ff;}
-.cm-s-monokai span.cm-number {color: #ae81ff;}
+.cm-s-monokai span.cm-comment { color: #75715e; }
+.cm-s-monokai span.cm-atom { color: #ae81ff; }
+.cm-s-monokai span.cm-number { color: #ae81ff; }
 
-.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute {color: #a6e22e;}
-.cm-s-monokai span.cm-keyword {color: #f92672;}
-.cm-s-monokai span.cm-string {color: #e6db74;}
+.cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute { color: #a6e22e; }
+.cm-s-monokai span.cm-keyword { color: #f92672; }
+.cm-s-monokai span.cm-string { color: #e6db74; }
 
-.cm-s-monokai span.cm-variable {color: #f8f8f2;}
-.cm-s-monokai span.cm-variable-2 {color: #9effff;}
-.cm-s-monokai span.cm-variable-3 {color: #66d9ef;}
-.cm-s-monokai span.cm-def {color: #fd971f;}
-.cm-s-monokai span.cm-bracket {color: #f8f8f2;}
-.cm-s-monokai span.cm-tag {color: #f92672;}
-.cm-s-monokai span.cm-header {color: #ae81ff;}
-.cm-s-monokai span.cm-link {color: #ae81ff;}
-.cm-s-monokai span.cm-error {background: #f92672; color: #f8f8f0;}
+.cm-s-monokai span.cm-variable { color: #f8f8f2; }
+.cm-s-monokai span.cm-variable-2 { color: #9effff; }
+.cm-s-monokai span.cm-variable-3 { color: #66d9ef; }
+.cm-s-monokai span.cm-def { color: #fd971f; }
+.cm-s-monokai span.cm-bracket { color: #f8f8f2; }
+.cm-s-monokai span.cm-tag { color: #f92672; }
+.cm-s-monokai span.cm-header { color: #ae81ff; }
+.cm-s-monokai span.cm-link { color: #ae81ff; }
+.cm-s-monokai span.cm-error { background: #f92672; color: #f8f8f0; }
 
-.cm-s-monokai .CodeMirror-activeline-background {background: #373831 !important;}
+.cm-s-monokai .CodeMirror-activeline-background { background: #373831 !important; }
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/theme/monokai.css
+++ b/theme/monokai.css
@@ -1,7 +1,7 @@
 /* Based on Sublime Text's Monokai theme */
 
 .cm-s-monokai.CodeMirror {background: #272822; color: #f8f8f2;}
-.cm-s-monokai div.CodeMirror-selected {background: #49483E !important;}
+.cm-s-monokai div.CodeMirror-selected {background: #49483E;}
 .cm-s-monokai .CodeMirror-line::selection, .cm-s-monokai .CodeMirror-line > span::selection, .cm-s-monokai .CodeMirror-line > span > span::selection { background: rgba(73, 72, 62, .99); }
 .cm-s-monokai .CodeMirror-line::-moz-selection, .cm-s-monokai .CodeMirror-line > span::-moz-selection, .cm-s-monokai .CodeMirror-line > span > span::-moz-selection { background: rgba(73, 72, 62, .99); }
 .cm-s-monokai .CodeMirror-gutters {background: #272822; border-right: 0px;}

--- a/theme/neat.css
+++ b/theme/neat.css
@@ -5,8 +5,8 @@
 .cm-s-neat span.cm-special { line-height: 1em; font-weight: bold; color: #0aa; }
 .cm-s-neat span.cm-variable { color: black; }
 .cm-s-neat span.cm-number, .cm-s-neat span.cm-atom { color: #3a3; }
-.cm-s-neat span.cm-meta {color: #555;}
+.cm-s-neat span.cm-meta { color: #555; }
 .cm-s-neat span.cm-link { color: #3a3; }
 
-.cm-s-neat .CodeMirror-activeline-background {background: #e8f2ff !important;}
-.cm-s-neat .CodeMirror-matchingbracket {outline:1px solid grey; color:black !important;}
+.cm-s-neat .CodeMirror-activeline-background { background: #e8f2ff !important; }
+.cm-s-neat .CodeMirror-matchingbracket { outline:1px solid grey; color:black !important; }

--- a/theme/neo.css
+++ b/theme/neo.css
@@ -7,12 +7,12 @@
   color:#2e383c;
   line-height:1.4375;
 }
-.cm-s-neo .cm-comment {color:#75787b}
-.cm-s-neo .cm-keyword, .cm-s-neo .cm-property {color:#1d75b3}
-.cm-s-neo .cm-atom,.cm-s-neo .cm-number {color:#75438a}
-.cm-s-neo .cm-node,.cm-s-neo .cm-tag {color:#9c3328}
-.cm-s-neo .cm-string {color:#b35e14}
-.cm-s-neo .cm-variable,.cm-s-neo .cm-qualifier {color:#047d65}
+.cm-s-neo .cm-comment { color:#75787b; }
+.cm-s-neo .cm-keyword, .cm-s-neo .cm-property { color:#1d75b3; }
+.cm-s-neo .cm-atom,.cm-s-neo .cm-number { color:#75438a; }
+.cm-s-neo .cm-node,.cm-s-neo .cm-tag { color:#9c3328; }
+.cm-s-neo .cm-string { color:#b35e14; }
+.cm-s-neo .cm-variable,.cm-s-neo .cm-qualifier { color:#047d65; }
 
 
 /* Editor styling */

--- a/theme/night.css
+++ b/theme/night.css
@@ -24,5 +24,5 @@
 .cm-s-night span.cm-link { color: #845dc4; }
 .cm-s-night span.cm-error { color: #9d1e15; }
 
-.cm-s-night .CodeMirror-activeline-background {background: #1C005A !important;}
-.cm-s-night .CodeMirror-matchingbracket {outline:1px solid grey; color:white !important;}
+.cm-s-night .CodeMirror-activeline-background { background: #1C005A !important; }
+.cm-s-night .CodeMirror-matchingbracket { outline:1px solid grey; color:white !important; }

--- a/theme/night.css
+++ b/theme/night.css
@@ -1,7 +1,7 @@
 /* Loosely based on the Midnight Textmate theme */
 
 .cm-s-night.CodeMirror { background: #0a001f; color: #f8f8f8; }
-.cm-s-night div.CodeMirror-selected { background: #447 !important; }
+.cm-s-night div.CodeMirror-selected { background: #447; }
 .cm-s-night .CodeMirror-line::selection, .cm-s-night .CodeMirror-line > span::selection, .cm-s-night .CodeMirror-line > span > span::selection { background: rgba(68, 68, 119, .99); }
 .cm-s-night .CodeMirror-line::-moz-selection, .cm-s-night .CodeMirror-line > span::-moz-selection, .cm-s-night .CodeMirror-line > span > span::-moz-selection { background: rgba(68, 68, 119, .99); }
 .cm-s-night .CodeMirror-gutters { background: #0a001f; border-right: 1px solid #aaa; }

--- a/theme/paraiso-dark.css
+++ b/theme/paraiso-dark.css
@@ -8,31 +8,31 @@
 
 */
 
-.cm-s-paraiso-dark.CodeMirror {background: #2f1e2e; color: #b9b6b0;}
-.cm-s-paraiso-dark div.CodeMirror-selected {background: #41323f;}
+.cm-s-paraiso-dark.CodeMirror { background: #2f1e2e; color: #b9b6b0; }
+.cm-s-paraiso-dark div.CodeMirror-selected { background: #41323f; }
 .cm-s-paraiso-dark .CodeMirror-line::selection, .cm-s-paraiso-dark .CodeMirror-line > span::selection, .cm-s-paraiso-dark .CodeMirror-line > span > span::selection { background: rgba(65, 50, 63, .99); }
 .cm-s-paraiso-dark .CodeMirror-line::-moz-selection, .cm-s-paraiso-dark .CodeMirror-line > span::-moz-selection, .cm-s-paraiso-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(65, 50, 63, .99); }
-.cm-s-paraiso-dark .CodeMirror-gutters {background: #2f1e2e; border-right: 0px;}
+.cm-s-paraiso-dark .CodeMirror-gutters { background: #2f1e2e; border-right: 0px; }
 .cm-s-paraiso-dark .CodeMirror-guttermarker { color: #ef6155; }
 .cm-s-paraiso-dark .CodeMirror-guttermarker-subtle { color: #776e71; }
-.cm-s-paraiso-dark .CodeMirror-linenumber {color: #776e71;}
-.cm-s-paraiso-dark .CodeMirror-cursor {border-left: 1px solid #8d8687 !important;}
+.cm-s-paraiso-dark .CodeMirror-linenumber { color: #776e71; }
+.cm-s-paraiso-dark .CodeMirror-cursor { border-left: 1px solid #8d8687 !important; }
 
-.cm-s-paraiso-dark span.cm-comment {color: #e96ba8;}
-.cm-s-paraiso-dark span.cm-atom {color: #815ba4;}
-.cm-s-paraiso-dark span.cm-number {color: #815ba4;}
+.cm-s-paraiso-dark span.cm-comment { color: #e96ba8; }
+.cm-s-paraiso-dark span.cm-atom { color: #815ba4; }
+.cm-s-paraiso-dark span.cm-number { color: #815ba4; }
 
-.cm-s-paraiso-dark span.cm-property, .cm-s-paraiso-dark span.cm-attribute {color: #48b685;}
-.cm-s-paraiso-dark span.cm-keyword {color: #ef6155;}
-.cm-s-paraiso-dark span.cm-string {color: #fec418;}
+.cm-s-paraiso-dark span.cm-property, .cm-s-paraiso-dark span.cm-attribute { color: #48b685; }
+.cm-s-paraiso-dark span.cm-keyword { color: #ef6155; }
+.cm-s-paraiso-dark span.cm-string { color: #fec418; }
 
-.cm-s-paraiso-dark span.cm-variable {color: #48b685;}
-.cm-s-paraiso-dark span.cm-variable-2 {color: #06b6ef;}
-.cm-s-paraiso-dark span.cm-def {color: #f99b15;}
-.cm-s-paraiso-dark span.cm-bracket {color: #b9b6b0;}
-.cm-s-paraiso-dark span.cm-tag {color: #ef6155;}
-.cm-s-paraiso-dark span.cm-link {color: #815ba4;}
-.cm-s-paraiso-dark span.cm-error {background: #ef6155; color: #8d8687;}
+.cm-s-paraiso-dark span.cm-variable { color: #48b685; }
+.cm-s-paraiso-dark span.cm-variable-2 { color: #06b6ef; }
+.cm-s-paraiso-dark span.cm-def { color: #f99b15; }
+.cm-s-paraiso-dark span.cm-bracket { color: #b9b6b0; }
+.cm-s-paraiso-dark span.cm-tag { color: #ef6155; }
+.cm-s-paraiso-dark span.cm-link { color: #815ba4; }
+.cm-s-paraiso-dark span.cm-error { background: #ef6155; color: #8d8687; }
 
-.cm-s-paraiso-dark .CodeMirror-activeline-background {background: #4D344A !important;}
-.cm-s-paraiso-dark .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}
+.cm-s-paraiso-dark .CodeMirror-activeline-background { background: #4D344A !important; }
+.cm-s-paraiso-dark .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/paraiso-dark.css
+++ b/theme/paraiso-dark.css
@@ -9,7 +9,7 @@
 */
 
 .cm-s-paraiso-dark.CodeMirror {background: #2f1e2e; color: #b9b6b0;}
-.cm-s-paraiso-dark div.CodeMirror-selected {background: #41323f !important;}
+.cm-s-paraiso-dark div.CodeMirror-selected {background: #41323f;}
 .cm-s-paraiso-dark .CodeMirror-line::selection, .cm-s-paraiso-dark .CodeMirror-line > span::selection, .cm-s-paraiso-dark .CodeMirror-line > span > span::selection { background: rgba(65, 50, 63, .99); }
 .cm-s-paraiso-dark .CodeMirror-line::-moz-selection, .cm-s-paraiso-dark .CodeMirror-line > span::-moz-selection, .cm-s-paraiso-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(65, 50, 63, .99); }
 .cm-s-paraiso-dark .CodeMirror-gutters {background: #2f1e2e; border-right: 0px;}

--- a/theme/paraiso-light.css
+++ b/theme/paraiso-light.css
@@ -8,31 +8,31 @@
 
 */
 
-.cm-s-paraiso-light.CodeMirror {background: #e7e9db; color: #41323f;}
-.cm-s-paraiso-light div.CodeMirror-selected {background: #b9b6b0;}
+.cm-s-paraiso-light.CodeMirror { background: #e7e9db; color: #41323f; }
+.cm-s-paraiso-light div.CodeMirror-selected { background: #b9b6b0; }
 .cm-s-paraiso-light .CodeMirror-line::selection, .cm-s-paraiso-light .CodeMirror-line > span::selection, .cm-s-paraiso-light .CodeMirror-line > span > span::selection { background: #b9b6b0; }
 .cm-s-paraiso-light .CodeMirror-line::-moz-selection, .cm-s-paraiso-light .CodeMirror-line > span::-moz-selection, .cm-s-paraiso-light .CodeMirror-line > span > span::-moz-selection { background: #b9b6b0; }
-.cm-s-paraiso-light .CodeMirror-gutters {background: #e7e9db; border-right: 0px;}
+.cm-s-paraiso-light .CodeMirror-gutters { background: #e7e9db; border-right: 0px; }
 .cm-s-paraiso-light .CodeMirror-guttermarker { color: black; }
 .cm-s-paraiso-light .CodeMirror-guttermarker-subtle { color: #8d8687; }
-.cm-s-paraiso-light .CodeMirror-linenumber {color: #8d8687;}
-.cm-s-paraiso-light .CodeMirror-cursor {border-left: 1px solid #776e71 !important;}
+.cm-s-paraiso-light .CodeMirror-linenumber { color: #8d8687; }
+.cm-s-paraiso-light .CodeMirror-cursor { border-left: 1px solid #776e71 !important; }
 
-.cm-s-paraiso-light span.cm-comment {color: #e96ba8;}
-.cm-s-paraiso-light span.cm-atom {color: #815ba4;}
-.cm-s-paraiso-light span.cm-number {color: #815ba4;}
+.cm-s-paraiso-light span.cm-comment { color: #e96ba8; }
+.cm-s-paraiso-light span.cm-atom { color: #815ba4; }
+.cm-s-paraiso-light span.cm-number { color: #815ba4; }
 
-.cm-s-paraiso-light span.cm-property, .cm-s-paraiso-light span.cm-attribute {color: #48b685;}
-.cm-s-paraiso-light span.cm-keyword {color: #ef6155;}
-.cm-s-paraiso-light span.cm-string {color: #fec418;}
+.cm-s-paraiso-light span.cm-property, .cm-s-paraiso-light span.cm-attribute { color: #48b685; }
+.cm-s-paraiso-light span.cm-keyword { color: #ef6155; }
+.cm-s-paraiso-light span.cm-string { color: #fec418; }
 
-.cm-s-paraiso-light span.cm-variable {color: #48b685;}
-.cm-s-paraiso-light span.cm-variable-2 {color: #06b6ef;}
-.cm-s-paraiso-light span.cm-def {color: #f99b15;}
-.cm-s-paraiso-light span.cm-bracket {color: #41323f;}
-.cm-s-paraiso-light span.cm-tag {color: #ef6155;}
-.cm-s-paraiso-light span.cm-link {color: #815ba4;}
-.cm-s-paraiso-light span.cm-error {background: #ef6155; color: #776e71;}
+.cm-s-paraiso-light span.cm-variable { color: #48b685; }
+.cm-s-paraiso-light span.cm-variable-2 { color: #06b6ef; }
+.cm-s-paraiso-light span.cm-def { color: #f99b15; }
+.cm-s-paraiso-light span.cm-bracket { color: #41323f; }
+.cm-s-paraiso-light span.cm-tag { color: #ef6155; }
+.cm-s-paraiso-light span.cm-link { color: #815ba4; }
+.cm-s-paraiso-light span.cm-error { background: #ef6155; color: #776e71; }
 
-.cm-s-paraiso-light .CodeMirror-activeline-background {background: #CFD1C4 !important;}
-.cm-s-paraiso-light .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}
+.cm-s-paraiso-light .CodeMirror-activeline-background { background: #CFD1C4 !important; }
+.cm-s-paraiso-light .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/paraiso-light.css
+++ b/theme/paraiso-light.css
@@ -9,7 +9,7 @@
 */
 
 .cm-s-paraiso-light.CodeMirror {background: #e7e9db; color: #41323f;}
-.cm-s-paraiso-light div.CodeMirror-selected {background: #b9b6b0 !important;}
+.cm-s-paraiso-light div.CodeMirror-selected {background: #b9b6b0;}
 .cm-s-paraiso-light .CodeMirror-line::selection, .cm-s-paraiso-light .CodeMirror-line > span::selection, .cm-s-paraiso-light .CodeMirror-line > span > span::selection { background: #b9b6b0; }
 .cm-s-paraiso-light .CodeMirror-line::-moz-selection, .cm-s-paraiso-light .CodeMirror-line > span::-moz-selection, .cm-s-paraiso-light .CodeMirror-line > span > span::-moz-selection { background: #b9b6b0; }
 .cm-s-paraiso-light .CodeMirror-gutters {background: #e7e9db; border-right: 0px;}

--- a/theme/pastel-on-dark.css
+++ b/theme/pastel-on-dark.css
@@ -13,7 +13,7 @@
 	line-height: 1.5;
 	font-size: 14px;
 }
-.cm-s-pastel-on-dark div.CodeMirror-selected { background: rgba(221,240,255,0.2) !important; }
+.cm-s-pastel-on-dark div.CodeMirror-selected { background: rgba(221,240,255,0.2); }
 .cm-s-pastel-on-dark .CodeMirror-line::selection, .cm-s-pastel-on-dark .CodeMirror-line > span::selection, .cm-s-pastel-on-dark .CodeMirror-line > span > span::selection { background: rgba(221,240,255,0.2); }
 .cm-s-pastel-on-dark .CodeMirror-line::-moz-selection, .cm-s-pastel-on-dark .CodeMirror-line > span::-moz-selection, .cm-s-pastel-on-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(221,240,255,0.2); }
 

--- a/theme/rubyblue.css
+++ b/theme/rubyblue.css
@@ -22,4 +22,4 @@
 .cm-s-rubyblue span.cm-builtin, .cm-s-rubyblue span.cm-special { color: #FF9D00; }
 .cm-s-rubyblue span.cm-error { color: #AF2018; }
 
-.cm-s-rubyblue .CodeMirror-activeline-background {background: #173047 !important;}
+.cm-s-rubyblue .CodeMirror-activeline-background { background: #173047 !important; }

--- a/theme/rubyblue.css
+++ b/theme/rubyblue.css
@@ -1,5 +1,5 @@
 .cm-s-rubyblue.CodeMirror { background: #112435; color: white; }
-.cm-s-rubyblue div.CodeMirror-selected { background: #38566F !important; }
+.cm-s-rubyblue div.CodeMirror-selected { background: #38566F; }
 .cm-s-rubyblue .CodeMirror-line::selection, .cm-s-rubyblue .CodeMirror-line > span::selection, .cm-s-rubyblue .CodeMirror-line > span > span::selection { background: rgba(56, 86, 111, 0.99); }
 .cm-s-rubyblue .CodeMirror-line::-moz-selection, .cm-s-rubyblue .CodeMirror-line > span::-moz-selection, .cm-s-rubyblue .CodeMirror-line > span > span::-moz-selection { background: rgba(56, 86, 111, 0.99); }
 .cm-s-rubyblue .CodeMirror-gutters { background: #1F4661; border-right: 7px solid #3E7087; }

--- a/theme/seti.css
+++ b/theme/seti.css
@@ -18,71 +18,27 @@
   background-color: #0E1112;
   border: none;
 }
-.cm-s-seti .CodeMirror-cursor {
-  border-left: solid thin #f8f8f0 !important;
-}
-.cm-s-seti .CodeMirror-linenumber {
-  color: #6D8A88;
-}
-.cm-s-seti.CodeMirror-focused .CodeMirror-selected {
-  background: rgba(255, 255, 255, 0.10);
-}
-.cm-s-seti .CodeMirror-line::selection, .cm-s-seti .CodeMirror-line > span::selection, .cm-s-seti .CodeMirror-line > span > span::selection {
-  background: rgba(255, 255, 255, 0.10);
-}
-.cm-s-seti .CodeMirror-line::-moz-selection, .cm-s-seti .CodeMirror-line > span::-moz-selection, .cm-s-seti .CodeMirror-line > span > span::-moz-selection {
-  background: rgba(255, 255, 255, 0.10);
-}
-.cm-s-seti span.cm-comment {
-  color: #41535b;
-}
-.cm-s-seti span.cm-string, .cm-s-seti span.cm-string-2 {
-  color: #55b5db;
-}
-.cm-s-seti span.cm-number {
-  color: #cd3f45;
-}
-.cm-s-seti span.cm-variable {
-  color: #55b5db;
-}
-.cm-s-seti span.cm-variable-2 {
-  color: #a074c4;
-}
-.cm-s-seti span.cm-def {
-  color: #55b5db;
-}
-.cm-s-seti span.cm-keyword {
-  color: #ff79c6;
-}
-.cm-s-seti span.cm-operator {
-  color: #9fca56;
-}
-.cm-s-seti span.cm-keyword {
-  color: #e6cd69;
-}
-.cm-s-seti span.cm-atom {
-  color: #cd3f45;
-}
-.cm-s-seti span.cm-meta {
-  color: #55b5db;
-}
-.cm-s-seti span.cm-tag {
-  color: #55b5db;
-}
-.cm-s-seti span.cm-attribute {
-  color: #9fca56;
-}
-.cm-s-seti span.cm-qualifier {
-  color: #9fca56;
-}
-.cm-s-seti span.cm-property {
-  color: #a074c4;
-}
-.cm-s-seti span.cm-variable-3 {
-  color: #9fca56;
-}
-.cm-s-seti span.cm-builtin {
-  color: #9fca56;
-}
+.cm-s-seti .CodeMirror-cursor { border-left: solid thin #f8f8f0 !important; }
+.cm-s-seti .CodeMirror-linenumber { color: #6D8A88; }
+.cm-s-seti.CodeMirror-focused .CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
+.cm-s-seti .CodeMirror-line::selection, .cm-s-seti .CodeMirror-line > span::selection, .cm-s-seti .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
+.cm-s-seti .CodeMirror-line::-moz-selection, .cm-s-seti .CodeMirror-line > span::-moz-selection, .cm-s-seti .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
+.cm-s-seti span.cm-comment { color: #41535b; }
+.cm-s-seti span.cm-string, .cm-s-seti span.cm-string-2 { color: #55b5db; }
+.cm-s-seti span.cm-number { color: #cd3f45; }
+.cm-s-seti span.cm-variable { color: #55b5db; }
+.cm-s-seti span.cm-variable-2 { color: #a074c4; }
+.cm-s-seti span.cm-def { color: #55b5db; }
+.cm-s-seti span.cm-keyword { color: #ff79c6; }
+.cm-s-seti span.cm-operator { color: #9fca56; }
+.cm-s-seti span.cm-keyword { color: #e6cd69; }
+.cm-s-seti span.cm-atom { color: #cd3f45; }
+.cm-s-seti span.cm-meta { color: #55b5db; }
+.cm-s-seti span.cm-tag { color: #55b5db; }
+.cm-s-seti span.cm-attribute { color: #9fca56; }
+.cm-s-seti span.cm-qualifier { color: #9fca56; }
+.cm-s-seti span.cm-property { color: #a074c4; }
+.cm-s-seti span.cm-variable-3 { color: #9fca56; }
+.cm-s-seti span.cm-builtin { color: #9fca56; }
 .cm-s-seti .CodeMirror-activeline-background {background: #101213 !important;}
 .cm-s-seti .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}

--- a/theme/seti.css
+++ b/theme/seti.css
@@ -13,7 +13,7 @@
   color: #CFD2D1 !important;
   border: none;
 }
-.cm-s-seti .CodeMirror-gutters{
+.cm-s-seti .CodeMirror-gutters {
   color: #404b53;
   background-color: #0E1112;
   border: none;

--- a/theme/seti.css
+++ b/theme/seti.css
@@ -40,5 +40,5 @@
 .cm-s-seti span.cm-property { color: #a074c4; }
 .cm-s-seti span.cm-variable-3 { color: #9fca56; }
 .cm-s-seti span.cm-builtin { color: #9fca56; }
-.cm-s-seti .CodeMirror-activeline-background {background: #101213 !important;}
-.cm-s-seti .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}
+.cm-s-seti .CodeMirror-activeline-background { background: #101213 !important; }
+.cm-s-seti .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/seti.css
+++ b/theme/seti.css
@@ -20,7 +20,7 @@
 }
 .cm-s-seti .CodeMirror-cursor { border-left: solid thin #f8f8f0 !important; }
 .cm-s-seti .CodeMirror-linenumber { color: #6D8A88; }
-.cm-s-seti.CodeMirror-focused .CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
+.cm-s-seti.CodeMirror-focused div.CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
 .cm-s-seti .CodeMirror-line::selection, .cm-s-seti .CodeMirror-line > span::selection, .cm-s-seti .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
 .cm-s-seti .CodeMirror-line::-moz-selection, .cm-s-seti .CodeMirror-line > span::-moz-selection, .cm-s-seti .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
 .cm-s-seti span.cm-comment { color: #41535b; }

--- a/theme/solarized.css
+++ b/theme/solarized.css
@@ -94,11 +94,11 @@ http://ethanschoonover.com/solarized/img/solarized-palette.png
   border-bottom: 1px dotted #dc322f;
 }
 
-.cm-s-solarized.cm-s-dark .CodeMirror-selected { background: #073642; }
+.cm-s-solarized.cm-s-dark div.CodeMirror-selected { background: #073642; }
 .cm-s-solarized.cm-s-dark.CodeMirror ::selection { background: rgba(7, 54, 66, 0.99); }
 .cm-s-solarized.cm-s-dark .CodeMirror-line::-moz-selection, .cm-s-dark .CodeMirror-line > span::-moz-selection, .cm-s-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(7, 54, 66, 0.99); }
 
-.cm-s-solarized.cm-s-light .CodeMirror-selected { background: #eee8d5; }
+.cm-s-solarized.cm-s-light div.CodeMirror-selected { background: #eee8d5; }
 .cm-s-solarized.cm-s-light .CodeMirror-line::selection, .cm-s-light .CodeMirror-line > span::selection, .cm-s-light .CodeMirror-line > span > span::selection { background: #eee8d5; }
 .cm-s-solarized.cm-s-light .CodeMirror-line::-moz-selection, .cm-s-ligh .CodeMirror-line > span::-moz-selection, .cm-s-ligh .CodeMirror-line > span > span::-moz-selection { background: #eee8d5; }
 

--- a/theme/solarized.css
+++ b/theme/solarized.css
@@ -50,7 +50,7 @@ http://ethanschoonover.com/solarized/img/solarized-palette.png
 .cm-s-solarized .cm-header { color: #586e75; }
 .cm-s-solarized .cm-quote { color: #93a1a1; }
 
-.cm-s-solarized .cm-keyword { color: #cb4b16 }
+.cm-s-solarized .cm-keyword { color: #cb4b16; }
 .cm-s-solarized .cm-atom { color: #d33682; }
 .cm-s-solarized .cm-number { color: #d33682; }
 .cm-s-solarized .cm-def { color: #2aa198; }
@@ -60,7 +60,7 @@ http://ethanschoonover.com/solarized/img/solarized-palette.png
 .cm-s-solarized .cm-variable-3 { color: #6c71c4; }
 
 .cm-s-solarized .cm-property { color: #2aa198; }
-.cm-s-solarized .cm-operator {color: #6c71c4;}
+.cm-s-solarized .cm-operator { color: #6c71c4; }
 
 .cm-s-solarized .cm-comment { color: #586e75; font-style:italic; }
 
@@ -73,8 +73,8 @@ http://ethanschoonover.com/solarized/img/solarized-palette.png
 .cm-s-solarized .cm-bracket { color: #cb4b16; }
 .cm-s-solarized .CodeMirror-matchingbracket { color: #859900; }
 .cm-s-solarized .CodeMirror-nonmatchingbracket { color: #dc322f; }
-.cm-s-solarized .cm-tag { color: #93a1a1 }
-.cm-s-solarized .cm-attribute {  color: #2aa198; }
+.cm-s-solarized .cm-tag { color: #93a1a1; }
+.cm-s-solarized .cm-attribute { color: #2aa198; }
 .cm-s-solarized .cm-hr {
   color: transparent;
   border-top: 1px solid #586e75;

--- a/theme/the-matrix.css
+++ b/theme/the-matrix.css
@@ -8,23 +8,23 @@
 .cm-s-the-matrix .CodeMirror-linenumber { color: #FFFFFF; }
 .cm-s-the-matrix .CodeMirror-cursor { border-left: 1px solid #00FF00 !important; }
 
-.cm-s-the-matrix span.cm-keyword {color: #008803; font-weight: bold;}
-.cm-s-the-matrix span.cm-atom {color: #3FF;}
-.cm-s-the-matrix span.cm-number {color: #FFB94F;}
-.cm-s-the-matrix span.cm-def {color: #99C;}
-.cm-s-the-matrix span.cm-variable {color: #F6C;}
-.cm-s-the-matrix span.cm-variable-2 {color: #C6F;}
-.cm-s-the-matrix span.cm-variable-3 {color: #96F;}
-.cm-s-the-matrix span.cm-property {color: #62FFA0;}
-.cm-s-the-matrix span.cm-operator {color: #999}
-.cm-s-the-matrix span.cm-comment {color: #CCCCCC;}
-.cm-s-the-matrix span.cm-string {color: #39C;}
-.cm-s-the-matrix span.cm-meta {color: #C9F;}
-.cm-s-the-matrix span.cm-qualifier {color: #FFF700;}
-.cm-s-the-matrix span.cm-builtin {color: #30a;}
-.cm-s-the-matrix span.cm-bracket {color: #cc7;}
-.cm-s-the-matrix span.cm-tag {color: #FFBD40;}
-.cm-s-the-matrix span.cm-attribute {color: #FFF700;}
-.cm-s-the-matrix span.cm-error {color: #FF0000;}
+.cm-s-the-matrix span.cm-keyword { color: #008803; font-weight: bold; }
+.cm-s-the-matrix span.cm-atom { color: #3FF; }
+.cm-s-the-matrix span.cm-number { color: #FFB94F; }
+.cm-s-the-matrix span.cm-def { color: #99C; }
+.cm-s-the-matrix span.cm-variable { color: #F6C; }
+.cm-s-the-matrix span.cm-variable-2 { color: #C6F; }
+.cm-s-the-matrix span.cm-variable-3 { color: #96F; }
+.cm-s-the-matrix span.cm-property { color: #62FFA0; }
+.cm-s-the-matrix span.cm-operator { color: #999; }
+.cm-s-the-matrix span.cm-comment { color: #CCCCCC; }
+.cm-s-the-matrix span.cm-string { color: #39C; }
+.cm-s-the-matrix span.cm-meta { color: #C9F; }
+.cm-s-the-matrix span.cm-qualifier { color: #FFF700; }
+.cm-s-the-matrix span.cm-builtin { color: #30a; }
+.cm-s-the-matrix span.cm-bracket { color: #cc7; }
+.cm-s-the-matrix span.cm-tag { color: #FFBD40; }
+.cm-s-the-matrix span.cm-attribute { color: #FFF700; }
+.cm-s-the-matrix span.cm-error { color: #FF0000; }
 
-.cm-s-the-matrix .CodeMirror-activeline-background {background: #040;}
+.cm-s-the-matrix .CodeMirror-activeline-background { background: #040; }

--- a/theme/the-matrix.css
+++ b/theme/the-matrix.css
@@ -1,5 +1,5 @@
 .cm-s-the-matrix.CodeMirror { background: #000000; color: #00FF00; }
-.cm-s-the-matrix div.CodeMirror-selected { background: #2D2D2D !important; }
+.cm-s-the-matrix div.CodeMirror-selected { background: #2D2D2D; }
 .cm-s-the-matrix .CodeMirror-line::selection, .cm-s-the-matrix .CodeMirror-line > span::selection, .cm-s-the-matrix .CodeMirror-line > span > span::selection { background: rgba(45, 45, 45, 0.99); }
 .cm-s-the-matrix .CodeMirror-line::-moz-selection, .cm-s-the-matrix .CodeMirror-line > span::-moz-selection, .cm-s-the-matrix .CodeMirror-line > span > span::-moz-selection { background: rgba(45, 45, 45, 0.99); }
 .cm-s-the-matrix .CodeMirror-gutters { background: #060; border-right: 2px solid #00FF00; }

--- a/theme/tomorrow-night-bright.css
+++ b/theme/tomorrow-night-bright.css
@@ -8,7 +8,7 @@
 */
 
 .cm-s-tomorrow-night-bright.CodeMirror {background: #000000; color: #eaeaea;}
-.cm-s-tomorrow-night-bright div.CodeMirror-selected {background: #424242 !important;}
+.cm-s-tomorrow-night-bright div.CodeMirror-selected {background: #424242;}
 .cm-s-tomorrow-night-bright .CodeMirror-gutters {background: #000000; border-right: 0px;}
 .cm-s-tomorrow-night-bright .CodeMirror-guttermarker { color: #e78c45; }
 .cm-s-tomorrow-night-bright .CodeMirror-guttermarker-subtle { color: #777; }

--- a/theme/tomorrow-night-bright.css
+++ b/theme/tomorrow-night-bright.css
@@ -7,29 +7,29 @@
 
 */
 
-.cm-s-tomorrow-night-bright.CodeMirror {background: #000000; color: #eaeaea;}
-.cm-s-tomorrow-night-bright div.CodeMirror-selected {background: #424242;}
-.cm-s-tomorrow-night-bright .CodeMirror-gutters {background: #000000; border-right: 0px;}
+.cm-s-tomorrow-night-bright.CodeMirror { background: #000000; color: #eaeaea; }
+.cm-s-tomorrow-night-bright div.CodeMirror-selected { background: #424242; }
+.cm-s-tomorrow-night-bright .CodeMirror-gutters { background: #000000; border-right: 0px; }
 .cm-s-tomorrow-night-bright .CodeMirror-guttermarker { color: #e78c45; }
 .cm-s-tomorrow-night-bright .CodeMirror-guttermarker-subtle { color: #777; }
-.cm-s-tomorrow-night-bright .CodeMirror-linenumber {color: #424242;}
-.cm-s-tomorrow-night-bright .CodeMirror-cursor {border-left: 1px solid #6A6A6A !important;}
+.cm-s-tomorrow-night-bright .CodeMirror-linenumber { color: #424242; }
+.cm-s-tomorrow-night-bright .CodeMirror-cursor { border-left: 1px solid #6A6A6A !important; }
 
-.cm-s-tomorrow-night-bright span.cm-comment {color: #d27b53;}
-.cm-s-tomorrow-night-bright span.cm-atom {color: #a16a94;}
-.cm-s-tomorrow-night-bright span.cm-number {color: #a16a94;}
+.cm-s-tomorrow-night-bright span.cm-comment { color: #d27b53; }
+.cm-s-tomorrow-night-bright span.cm-atom { color: #a16a94; }
+.cm-s-tomorrow-night-bright span.cm-number { color: #a16a94; }
 
-.cm-s-tomorrow-night-bright span.cm-property, .cm-s-tomorrow-night-bright span.cm-attribute {color: #99cc99;}
-.cm-s-tomorrow-night-bright span.cm-keyword {color: #d54e53;}
-.cm-s-tomorrow-night-bright span.cm-string {color: #e7c547;}
+.cm-s-tomorrow-night-bright span.cm-property, .cm-s-tomorrow-night-bright span.cm-attribute { color: #99cc99; }
+.cm-s-tomorrow-night-bright span.cm-keyword { color: #d54e53; }
+.cm-s-tomorrow-night-bright span.cm-string { color: #e7c547; }
 
-.cm-s-tomorrow-night-bright span.cm-variable {color: #b9ca4a;}
-.cm-s-tomorrow-night-bright span.cm-variable-2 {color: #7aa6da;}
-.cm-s-tomorrow-night-bright span.cm-def {color: #e78c45;}
-.cm-s-tomorrow-night-bright span.cm-bracket {color: #eaeaea;}
-.cm-s-tomorrow-night-bright span.cm-tag {color: #d54e53;}
-.cm-s-tomorrow-night-bright span.cm-link {color: #a16a94;}
-.cm-s-tomorrow-night-bright span.cm-error {background: #d54e53; color: #6A6A6A;}
+.cm-s-tomorrow-night-bright span.cm-variable { color: #b9ca4a; }
+.cm-s-tomorrow-night-bright span.cm-variable-2 { color: #7aa6da; }
+.cm-s-tomorrow-night-bright span.cm-def { color: #e78c45; }
+.cm-s-tomorrow-night-bright span.cm-bracket { color: #eaeaea; }
+.cm-s-tomorrow-night-bright span.cm-tag { color: #d54e53; }
+.cm-s-tomorrow-night-bright span.cm-link { color: #a16a94; }
+.cm-s-tomorrow-night-bright span.cm-error { background: #d54e53; color: #6A6A6A; }
 
-.cm-s-tomorrow-night-bright .CodeMirror-activeline-background {background: #2a2a2a !important;}
-.cm-s-tomorrow-night-bright .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}
+.cm-s-tomorrow-night-bright .CodeMirror-activeline-background { background: #2a2a2a !important; }
+.cm-s-tomorrow-night-bright .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/tomorrow-night-eighties.css
+++ b/theme/tomorrow-night-eighties.css
@@ -9,7 +9,7 @@
 */
 
 .cm-s-tomorrow-night-eighties.CodeMirror {background: #000000; color: #CCCCCC;}
-.cm-s-tomorrow-night-eighties div.CodeMirror-selected {background: #2D2D2D !important;}
+.cm-s-tomorrow-night-eighties div.CodeMirror-selected {background: #2D2D2D;}
 .cm-s-tomorrow-night-eighties .CodeMirror-line::selection, .cm-s-tomorrow-night-eighties .CodeMirror-line > span::selection, .cm-s-tomorrow-night-eighties .CodeMirror-line > span > span::selection { background: rgba(45, 45, 45, 0.99); }
 .cm-s-tomorrow-night-eighties .CodeMirror-line::-moz-selection, .cm-s-tomorrow-night-eighties .CodeMirror-line > span::-moz-selection, .cm-s-tomorrow-night-eighties .CodeMirror-line > span > span::-moz-selection { background: rgba(45, 45, 45, 0.99); }
 .cm-s-tomorrow-night-eighties .CodeMirror-gutters {background: #000000; border-right: 0px;}

--- a/theme/tomorrow-night-eighties.css
+++ b/theme/tomorrow-night-eighties.css
@@ -8,31 +8,31 @@
 
 */
 
-.cm-s-tomorrow-night-eighties.CodeMirror {background: #000000; color: #CCCCCC;}
-.cm-s-tomorrow-night-eighties div.CodeMirror-selected {background: #2D2D2D;}
+.cm-s-tomorrow-night-eighties.CodeMirror { background: #000000; color: #CCCCCC; }
+.cm-s-tomorrow-night-eighties div.CodeMirror-selected { background: #2D2D2D; }
 .cm-s-tomorrow-night-eighties .CodeMirror-line::selection, .cm-s-tomorrow-night-eighties .CodeMirror-line > span::selection, .cm-s-tomorrow-night-eighties .CodeMirror-line > span > span::selection { background: rgba(45, 45, 45, 0.99); }
 .cm-s-tomorrow-night-eighties .CodeMirror-line::-moz-selection, .cm-s-tomorrow-night-eighties .CodeMirror-line > span::-moz-selection, .cm-s-tomorrow-night-eighties .CodeMirror-line > span > span::-moz-selection { background: rgba(45, 45, 45, 0.99); }
-.cm-s-tomorrow-night-eighties .CodeMirror-gutters {background: #000000; border-right: 0px;}
+.cm-s-tomorrow-night-eighties .CodeMirror-gutters { background: #000000; border-right: 0px; }
 .cm-s-tomorrow-night-eighties .CodeMirror-guttermarker { color: #f2777a; }
 .cm-s-tomorrow-night-eighties .CodeMirror-guttermarker-subtle { color: #777; }
-.cm-s-tomorrow-night-eighties .CodeMirror-linenumber {color: #515151;}
-.cm-s-tomorrow-night-eighties .CodeMirror-cursor {border-left: 1px solid #6A6A6A !important;}
+.cm-s-tomorrow-night-eighties .CodeMirror-linenumber { color: #515151; }
+.cm-s-tomorrow-night-eighties .CodeMirror-cursor { border-left: 1px solid #6A6A6A !important; }
 
-.cm-s-tomorrow-night-eighties span.cm-comment {color: #d27b53;}
-.cm-s-tomorrow-night-eighties span.cm-atom {color: #a16a94;}
-.cm-s-tomorrow-night-eighties span.cm-number {color: #a16a94;}
+.cm-s-tomorrow-night-eighties span.cm-comment { color: #d27b53; }
+.cm-s-tomorrow-night-eighties span.cm-atom { color: #a16a94; }
+.cm-s-tomorrow-night-eighties span.cm-number { color: #a16a94; }
 
-.cm-s-tomorrow-night-eighties span.cm-property, .cm-s-tomorrow-night-eighties span.cm-attribute {color: #99cc99;}
-.cm-s-tomorrow-night-eighties span.cm-keyword {color: #f2777a;}
-.cm-s-tomorrow-night-eighties span.cm-string {color: #ffcc66;}
+.cm-s-tomorrow-night-eighties span.cm-property, .cm-s-tomorrow-night-eighties span.cm-attribute { color: #99cc99; }
+.cm-s-tomorrow-night-eighties span.cm-keyword { color: #f2777a; }
+.cm-s-tomorrow-night-eighties span.cm-string { color: #ffcc66; }
 
-.cm-s-tomorrow-night-eighties span.cm-variable {color: #99cc99;}
-.cm-s-tomorrow-night-eighties span.cm-variable-2 {color: #6699cc;}
-.cm-s-tomorrow-night-eighties span.cm-def {color: #f99157;}
-.cm-s-tomorrow-night-eighties span.cm-bracket {color: #CCCCCC;}
-.cm-s-tomorrow-night-eighties span.cm-tag {color: #f2777a;}
-.cm-s-tomorrow-night-eighties span.cm-link {color: #a16a94;}
-.cm-s-tomorrow-night-eighties span.cm-error {background: #f2777a; color: #6A6A6A;}
+.cm-s-tomorrow-night-eighties span.cm-variable { color: #99cc99; }
+.cm-s-tomorrow-night-eighties span.cm-variable-2 { color: #6699cc; }
+.cm-s-tomorrow-night-eighties span.cm-def { color: #f99157; }
+.cm-s-tomorrow-night-eighties span.cm-bracket { color: #CCCCCC; }
+.cm-s-tomorrow-night-eighties span.cm-tag { color: #f2777a; }
+.cm-s-tomorrow-night-eighties span.cm-link { color: #a16a94; }
+.cm-s-tomorrow-night-eighties span.cm-error { background: #f2777a; color: #6A6A6A; }
 
-.cm-s-tomorrow-night-eighties .CodeMirror-activeline-background {background: #343600 !important;}
-.cm-s-tomorrow-night-eighties .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}
+.cm-s-tomorrow-night-eighties .CodeMirror-activeline-background { background: #343600 !important; }
+.cm-s-tomorrow-night-eighties .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/ttcn.css
+++ b/theme/ttcn.css
@@ -1,65 +1,65 @@
-.cm-quote {color: #090;}
-.cm-negative {color: #d44;}
-.cm-positive {color: #292;}
-.cm-header, .cm-strong {font-weight: bold;}
-.cm-em {font-style: italic;}
-.cm-link {text-decoration: underline;}
-.cm-strikethrough {text-decoration: line-through;}
-.cm-header {color: #00f; font-weight: bold;}
+.cm-quote { color: #090; }
+.cm-negative { color: #d44; }
+.cm-positive { color: #292; }
+.cm-header, .cm-strong { font-weight: bold; }
+.cm-em { font-style: italic; }
+.cm-link { text-decoration: underline; }
+.cm-strikethrough { text-decoration: line-through; }
+.cm-header { color: #00f; font-weight: bold; }
 
-.cm-atom {color: #219;}
-.cm-attribute {color: #00c;}
-.cm-bracket {color: #997;}
-.cm-comment {color: #333333;}
-.cm-def {color: #00f;}
-.cm-em {font-style: italic;}
-.cm-error {color: #f00;}
-.cm-hr {color: #999;}
-.cm-invalidchar {color: #f00;}
-.cm-keyword {font-weight:bold}
-.cm-link {color: #00c; text-decoration: underline;}
-.cm-meta {color: #555;}
-.cm-negative {color: #d44;}
-.cm-positive {color: #292;}
-.cm-qualifier {color: #555;}
-.cm-strikethrough {text-decoration: line-through;}
-.cm-string {color: #006400;}
-.cm-string-2 {color: #f50;}
-.cm-strong {font-weight: bold;}
-.cm-tag {color: #170;}
-.cm-variable {color: #8B2252;}
-.cm-variable-2 {color: #05a;}
-.cm-variable-3 {color: #085;}
+.cm-atom { color: #219; }
+.cm-attribute { color: #00c; }
+.cm-bracket { color: #997; }
+.cm-comment { color: #333333; }
+.cm-def { color: #00f; }
+.cm-em { font-style: italic; }
+.cm-error { color: #f00; }
+.cm-hr { color: #999; }
+.cm-invalidchar { color: #f00; }
+.cm-keyword { font-weight:bold; }
+.cm-link { color: #00c; text-decoration: underline; }
+.cm-meta { color: #555; }
+.cm-negative { color: #d44; }
+.cm-positive { color: #292; }
+.cm-qualifier { color: #555; }
+.cm-strikethrough { text-decoration: line-through; }
+.cm-string { color: #006400; }
+.cm-string-2 { color: #f50; }
+.cm-strong { font-weight: bold; }
+.cm-tag { color: #170; }
+.cm-variable { color: #8B2252; }
+.cm-variable-2 { color: #05a; }
+.cm-variable-3 { color: #085; }
 
-.cm-s-default .cm-error {color: #f00;}
-.cm-invalidchar {color: #f00;}
+.cm-s-default .cm-error { color: #f00; }
+.cm-invalidchar { color: #f00; }
 
 /* ASN */
 .cm-s-ttcn .cm-accessTypes,
-.cm-s-ttcn .cm-compareTypes {color: #27408B}
-.cm-s-ttcn .cm-cmipVerbs {color: #8B2252}
-.cm-s-ttcn .cm-modifier {color:#D2691E}
-.cm-s-ttcn .cm-status {color:#8B4545}
-.cm-s-ttcn .cm-storage {color:#A020F0}
-.cm-s-ttcn .cm-tags {color:#006400}
+.cm-s-ttcn .cm-compareTypes { color: #27408B; }
+.cm-s-ttcn .cm-cmipVerbs { color: #8B2252; }
+.cm-s-ttcn .cm-modifier { color:#D2691E; }
+.cm-s-ttcn .cm-status { color:#8B4545; }
+.cm-s-ttcn .cm-storage { color:#A020F0; }
+.cm-s-ttcn .cm-tags { color:#006400; }
 
 /* CFG */
-.cm-s-ttcn .cm-externalCommands {color: #8B4545; font-weight:bold}
+.cm-s-ttcn .cm-externalCommands { color: #8B4545; font-weight:bold; }
 .cm-s-ttcn .cm-fileNCtrlMaskOptions,
-.cm-s-ttcn .cm-sectionTitle {color: #2E8B57; font-weight:bold}
+.cm-s-ttcn .cm-sectionTitle { color: #2E8B57; font-weight:bold; }
 
 /* TTCN */
 .cm-s-ttcn .cm-booleanConsts,
 .cm-s-ttcn .cm-otherConsts,
-.cm-s-ttcn .cm-verdictConsts {color: #006400}
+.cm-s-ttcn .cm-verdictConsts { color: #006400; }
 .cm-s-ttcn .cm-configOps,
 .cm-s-ttcn .cm-functionOps,
 .cm-s-ttcn .cm-portOps,
 .cm-s-ttcn .cm-sutOps,
 .cm-s-ttcn .cm-timerOps,
-.cm-s-ttcn .cm-verdictOps {color: #0000FF}
+.cm-s-ttcn .cm-verdictOps { color: #0000FF; }
 .cm-s-ttcn .cm-preprocessor,
 .cm-s-ttcn .cm-templateMatch,
-.cm-s-ttcn .cm-ttcn3Macros {color: #27408B}
-.cm-s-ttcn .cm-types {color: #A52A2A; font-weight:bold}
-.cm-s-ttcn .cm-visibilityModifiers {font-weight:bold}
+.cm-s-ttcn .cm-ttcn3Macros { color: #27408B; }
+.cm-s-ttcn .cm-types { color: #A52A2A; font-weight:bold; }
+.cm-s-ttcn .cm-visibilityModifiers { font-weight:bold; }

--- a/theme/twilight.css
+++ b/theme/twilight.css
@@ -9,7 +9,7 @@
 .cm-s-twilight .CodeMirror-linenumber { color: #aaa; }
 .cm-s-twilight .CodeMirror-cursor { border-left: 1px solid white !important; }
 
-.cm-s-twilight .cm-keyword {  color: #f9ee98; } /**/
+.cm-s-twilight .cm-keyword { color: #f9ee98; } /**/
 .cm-s-twilight .cm-atom { color: #FC0; }
 .cm-s-twilight .cm-number { color:  #ca7841; } /**/
 .cm-s-twilight .cm-def { color: #8DA6CE; }
@@ -18,15 +18,15 @@
 .cm-s-twilight .cm-operator { color: #cda869; } /**/
 .cm-s-twilight .cm-comment { color:#777; font-style:italic; font-weight:normal; } /**/
 .cm-s-twilight .cm-string { color:#8f9d6a; font-style:italic; } /**/
-.cm-s-twilight .cm-string-2 { color:#bd6b18 } /*?*/
+.cm-s-twilight .cm-string-2 { color:#bd6b18; } /*?*/
 .cm-s-twilight .cm-meta { background-color:#141414; color:#f7f7f7; } /*?*/
 .cm-s-twilight .cm-builtin { color: #cda869; } /*?*/
 .cm-s-twilight .cm-tag { color: #997643; } /**/
 .cm-s-twilight .cm-attribute { color: #d6bb6d; } /*?*/
 .cm-s-twilight .cm-header { color: #FF6400; }
 .cm-s-twilight .cm-hr { color: #AEAEAE; }
-.cm-s-twilight .cm-link {   color:#ad9361; font-style:italic; text-decoration:none; } /**/
+.cm-s-twilight .cm-link { color:#ad9361; font-style:italic; text-decoration:none; } /**/
 .cm-s-twilight .cm-error { border-bottom: 1px solid red; }
 
-.cm-s-twilight .CodeMirror-activeline-background {background: #27282E !important;}
-.cm-s-twilight .CodeMirror-matchingbracket {outline:1px solid grey; color:white !important;}
+.cm-s-twilight .CodeMirror-activeline-background { background: #27282E !important; }
+.cm-s-twilight .CodeMirror-matchingbracket { outline:1px solid grey; color:white !important; }

--- a/theme/twilight.css
+++ b/theme/twilight.css
@@ -1,5 +1,5 @@
 .cm-s-twilight.CodeMirror { background: #141414; color: #f7f7f7; } /**/
-.cm-s-twilight .CodeMirror-selected { background: #323232 !important; } /**/
+.cm-s-twilight div.CodeMirror-selected { background: #323232; } /**/
 .cm-s-twilight .CodeMirror-line::selection, .cm-s-twilight .CodeMirror-line > span::selection, .cm-s-twilight .CodeMirror-line > span > span::selection { background: rgba(50, 50, 50, 0.99); }
 .cm-s-twilight .CodeMirror-line::-moz-selection, .cm-s-twilight .CodeMirror-line > span::-moz-selection, .cm-s-twilight .CodeMirror-line > span > span::-moz-selection { background: rgba(50, 50, 50, 0.99); }
 

--- a/theme/vibrant-ink.css
+++ b/theme/vibrant-ink.css
@@ -11,16 +11,16 @@
 .cm-s-vibrant-ink .CodeMirror-linenumber { color: #d0d0d0; }
 .cm-s-vibrant-ink .CodeMirror-cursor { border-left: 1px solid white !important; }
 
-.cm-s-vibrant-ink .cm-keyword {  color: #CC7832; }
+.cm-s-vibrant-ink .cm-keyword { color: #CC7832; }
 .cm-s-vibrant-ink .cm-atom { color: #FC0; }
 .cm-s-vibrant-ink .cm-number { color:  #FFEE98; }
 .cm-s-vibrant-ink .cm-def { color: #8DA6CE; }
-.cm-s-vibrant-ink span.cm-variable-2, .cm-s-vibrant span.cm-tag { color: #FFC66D }
-.cm-s-vibrant-ink span.cm-variable-3, .cm-s-vibrant span.cm-def { color: #FFC66D }
+.cm-s-vibrant-ink span.cm-variable-2, .cm-s-vibrant span.cm-tag { color: #FFC66D; }
+.cm-s-vibrant-ink span.cm-variable-3, .cm-s-vibrant span.cm-def { color: #FFC66D; }
 .cm-s-vibrant-ink .cm-operator { color: #888; }
 .cm-s-vibrant-ink .cm-comment { color: gray; font-weight: bold; }
-.cm-s-vibrant-ink .cm-string { color:  #A5C25C }
-.cm-s-vibrant-ink .cm-string-2 { color: red }
+.cm-s-vibrant-ink .cm-string { color:  #A5C25C; }
+.cm-s-vibrant-ink .cm-string-2 { color: red; }
 .cm-s-vibrant-ink .cm-meta { color: #D8FA3C; }
 .cm-s-vibrant-ink .cm-builtin { color: #8DA6CE; }
 .cm-s-vibrant-ink .cm-tag { color: #8DA6CE; }
@@ -30,5 +30,5 @@
 .cm-s-vibrant-ink .cm-link { color: blue; }
 .cm-s-vibrant-ink .cm-error { border-bottom: 1px solid red; }
 
-.cm-s-vibrant-ink .CodeMirror-activeline-background {background: #27282E !important;}
-.cm-s-vibrant-ink .CodeMirror-matchingbracket {outline:1px solid grey; color:white !important;}
+.cm-s-vibrant-ink .CodeMirror-activeline-background { background: #27282E !important; }
+.cm-s-vibrant-ink .CodeMirror-matchingbracket { outline:1px solid grey; color:white !important; }

--- a/theme/vibrant-ink.css
+++ b/theme/vibrant-ink.css
@@ -1,7 +1,7 @@
 /* Taken from the popular Visual Studio Vibrant Ink Schema */
 
 .cm-s-vibrant-ink.CodeMirror { background: black; color: white; }
-.cm-s-vibrant-ink .CodeMirror-selected { background: #35493c !important; }
+.cm-s-vibrant-ink div.CodeMirror-selected { background: #35493c; }
 .cm-s-vibrant-ink .CodeMirror-line::selection, .cm-s-vibrant-ink .CodeMirror-line > span::selection, .cm-s-vibrant-ink .CodeMirror-line > span > span::selection { background: rgba(53, 73, 60, 0.99); }
 .cm-s-vibrant-ink .CodeMirror-line::-moz-selection, .cm-s-vibrant-ink .CodeMirror-line > span::-moz-selection, .cm-s-vibrant-ink .CodeMirror-line > span > span::-moz-selection { background: rgba(53, 73, 60, 0.99); }
 

--- a/theme/xq-dark.css
+++ b/theme/xq-dark.css
@@ -30,24 +30,24 @@ THE SOFTWARE.
 .cm-s-xq-dark .CodeMirror-linenumber { color: #f8f8f8; }
 .cm-s-xq-dark .CodeMirror-cursor { border-left: 1px solid white !important; }
 
-.cm-s-xq-dark span.cm-keyword {color: #FFBD40;}
-.cm-s-xq-dark span.cm-atom {color: #6C8CD5;}
-.cm-s-xq-dark span.cm-number {color: #164;}
-.cm-s-xq-dark span.cm-def {color: #FFF; text-decoration:underline;}
-.cm-s-xq-dark span.cm-variable {color: #FFF;}
-.cm-s-xq-dark span.cm-variable-2 {color: #EEE;}
-.cm-s-xq-dark span.cm-variable-3 {color: #DDD;}
+.cm-s-xq-dark span.cm-keyword { color: #FFBD40; }
+.cm-s-xq-dark span.cm-atom { color: #6C8CD5; }
+.cm-s-xq-dark span.cm-number { color: #164; }
+.cm-s-xq-dark span.cm-def { color: #FFF; text-decoration:underline; }
+.cm-s-xq-dark span.cm-variable { color: #FFF; }
+.cm-s-xq-dark span.cm-variable-2 { color: #EEE; }
+.cm-s-xq-dark span.cm-variable-3 { color: #DDD; }
 .cm-s-xq-dark span.cm-property {}
 .cm-s-xq-dark span.cm-operator {}
-.cm-s-xq-dark span.cm-comment {color: gray;}
-.cm-s-xq-dark span.cm-string {color: #9FEE00;}
-.cm-s-xq-dark span.cm-meta {color: yellow;}
-.cm-s-xq-dark span.cm-qualifier {color: #FFF700;}
-.cm-s-xq-dark span.cm-builtin {color: #30a;}
-.cm-s-xq-dark span.cm-bracket {color: #cc7;}
-.cm-s-xq-dark span.cm-tag {color: #FFBD40;}
-.cm-s-xq-dark span.cm-attribute {color: #FFF700;}
-.cm-s-xq-dark span.cm-error {color: #f00;}
+.cm-s-xq-dark span.cm-comment { color: gray; }
+.cm-s-xq-dark span.cm-string { color: #9FEE00; }
+.cm-s-xq-dark span.cm-meta { color: yellow; }
+.cm-s-xq-dark span.cm-qualifier { color: #FFF700; }
+.cm-s-xq-dark span.cm-builtin { color: #30a; }
+.cm-s-xq-dark span.cm-bracket { color: #cc7; }
+.cm-s-xq-dark span.cm-tag { color: #FFBD40; }
+.cm-s-xq-dark span.cm-attribute { color: #FFF700; }
+.cm-s-xq-dark span.cm-error { color: #f00; }
 
-.cm-s-xq-dark .CodeMirror-activeline-background {background: #27282E !important;}
-.cm-s-xq-dark .CodeMirror-matchingbracket {outline:1px solid grey; color:white !important;}
+.cm-s-xq-dark .CodeMirror-activeline-background { background: #27282E !important; }
+.cm-s-xq-dark .CodeMirror-matchingbracket { outline:1px solid grey; color:white !important; }

--- a/theme/xq-dark.css
+++ b/theme/xq-dark.css
@@ -21,7 +21,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 .cm-s-xq-dark.CodeMirror { background: #0a001f; color: #f8f8f8; }
-.cm-s-xq-dark .CodeMirror-selected { background: #27007A !important; }
+.cm-s-xq-dark div.CodeMirror-selected { background: #27007A; }
 .cm-s-xq-dark .CodeMirror-line::selection, .cm-s-xq-dark .CodeMirror-line > span::selection, .cm-s-xq-dark .CodeMirror-line > span > span::selection { background: rgba(39, 0, 122, 0.99); }
 .cm-s-xq-dark .CodeMirror-line::-moz-selection, .cm-s-xq-dark .CodeMirror-line > span::-moz-selection, .cm-s-xq-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(39, 0, 122, 0.99); }
 .cm-s-xq-dark .CodeMirror-gutters { background: #0a001f; border-right: 1px solid #aaa; }

--- a/theme/xq-light.css
+++ b/theme/xq-light.css
@@ -20,24 +20,24 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-.cm-s-xq-light span.cm-keyword {line-height: 1em; font-weight: bold; color: #5A5CAD; }
-.cm-s-xq-light span.cm-atom {color: #6C8CD5;}
-.cm-s-xq-light span.cm-number {color: #164;}
-.cm-s-xq-light span.cm-def {text-decoration:underline;}
-.cm-s-xq-light span.cm-variable {color: black; }
-.cm-s-xq-light span.cm-variable-2 {color:black;}
-.cm-s-xq-light span.cm-variable-3 {color: black; }
+.cm-s-xq-light span.cm-keyword { line-height: 1em; font-weight: bold; color: #5A5CAD; }
+.cm-s-xq-light span.cm-atom { color: #6C8CD5; }
+.cm-s-xq-light span.cm-number { color: #164; }
+.cm-s-xq-light span.cm-def { text-decoration:underline; }
+.cm-s-xq-light span.cm-variable { color: black; }
+.cm-s-xq-light span.cm-variable-2 { color:black; }
+.cm-s-xq-light span.cm-variable-3 { color: black; }
 .cm-s-xq-light span.cm-property {}
 .cm-s-xq-light span.cm-operator {}
-.cm-s-xq-light span.cm-comment {color: #0080FF; font-style: italic;}
-.cm-s-xq-light span.cm-string {color: red;}
-.cm-s-xq-light span.cm-meta {color: yellow;}
-.cm-s-xq-light span.cm-qualifier {color: grey}
-.cm-s-xq-light span.cm-builtin {color: #7EA656;}
-.cm-s-xq-light span.cm-bracket {color: #cc7;}
-.cm-s-xq-light span.cm-tag {color: #3F7F7F;}
-.cm-s-xq-light span.cm-attribute {color: #7F007F;}
-.cm-s-xq-light span.cm-error {color: #f00;}
+.cm-s-xq-light span.cm-comment { color: #0080FF; font-style: italic; }
+.cm-s-xq-light span.cm-string { color: red; }
+.cm-s-xq-light span.cm-meta { color: yellow; }
+.cm-s-xq-light span.cm-qualifier { color: grey; }
+.cm-s-xq-light span.cm-builtin { color: #7EA656; }
+.cm-s-xq-light span.cm-bracket { color: #cc7; }
+.cm-s-xq-light span.cm-tag { color: #3F7F7F; }
+.cm-s-xq-light span.cm-attribute { color: #7F007F; }
+.cm-s-xq-light span.cm-error { color: #f00; }
 
-.cm-s-xq-light .CodeMirror-activeline-background {background: #e8f2ff !important;}
-.cm-s-xq-light .CodeMirror-matchingbracket {outline:1px solid grey;color:black !important;background:yellow;}
+.cm-s-xq-light .CodeMirror-activeline-background { background: #e8f2ff !important; }
+.cm-s-xq-light .CodeMirror-matchingbracket { outline:1px solid grey;color:black !important;background:yellow; }

--- a/theme/yeti.css
+++ b/theme/yeti.css
@@ -21,7 +21,7 @@
 }
 .cm-s-yeti .CodeMirror-cursor { border-left: solid thin #d1c9c0 !important; }
 .cm-s-yeti .CodeMirror-linenumber { color: #adaba6; }
-.cm-s-yeti.CodeMirror-focused .CodeMirror-selected { background: #DCD8D2; }
+.cm-s-yeti.CodeMirror-focused div.CodeMirror-selected { background: #DCD8D2; }
 .cm-s-yeti .CodeMirror-line::selection, .cm-s-yeti .CodeMirror-line > span::selection, .cm-s-yeti .CodeMirror-line > span > span::selection { background: #DCD8D2; }
 .cm-s-yeti .CodeMirror-line::-moz-selection, .cm-s-yeti .CodeMirror-line > span::-moz-selection, .cm-s-yeti .CodeMirror-line > span > span::-moz-selection { background: #DCD8D2; }
 .cm-s-yeti span.cm-comment { color: #d4c8be; }

--- a/theme/yeti.css
+++ b/theme/yeti.css
@@ -19,68 +19,26 @@
   background-color: #E5E1DB;
   border: none;
 }
-.cm-s-yeti .CodeMirror-cursor {
-  border-left: solid thin #d1c9c0 !important;
-}
-.cm-s-yeti .CodeMirror-linenumber {
-  color: #adaba6;
-}
-.cm-s-yeti.CodeMirror-focused .CodeMirror-selected {
-  background: #DCD8D2;
-}
-.cm-s-yeti .CodeMirror-line::selection, .cm-s-yeti .CodeMirror-line > span::selection, .cm-s-yeti .CodeMirror-line > span > span::selection {
-  background: #DCD8D2;
-}
-.cm-s-yeti .CodeMirror-line::-moz-selection, .cm-s-yeti .CodeMirror-line > span::-moz-selection, .cm-s-yeti .CodeMirror-line > span > span::-moz-selection {
-  background: #DCD8D2;
-}
-.cm-s-yeti span.cm-comment {
-  color: #d4c8be;
-}
-.cm-s-yeti span.cm-string, .cm-s-yeti span.cm-string-2 {
-  color: #96c0d8;
-}
-.cm-s-yeti span.cm-number {
-  color: #a074c4;
-}
-.cm-s-yeti span.cm-variable {
-  color: #55b5db;
-}
-.cm-s-yeti span.cm-variable-2 {
-  color: #a074c4;
-}
-.cm-s-yeti span.cm-def {
-  color: #55b5db;
-}
-.cm-s-yeti span.cm-operator {
-  color: #9fb96e;
-}
-.cm-s-yeti span.cm-keyword {
-  color: #9fb96e;
-}
-.cm-s-yeti span.cm-atom {
-  color: #a074c4;
-}
-.cm-s-yeti span.cm-meta {
-  color: #96c0d8;
-}
-.cm-s-yeti span.cm-tag {
-  color: #96c0d8;
-}
-.cm-s-yeti span.cm-attribute {
-  color: #9fb96e;
-}
-.cm-s-yeti span.cm-qualifier {
-  color: #96c0d8;
-}
-.cm-s-yeti span.cm-property {
-  color: #a074c4;
-}
-.cm-s-yeti span.cm-builtin {
-  color: #a074c4;
-}
-.cm-s-yeti span.cm-variable-3 {
-  color: #96c0d8;
-}
+.cm-s-yeti .CodeMirror-cursor { border-left: solid thin #d1c9c0 !important; }
+.cm-s-yeti .CodeMirror-linenumber { color: #adaba6; }
+.cm-s-yeti.CodeMirror-focused .CodeMirror-selected { background: #DCD8D2; }
+.cm-s-yeti .CodeMirror-line::selection, .cm-s-yeti .CodeMirror-line > span::selection, .cm-s-yeti .CodeMirror-line > span > span::selection { background: #DCD8D2; }
+.cm-s-yeti .CodeMirror-line::-moz-selection, .cm-s-yeti .CodeMirror-line > span::-moz-selection, .cm-s-yeti .CodeMirror-line > span > span::-moz-selection { background: #DCD8D2; }
+.cm-s-yeti span.cm-comment { color: #d4c8be; }
+.cm-s-yeti span.cm-string, .cm-s-yeti span.cm-string-2 { color: #96c0d8; }
+.cm-s-yeti span.cm-number { color: #a074c4; }
+.cm-s-yeti span.cm-variable { color: #55b5db; }
+.cm-s-yeti span.cm-variable-2 { color: #a074c4; }
+.cm-s-yeti span.cm-def { color: #55b5db; }
+.cm-s-yeti span.cm-operator { color: #9fb96e; }
+.cm-s-yeti span.cm-keyword { color: #9fb96e; }
+.cm-s-yeti span.cm-atom { color: #a074c4; }
+.cm-s-yeti span.cm-meta { color: #96c0d8; }
+.cm-s-yeti span.cm-tag { color: #96c0d8; }
+.cm-s-yeti span.cm-attribute { color: #9fb96e; }
+.cm-s-yeti span.cm-qualifier { color: #96c0d8; }
+.cm-s-yeti span.cm-property { color: #a074c4; }
+.cm-s-yeti span.cm-builtin { color: #a074c4; }
+.cm-s-yeti span.cm-variable-3 { color: #96c0d8; }
 .cm-s-yeti .CodeMirror-activeline-background {background: #E7E4E0 !important;}
 .cm-s-yeti .CodeMirror-matchingbracket { text-decoration: underline;}

--- a/theme/yeti.css
+++ b/theme/yeti.css
@@ -14,7 +14,7 @@
   border: none;
 }
 
-.cm-s-yeti .CodeMirror-gutters{
+.cm-s-yeti .CodeMirror-gutters {
   color: #adaba6;
   background-color: #E5E1DB;
   border: none;

--- a/theme/yeti.css
+++ b/theme/yeti.css
@@ -40,5 +40,5 @@
 .cm-s-yeti span.cm-property { color: #a074c4; }
 .cm-s-yeti span.cm-builtin { color: #a074c4; }
 .cm-s-yeti span.cm-variable-3 { color: #96c0d8; }
-.cm-s-yeti .CodeMirror-activeline-background {background: #E7E4E0 !important;}
-.cm-s-yeti .CodeMirror-matchingbracket { text-decoration: underline;}
+.cm-s-yeti .CodeMirror-activeline-background { background: #E7E4E0 !important; }
+.cm-s-yeti .CodeMirror-matchingbracket { text-decoration: underline; }

--- a/theme/zenburn.css
+++ b/theme/zenburn.css
@@ -33,5 +33,5 @@
 .cm-s-zenburn span.CodeMirror-nonmatchingbracket { border-bottom: 1px solid; background: none; }
 .cm-s-zenburn .CodeMirror-activeline { background: #000000; }
 .cm-s-zenburn .CodeMirror-activeline-background { background: #000000; }
-.cm-s-zenburn .CodeMirror-selected { background: #545454; }
-.cm-s-zenburn .CodeMirror-focused .CodeMirror-selected { background: #4f4f4f; }
+.cm-s-zenburn div.CodeMirror-selected { background: #545454; }
+.cm-s-zenburn .CodeMirror-focused div.CodeMirror-selected { background: #4f4f4f; }


### PR DESCRIPTION
The formatting/design of the CSS in the themes directory is a bit all over the place, so I tried to tidy it up. I broke this change up into 4 commits, the first two being less controversial than the second two.

1. Four themes (seti, yeti, dracula, and material) use three-line css definitions where every other theme uses one-liners. I switched those four to use one-line definitions as well.
2. A fair amount of themes use `!important` in their `.CodeMirror-selected` definitions. Since https://github.com/codemirror/CodeMirror/commit/e1e9aca0c7c90695d600b0cf38e2798f2de9f83d got checked in, this is unnecessary (and problematic for users to override). Now, all themes that specify a rule for `.CodeMirror-selected` do so with `.themename div.CodeMirror-selected` and no `!important` clause.
3. Some themes have definitions like `.cm-s-material span.cm-meta{ color: #80CBC4; }` where there is no space between `meta` and the opening brace. This commit adds spaces there.
4. This is probably the most contentious change. The majority of one-line css definitions look like `.selector { attr: value; }`, that is, with one space after the selector, one after the opening brace, and one before the closing brace. However, there are a lot of nonstandard one-liners, the most common form being something like `.selector {attr:value}`. This commit ensures that all the definitions have the same spacing and that a semicolon is present.

Feel free to pick and choose if you don't want all of this! The last commit definitely touches a lot of lines, so I can understand not wanting to dirty up the blame log for essentially a cosmetic change.