### PR TITLE
Reduce css specificity for cursor and activeline classes

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -41,14 +41,17 @@
 
 /* CURSOR */
 
-.CodeMirror div.CodeMirror-cursor {
+.CodeMirror-cursor {
+  position: absolute;
+  border-right: none;
+  width: 0;
   border-left: 1px solid black;
 }
 /* Shown when moving in bi-directional text */
 .CodeMirror div.CodeMirror-secondarycursor {
   border-left: 1px solid silver;
 }
-.CodeMirror.cm-fat-cursor div.CodeMirror-cursor {
+.CodeMirror.cm-fat-cursor .CodeMirror-cursor {
   width: auto;
   border: 0;
   background: #7e7;
@@ -80,9 +83,6 @@
   50% { background-color: transparent; }
   100% {}
 }
-
-/* Can style cursor different in overwrite (non-insert) mode */
-div.CodeMirror-overwrite div.CodeMirror-cursor {}
 
 .cm-tab { display: inline-block; text-decoration: inherit; }
 
@@ -285,12 +285,6 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   visibility: hidden;
 }
 .CodeMirror-measure pre { position: static; }
-
-.CodeMirror div.CodeMirror-cursor {
-  position: absolute;
-  border-right: none;
-  width: 0;
-}
 
 div.CodeMirror-cursors {
   visibility: hidden;

--- a/theme/3024-day.css
+++ b/theme/3024-day.css
@@ -19,7 +19,7 @@
 .cm-s-3024-day .CodeMirror-guttermarker-subtle { color: #807d7c; }
 .cm-s-3024-day .CodeMirror-linenumber { color: #807d7c; }
 
-.cm-s-3024-day .CodeMirror-cursor { border-left: 1px solid #5c5855 !important; }
+.cm-s-3024-day .CodeMirror-cursor { border-left: 1px solid #5c5855; }
 
 .cm-s-3024-day span.cm-comment { color: #cdab53; }
 .cm-s-3024-day span.cm-atom { color: #a16a94; }
@@ -37,5 +37,5 @@
 .cm-s-3024-day span.cm-link { color: #a16a94; }
 .cm-s-3024-day span.cm-error { background: #db2d20; color: #5c5855; }
 
-.cm-s-3024-day .CodeMirror-activeline-background { background: #e8f2ff !important; }
+.cm-s-3024-day .CodeMirror-activeline-background { background: #e8f2ff; }
 .cm-s-3024-day .CodeMirror-matchingbracket { text-decoration: underline; color: #a16a94 !important; }

--- a/theme/3024-night.css
+++ b/theme/3024-night.css
@@ -17,7 +17,7 @@
 .cm-s-3024-night .CodeMirror-guttermarker-subtle { color: #5c5855; }
 .cm-s-3024-night .CodeMirror-linenumber { color: #5c5855; }
 
-.cm-s-3024-night .CodeMirror-cursor { border-left: 1px solid #807d7c !important; }
+.cm-s-3024-night .CodeMirror-cursor { border-left: 1px solid #807d7c; }
 
 .cm-s-3024-night span.cm-comment { color: #cdab53; }
 .cm-s-3024-night span.cm-atom { color: #a16a94; }
@@ -35,5 +35,5 @@
 .cm-s-3024-night span.cm-link { color: #a16a94; }
 .cm-s-3024-night span.cm-error { background: #db2d20; color: #807d7c; }
 
-.cm-s-3024-night .CodeMirror-activeline-background { background: #2F2F2F !important; }
+.cm-s-3024-night .CodeMirror-activeline-background { background: #2F2F2F; }
 .cm-s-3024-night .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/ambiance.css
+++ b/theme/ambiance.css
@@ -62,9 +62,7 @@
 .cm-s-ambiance .CodeMirror-guttermarker { color: #aaa; }
 .cm-s-ambiance .CodeMirror-guttermarker-subtle { color: #111; }
 
-.cm-s-ambiance .CodeMirror-lines .CodeMirror-cursor {
-  border-left: 1px solid #7991E8;
-}
+.cm-s-ambiance .CodeMirror-cursor { border-left: 1px solid #7991E8; }
 
 .cm-s-ambiance .CodeMirror-activeline-background {
   background: none repeat scroll 0% 0% rgba(255, 255, 255, 0.031);

--- a/theme/base16-dark.css
+++ b/theme/base16-dark.css
@@ -16,7 +16,7 @@
 .cm-s-base16-dark .CodeMirror-guttermarker { color: #ac4142; }
 .cm-s-base16-dark .CodeMirror-guttermarker-subtle { color: #505050; }
 .cm-s-base16-dark .CodeMirror-linenumber { color: #505050; }
-.cm-s-base16-dark .CodeMirror-cursor { border-left: 1px solid #b0b0b0 !important; }
+.cm-s-base16-dark .CodeMirror-cursor { border-left: 1px solid #b0b0b0; }
 
 .cm-s-base16-dark span.cm-comment { color: #8f5536; }
 .cm-s-base16-dark span.cm-atom { color: #aa759f; }
@@ -34,5 +34,5 @@
 .cm-s-base16-dark span.cm-link { color: #aa759f; }
 .cm-s-base16-dark span.cm-error { background: #ac4142; color: #b0b0b0; }
 
-.cm-s-base16-dark .CodeMirror-activeline-background { background: #202020 !important; }
+.cm-s-base16-dark .CodeMirror-activeline-background { background: #202020; }
 .cm-s-base16-dark .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/base16-light.css
+++ b/theme/base16-light.css
@@ -16,7 +16,7 @@
 .cm-s-base16-light .CodeMirror-guttermarker { color: #ac4142; }
 .cm-s-base16-light .CodeMirror-guttermarker-subtle { color: #b0b0b0; }
 .cm-s-base16-light .CodeMirror-linenumber { color: #b0b0b0; }
-.cm-s-base16-light .CodeMirror-cursor { border-left: 1px solid #505050 !important; }
+.cm-s-base16-light .CodeMirror-cursor { border-left: 1px solid #505050; }
 
 .cm-s-base16-light span.cm-comment { color: #8f5536; }
 .cm-s-base16-light span.cm-atom { color: #aa759f; }
@@ -34,5 +34,5 @@
 .cm-s-base16-light span.cm-link { color: #aa759f; }
 .cm-s-base16-light span.cm-error { background: #ac4142; color: #505050; }
 
-.cm-s-base16-light .CodeMirror-activeline-background { background: #DDDCDC !important; }
+.cm-s-base16-light .CodeMirror-activeline-background { background: #DDDCDC; }
 .cm-s-base16-light .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/blackboard.css
+++ b/theme/blackboard.css
@@ -8,7 +8,7 @@
 .cm-s-blackboard .CodeMirror-guttermarker { color: #FBDE2D; }
 .cm-s-blackboard .CodeMirror-guttermarker-subtle { color: #888; }
 .cm-s-blackboard .CodeMirror-linenumber { color: #888; }
-.cm-s-blackboard .CodeMirror-cursor { border-left: 1px solid #A7A7A7 !important; }
+.cm-s-blackboard .CodeMirror-cursor { border-left: 1px solid #A7A7A7; }
 
 .cm-s-blackboard .cm-keyword { color: #FBDE2D; }
 .cm-s-blackboard .cm-atom { color: #D8FA3C; }
@@ -28,5 +28,5 @@
 .cm-s-blackboard .cm-link { color: #8DA6CE; }
 .cm-s-blackboard .cm-error { background: #9D1E15; color: #F8F8F8; }
 
-.cm-s-blackboard .CodeMirror-activeline-background { background: #3C3636 !important; }
+.cm-s-blackboard .CodeMirror-activeline-background { background: #3C3636; }
 .cm-s-blackboard .CodeMirror-matchingbracket { outline:1px solid grey;color:white !important; }

--- a/theme/cobalt.css
+++ b/theme/cobalt.css
@@ -6,7 +6,7 @@
 .cm-s-cobalt .CodeMirror-guttermarker { color: #ffee80; }
 .cm-s-cobalt .CodeMirror-guttermarker-subtle { color: #d0d0d0; }
 .cm-s-cobalt .CodeMirror-linenumber { color: #d0d0d0; }
-.cm-s-cobalt .CodeMirror-cursor { border-left: 1px solid white !important; }
+.cm-s-cobalt .CodeMirror-cursor { border-left: 1px solid white; }
 
 .cm-s-cobalt span.cm-comment { color: #08f; }
 .cm-s-cobalt span.cm-atom { color: #845dc4; }
@@ -21,5 +21,5 @@
 .cm-s-cobalt span.cm-link { color: #845dc4; }
 .cm-s-cobalt span.cm-error { color: #9d1e15; }
 
-.cm-s-cobalt .CodeMirror-activeline-background { background: #002D57 !important; }
+.cm-s-cobalt .CodeMirror-activeline-background { background: #002D57; }
 .cm-s-cobalt .CodeMirror-matchingbracket { outline:1px solid grey;color:white !important; }

--- a/theme/colorforth.css
+++ b/theme/colorforth.css
@@ -3,7 +3,7 @@
 .cm-s-colorforth .CodeMirror-guttermarker { color: #FFBD40; }
 .cm-s-colorforth .CodeMirror-guttermarker-subtle { color: #78846f; }
 .cm-s-colorforth .CodeMirror-linenumber { color: #bababa; }
-.cm-s-colorforth .CodeMirror-cursor { border-left: 1px solid white !important; }
+.cm-s-colorforth .CodeMirror-cursor { border-left: 1px solid white; }
 
 .cm-s-colorforth span.cm-comment     { color: #ededed; }
 .cm-s-colorforth span.cm-def         { color: #ff1c1c; font-weight:bold; }
@@ -30,4 +30,4 @@
 
 .cm-s-colorforth span.cm-compilation { background: rgba(255, 255, 255, 0.12); }
 
-.cm-s-colorforth .CodeMirror-activeline-background { background: #253540 !important; }
+.cm-s-colorforth .CodeMirror-activeline-background { background: #253540; }

--- a/theme/dracula.css
+++ b/theme/dracula.css
@@ -14,7 +14,7 @@
   border: none;
 }
 .cm-s-dracula .CodeMirror-gutters { color: #282a36; }
-.cm-s-dracula .CodeMirror-cursor { border-left: solid thin #f8f8f0 !important; }
+.cm-s-dracula .CodeMirror-cursor { border-left: solid thin #f8f8f0; }
 .cm-s-dracula .CodeMirror-linenumber { color: #6D8A88; }
 .cm-s-dracula.CodeMirror-focused div.CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
 .cm-s-dracula .CodeMirror-line::selection, .cm-s-dracula .CodeMirror-line > span::selection, .cm-s-dracula .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
@@ -37,5 +37,5 @@
 .cm-s-dracula span.cm-builtin { color: #50fa7b; }
 .cm-s-dracula span.cm-variable-3 { color: #50fa7b; }
 
-.cm-s-dracula .CodeMirror-activeline-background { background: rgba(255,255,255,0.1) !important; }
+.cm-s-dracula .CodeMirror-activeline-background { background: rgba(255,255,255,0.1); }
 .cm-s-dracula .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/eclipse.css
+++ b/theme/eclipse.css
@@ -19,5 +19,5 @@
 .cm-s-eclipse span.cm-link { color: #219; }
 .cm-s-eclipse span.cm-error { color: #f00; }
 
-.cm-s-eclipse .CodeMirror-activeline-background { background: #e8f2ff !important; }
+.cm-s-eclipse .CodeMirror-activeline-background { background: #e8f2ff; }
 .cm-s-eclipse .CodeMirror-matchingbracket { outline:1px solid grey; color:black !important; }

--- a/theme/elegant.css
+++ b/theme/elegant.css
@@ -9,5 +9,5 @@
 .cm-s-elegant span.cm-link { color: #762; }
 .cm-s-elegant span.cm-error { background-color: #fdd; }
 
-.cm-s-elegant .CodeMirror-activeline-background { background: #e8f2ff !important; }
+.cm-s-elegant .CodeMirror-activeline-background { background: #e8f2ff; }
 .cm-s-elegant .CodeMirror-matchingbracket { outline:1px solid grey; color:black !important; }

--- a/theme/erlang-dark.css
+++ b/theme/erlang-dark.css
@@ -6,7 +6,7 @@
 .cm-s-erlang-dark .CodeMirror-guttermarker { color: white; }
 .cm-s-erlang-dark .CodeMirror-guttermarker-subtle { color: #d0d0d0; }
 .cm-s-erlang-dark .CodeMirror-linenumber { color: #d0d0d0; }
-.cm-s-erlang-dark .CodeMirror-cursor { border-left: 1px solid white !important; }
+.cm-s-erlang-dark .CodeMirror-cursor { border-left: 1px solid white; }
 
 .cm-s-erlang-dark span.cm-quote      { color: #ccc; }
 .cm-s-erlang-dark span.cm-atom       { color: #f133f1; }
@@ -30,5 +30,5 @@
 .cm-s-erlang-dark span.cm-variable-3 { color: #ccc; }
 .cm-s-erlang-dark span.cm-error      { color: #9d1e15; }
 
-.cm-s-erlang-dark .CodeMirror-activeline-background { background: #013461 !important; }
+.cm-s-erlang-dark .CodeMirror-activeline-background { background: #013461; }
 .cm-s-erlang-dark .CodeMirror-matchingbracket { outline:1px solid grey; color:white !important; }

--- a/theme/icecoder.css
+++ b/theme/icecoder.css
@@ -35,8 +35,8 @@ ICEcoder default theme by Matt Pass, used in code editor available at https://ic
 .cm-s-icecoder span.cm-link { color: #e1c76e; }                    /* yellow */
 .cm-s-icecoder span.cm-error { color: #d00; }                      /* red */
 
-.cm-s-icecoder .CodeMirror-cursor { border-left: 1px solid white !important; }
-.cm-s-icecoder div.CodeMirror-selected { color: #fff !important; background: #037; }
+.cm-s-icecoder .CodeMirror-cursor { border-left: 1px solid white; }
+.cm-s-icecoder div.CodeMirror-selected { color: #fff; background: #037; }
 .cm-s-icecoder .CodeMirror-gutters { background: #141612; min-width: 41px; border-right: 0; }
 .cm-s-icecoder .CodeMirror-linenumber { color: #555; cursor: default; }
 .cm-s-icecoder .CodeMirror-matchingbracket { border: 1px solid grey; color: black !important; }

--- a/theme/lesser-dark.css
+++ b/theme/lesser-dark.css
@@ -9,7 +9,7 @@ Ported to CodeMirror by Peter Kroon
 .cm-s-lesser-dark div.CodeMirror-selected { background: #45443B; } /* 33322B*/
 .cm-s-lesser-dark .CodeMirror-line::selection, .cm-s-lesser-dark .CodeMirror-line > span::selection, .cm-s-lesser-dark .CodeMirror-line > span > span::selection { background: rgba(69, 68, 59, .99); }
 .cm-s-lesser-dark .CodeMirror-line::-moz-selection, .cm-s-lesser-dark .CodeMirror-line > span::-moz-selection, .cm-s-lesser-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(69, 68, 59, .99); }
-.cm-s-lesser-dark .CodeMirror-cursor { border-left: 1px solid white !important; }
+.cm-s-lesser-dark .CodeMirror-cursor { border-left: 1px solid white; }
 .cm-s-lesser-dark pre { padding: 0 8px; }/*editable code holder*/
 
 .cm-s-lesser-dark.CodeMirror span.CodeMirror-matchingbracket { color: #7EFC7E; }/*65FC65*/
@@ -43,5 +43,5 @@ Ported to CodeMirror by Peter Kroon
 .cm-s-lesser-dark span.cm-link { color: #00c; }
 .cm-s-lesser-dark span.cm-error { color: #9d1e15; }
 
-.cm-s-lesser-dark .CodeMirror-activeline-background { background: #3C3A3A !important; }
+.cm-s-lesser-dark .CodeMirror-activeline-background { background: #3C3A3A; }
 .cm-s-lesser-dark .CodeMirror-matchingbracket { outline:1px solid grey; color:white !important; }

--- a/theme/liquibyte.css
+++ b/theme/liquibyte.css
@@ -24,7 +24,7 @@
 .cm-s-liquibyte .CodeMirror-guttermarker {  }
 .cm-s-liquibyte .CodeMirror-guttermarker-subtle {  }
 .cm-s-liquibyte .CodeMirror-linenumber { color: #606060; padding-left: 0; }
-.cm-s-liquibyte .CodeMirror-cursor { border-left: 1px solid #eee !important; }
+.cm-s-liquibyte .CodeMirror-cursor { border-left: 1px solid #eee; }
 
 .cm-s-liquibyte span.cm-comment     { color: #008000; }
 .cm-s-liquibyte span.cm-def         { color: #ffaf40; font-weight: bold; }
@@ -51,7 +51,7 @@
 
 .cm-s-liquibyte span.cm-compilation { background-color: rgba(255, 255, 255, 0.12); }
 
-.cm-s-liquibyte .CodeMirror-activeline-background { background-color: rgba(0, 255, 0, 0.15) !important; }
+.cm-s-liquibyte .CodeMirror-activeline-background { background-color: rgba(0, 255, 0, 0.15); }
 
 /* Default styles for common addons */
 div.CodeMirror span.CodeMirror-matchingbracket { color: #0f0; font-weight: bold; }

--- a/theme/material.css
+++ b/theme/material.css
@@ -17,36 +17,36 @@
   border: none;
 }
 .cm-s-material .CodeMirror-guttermarker, .cm-s-material .CodeMirror-guttermarker-subtle, .cm-s-material .CodeMirror-linenumber { color: rgb(83,127,126); }
-.cm-s-material .CodeMirror-cursor { border-left: 1px solid #f8f8f0 !important; }
+.cm-s-material .CodeMirror-cursor { border-left: 1px solid #f8f8f0; }
 .cm-s-material div.CodeMirror-selected { background: rgba(255, 255, 255, 0.15); }
 .cm-s-material.CodeMirror-focused div.CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
 .cm-s-material .CodeMirror-line::selection, .cm-s-material .CodeMirror-line > span::selection, .cm-s-material .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
 .cm-s-material .CodeMirror-line::-moz-selection, .cm-s-material .CodeMirror-line > span::-moz-selection, .cm-s-material .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
 
-.CodeMirror-activeline-background { background: rgba(0, 0, 0, 0) !important; }
-.cm-s-material span.cm-keyword { color: rgba(199, 146, 234, 1); }
-.cm-s-material span.cm-operator { color: rgba(233, 237, 237, 1); }
-.cm-s-material span.cm-variable-2 { color: #80CBC4; }
-.cm-s-material span.cm-variable-3 { color: #82B1FF; }
-.cm-s-material span.cm-builtin { color: #DECB6B; }
-.cm-s-material span.cm-atom { color: #F77669; }
-.cm-s-material span.cm-number { color: #F77669; }
-.cm-s-material span.cm-def { color: rgba(233, 237, 237, 1); }
-.cm-s-material span.cm-error {
+.cm-s-material .CodeMirror-activeline-background { background: rgba(0, 0, 0, 0); }
+.cm-s-material .cm-keyword { color: rgba(199, 146, 234, 1); }
+.cm-s-material .cm-operator { color: rgba(233, 237, 237, 1); }
+.cm-s-material .cm-variable-2 { color: #80CBC4; }
+.cm-s-material .cm-variable-3 { color: #82B1FF; }
+.cm-s-material .cm-builtin { color: #DECB6B; }
+.cm-s-material .cm-atom { color: #F77669; }
+.cm-s-material .cm-number { color: #F77669; }
+.cm-s-material .cm-def { color: rgba(233, 237, 237, 1); }
+.cm-s-material .cm-error {
   color: rgba(255, 255, 255, 1.0);
   background-color: #EC5F67;
 }
-.cm-s-material span.cm-string { color: #C3E88D; }
-.cm-s-material span.cm-string-2 { color: #80CBC4; }
-.cm-s-material span.cm-comment { color: #546E7A; }
-.cm-s-material span.cm-variable { color: #82B1FF; }
-.cm-s-material span.cm-tag { color: #80CBC4; }
-.cm-s-material span.cm-meta { color: #80CBC4; }
-.cm-s-material span.cm-attribute { color: #FFCB6B; }
-.cm-s-material span.cm-property { color: #80CBAE; }
-.cm-s-material span.cm-qualifier { color: #DECB6B; }
-.cm-s-material span.cm-variable-3 { color: #DECB6B; }
-.cm-s-material span.cm-tag { color: rgba(255, 83, 112, 1); }
+.cm-s-material .cm-string { color: #C3E88D; }
+.cm-s-material .cm-string-2 { color: #80CBC4; }
+.cm-s-material .cm-comment { color: #546E7A; }
+.cm-s-material .cm-variable { color: #82B1FF; }
+.cm-s-material .cm-tag { color: #80CBC4; }
+.cm-s-material .cm-meta { color: #80CBC4; }
+.cm-s-material .cm-attribute { color: #FFCB6B; }
+.cm-s-material .cm-property { color: #80CBAE; }
+.cm-s-material .cm-qualifier { color: #DECB6B; }
+.cm-s-material .cm-variable-3 { color: #DECB6B; }
+.cm-s-material .cm-tag { color: rgba(255, 83, 112, 1); }
 .cm-s-material .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/theme/mbo.css
+++ b/theme/mbo.css
@@ -12,7 +12,7 @@
 .cm-s-mbo .CodeMirror-guttermarker { color: white; }
 .cm-s-mbo .CodeMirror-guttermarker-subtle { color: grey; }
 .cm-s-mbo .CodeMirror-linenumber { color: #dadada; }
-.cm-s-mbo .CodeMirror-cursor { border-left: 1px solid #ffffec !important; }
+.cm-s-mbo .CodeMirror-cursor { border-left: 1px solid #ffffec; }
 
 .cm-s-mbo span.cm-comment { color: #95958a; }
 .cm-s-mbo span.cm-atom { color: #00a8c6; }
@@ -32,6 +32,6 @@
 .cm-s-mbo span.cm-error { border-bottom: #636363; color: #ffffec; }
 .cm-s-mbo span.cm-qualifier { color: #ffffec; }
 
-.cm-s-mbo .CodeMirror-activeline-background { background: #494b41 !important; }
+.cm-s-mbo .CodeMirror-activeline-background { background: #494b41; }
 .cm-s-mbo .CodeMirror-matchingbracket { color: #222 !important; }
 .cm-s-mbo .CodeMirror-matchingtag { background: rgba(255, 255, 255, .37); }

--- a/theme/mdn-like.css
+++ b/theme/mdn-like.css
@@ -14,7 +14,7 @@
 
 .cm-s-mdn-like .CodeMirror-gutters { background: #f8f8f8; border-left: 6px solid rgba(0,83,159,0.65); color: #333; }
 .cm-s-mdn-like .CodeMirror-linenumber { color: #aaa; padding-left: 8px; }
-div.cm-s-mdn-like .CodeMirror-cursor { border-left: 2px solid #222; }
+.cm-s-mdn-like .CodeMirror-cursor { border-left: 2px solid #222; }
 
 .cm-s-mdn-like .cm-keyword { color: #6262FF; }
 .cm-s-mdn-like .cm-atom { color: #F90; }

--- a/theme/midnight.css
+++ b/theme/midnight.css
@@ -5,7 +5,7 @@
 .cm-s-midnight.CodeMirror-focused span.CodeMirror-matchhighlight { background: #314D67 !important; }
 
 /*<!--activeline-->*/
-.cm-s-midnight .CodeMirror-activeline-background { background: #253540 !important; }
+.cm-s-midnight .CodeMirror-activeline-background { background: #253540; }
 
 .cm-s-midnight.CodeMirror {
     background: #0F192A;
@@ -21,9 +21,7 @@
 .cm-s-midnight .CodeMirror-guttermarker { color: white; }
 .cm-s-midnight .CodeMirror-guttermarker-subtle { color: #d0d0d0; }
 .cm-s-midnight .CodeMirror-linenumber { color: #D0D0D0; }
-.cm-s-midnight .CodeMirror-cursor {
-    border-left: 1px solid #F8F8F0 !important;
-}
+.cm-s-midnight .CodeMirror-cursor { border-left: 1px solid #F8F8F0; }
 
 .cm-s-midnight span.cm-comment { color: #428BDD; }
 .cm-s-midnight span.cm-atom { color: #AE81FF; }

--- a/theme/monokai.css
+++ b/theme/monokai.css
@@ -8,7 +8,7 @@
 .cm-s-monokai .CodeMirror-guttermarker { color: white; }
 .cm-s-monokai .CodeMirror-guttermarker-subtle { color: #d0d0d0; }
 .cm-s-monokai .CodeMirror-linenumber { color: #d0d0d0; }
-.cm-s-monokai .CodeMirror-cursor { border-left: 1px solid #f8f8f0 !important; }
+.cm-s-monokai .CodeMirror-cursor { border-left: 1px solid #f8f8f0; }
 
 .cm-s-monokai span.cm-comment { color: #75715e; }
 .cm-s-monokai span.cm-atom { color: #ae81ff; }
@@ -28,7 +28,7 @@
 .cm-s-monokai span.cm-link { color: #ae81ff; }
 .cm-s-monokai span.cm-error { background: #f92672; color: #f8f8f0; }
 
-.cm-s-monokai .CodeMirror-activeline-background { background: #373831 !important; }
+.cm-s-monokai .CodeMirror-activeline-background { background: #373831; }
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;

--- a/theme/neat.css
+++ b/theme/neat.css
@@ -8,5 +8,5 @@
 .cm-s-neat span.cm-meta { color: #555; }
 .cm-s-neat span.cm-link { color: #3a3; }
 
-.cm-s-neat .CodeMirror-activeline-background { background: #e8f2ff !important; }
+.cm-s-neat .CodeMirror-activeline-background { background: #e8f2ff; }
 .cm-s-neat .CodeMirror-matchingbracket { outline:1px solid grey; color:black !important; }

--- a/theme/neo.css
+++ b/theme/neo.css
@@ -35,7 +35,7 @@
 .cm-s-neo .CodeMirror-guttermarker { color: #1d75b3; }
 .cm-s-neo .CodeMirror-guttermarker-subtle { color: #e0e2e5; }
 
-.cm-s-neo div.CodeMirror-cursor {
+.cm-s-neo .CodeMirror-cursor {
   width: auto;
   border: 0;
   background: rgba(155,157,162,0.37);

--- a/theme/night.css
+++ b/theme/night.css
@@ -8,7 +8,7 @@
 .cm-s-night .CodeMirror-guttermarker { color: white; }
 .cm-s-night .CodeMirror-guttermarker-subtle { color: #bbb; }
 .cm-s-night .CodeMirror-linenumber { color: #f8f8f8; }
-.cm-s-night .CodeMirror-cursor { border-left: 1px solid white !important; }
+.cm-s-night .CodeMirror-cursor { border-left: 1px solid white; }
 
 .cm-s-night span.cm-comment { color: #6900a1; }
 .cm-s-night span.cm-atom { color: #845dc4; }
@@ -24,5 +24,5 @@
 .cm-s-night span.cm-link { color: #845dc4; }
 .cm-s-night span.cm-error { color: #9d1e15; }
 
-.cm-s-night .CodeMirror-activeline-background { background: #1C005A !important; }
+.cm-s-night .CodeMirror-activeline-background { background: #1C005A; }
 .cm-s-night .CodeMirror-matchingbracket { outline:1px solid grey; color:white !important; }

--- a/theme/paraiso-dark.css
+++ b/theme/paraiso-dark.css
@@ -16,7 +16,7 @@
 .cm-s-paraiso-dark .CodeMirror-guttermarker { color: #ef6155; }
 .cm-s-paraiso-dark .CodeMirror-guttermarker-subtle { color: #776e71; }
 .cm-s-paraiso-dark .CodeMirror-linenumber { color: #776e71; }
-.cm-s-paraiso-dark .CodeMirror-cursor { border-left: 1px solid #8d8687 !important; }
+.cm-s-paraiso-dark .CodeMirror-cursor { border-left: 1px solid #8d8687; }
 
 .cm-s-paraiso-dark span.cm-comment { color: #e96ba8; }
 .cm-s-paraiso-dark span.cm-atom { color: #815ba4; }
@@ -34,5 +34,5 @@
 .cm-s-paraiso-dark span.cm-link { color: #815ba4; }
 .cm-s-paraiso-dark span.cm-error { background: #ef6155; color: #8d8687; }
 
-.cm-s-paraiso-dark .CodeMirror-activeline-background { background: #4D344A !important; }
+.cm-s-paraiso-dark .CodeMirror-activeline-background { background: #4D344A; }
 .cm-s-paraiso-dark .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/paraiso-light.css
+++ b/theme/paraiso-light.css
@@ -16,7 +16,7 @@
 .cm-s-paraiso-light .CodeMirror-guttermarker { color: black; }
 .cm-s-paraiso-light .CodeMirror-guttermarker-subtle { color: #8d8687; }
 .cm-s-paraiso-light .CodeMirror-linenumber { color: #8d8687; }
-.cm-s-paraiso-light .CodeMirror-cursor { border-left: 1px solid #776e71 !important; }
+.cm-s-paraiso-light .CodeMirror-cursor { border-left: 1px solid #776e71; }
 
 .cm-s-paraiso-light span.cm-comment { color: #e96ba8; }
 .cm-s-paraiso-light span.cm-atom { color: #815ba4; }
@@ -34,5 +34,5 @@
 .cm-s-paraiso-light span.cm-link { color: #815ba4; }
 .cm-s-paraiso-light span.cm-error { background: #ef6155; color: #776e71; }
 
-.cm-s-paraiso-light .CodeMirror-activeline-background { background: #CFD1C4 !important; }
+.cm-s-paraiso-light .CodeMirror-activeline-background { background: #CFD1C4; }
 .cm-s-paraiso-light .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/pastel-on-dark.css
+++ b/theme/pastel-on-dark.css
@@ -25,7 +25,7 @@
 .cm-s-pastel-on-dark .CodeMirror-guttermarker { color: white; }
 .cm-s-pastel-on-dark .CodeMirror-guttermarker-subtle { color: #8F938F; }
 .cm-s-pastel-on-dark .CodeMirror-linenumber { color: #8F938F; }
-.cm-s-pastel-on-dark .CodeMirror-cursor { border-left: 1px solid #A7A7A7 !important; }
+.cm-s-pastel-on-dark .CodeMirror-cursor { border-left: 1px solid #A7A7A7; }
 .cm-s-pastel-on-dark span.cm-comment { color: #A6C6FF; }
 .cm-s-pastel-on-dark span.cm-atom { color: #DE8E30; }
 .cm-s-pastel-on-dark span.cm-number { color: #CCCCCC; }
@@ -45,7 +45,7 @@
 	background: #757aD8;
 	color: #f8f8f0;
 }
-.cm-s-pastel-on-dark .CodeMirror-activeline-background { background: rgba(255, 255, 255, 0.031) !important; }
+.cm-s-pastel-on-dark .CodeMirror-activeline-background { background: rgba(255, 255, 255, 0.031); }
 .cm-s-pastel-on-dark .CodeMirror-matchingbracket {
 	border: 1px solid rgba(255,255,255,0.25);
 	color: #8F938F !important;

--- a/theme/rubyblue.css
+++ b/theme/rubyblue.css
@@ -6,7 +6,7 @@
 .cm-s-rubyblue .CodeMirror-guttermarker { color: white; }
 .cm-s-rubyblue .CodeMirror-guttermarker-subtle { color: #3E7087; }
 .cm-s-rubyblue .CodeMirror-linenumber { color: white; }
-.cm-s-rubyblue .CodeMirror-cursor { border-left: 1px solid white !important; }
+.cm-s-rubyblue .CodeMirror-cursor { border-left: 1px solid white; }
 
 .cm-s-rubyblue span.cm-comment { color: #999; font-style:italic; line-height: 1em; }
 .cm-s-rubyblue span.cm-atom { color: #F4C20B; }
@@ -22,4 +22,4 @@
 .cm-s-rubyblue span.cm-builtin, .cm-s-rubyblue span.cm-special { color: #FF9D00; }
 .cm-s-rubyblue span.cm-error { color: #AF2018; }
 
-.cm-s-rubyblue .CodeMirror-activeline-background { background: #173047 !important; }
+.cm-s-rubyblue .CodeMirror-activeline-background { background: #173047; }

--- a/theme/seti.css
+++ b/theme/seti.css
@@ -18,7 +18,7 @@
   background-color: #0E1112;
   border: none;
 }
-.cm-s-seti .CodeMirror-cursor { border-left: solid thin #f8f8f0 !important; }
+.cm-s-seti .CodeMirror-cursor { border-left: solid thin #f8f8f0; }
 .cm-s-seti .CodeMirror-linenumber { color: #6D8A88; }
 .cm-s-seti.CodeMirror-focused div.CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
 .cm-s-seti .CodeMirror-line::selection, .cm-s-seti .CodeMirror-line > span::selection, .cm-s-seti .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
@@ -40,5 +40,5 @@
 .cm-s-seti span.cm-property { color: #a074c4; }
 .cm-s-seti span.cm-variable-3 { color: #9fca56; }
 .cm-s-seti span.cm-builtin { color: #9fca56; }
-.cm-s-seti .CodeMirror-activeline-background { background: #101213 !important; }
+.cm-s-seti .CodeMirror-activeline-background { background: #101213; }
 .cm-s-seti .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/solarized.css
+++ b/theme/solarized.css
@@ -149,9 +149,7 @@ http://ethanschoonover.com/solarized/img/solarized-palette.png
   color: #586e75;
 }
 
-.cm-s-solarized .CodeMirror-lines .CodeMirror-cursor {
-  border-left: 1px solid #819090;
-}
+.cm-s-solarized .CodeMirror-cursor { border-left: 1px solid #819090; }
 
 /*
 Active line. Negative margin compensates left padding of the text in the

--- a/theme/the-matrix.css
+++ b/theme/the-matrix.css
@@ -6,7 +6,7 @@
 .cm-s-the-matrix .CodeMirror-guttermarker { color: #0f0; }
 .cm-s-the-matrix .CodeMirror-guttermarker-subtle { color: white; }
 .cm-s-the-matrix .CodeMirror-linenumber { color: #FFFFFF; }
-.cm-s-the-matrix .CodeMirror-cursor { border-left: 1px solid #00FF00 !important; }
+.cm-s-the-matrix .CodeMirror-cursor { border-left: 1px solid #00FF00; }
 
 .cm-s-the-matrix span.cm-keyword { color: #008803; font-weight: bold; }
 .cm-s-the-matrix span.cm-atom { color: #3FF; }

--- a/theme/tomorrow-night-bright.css
+++ b/theme/tomorrow-night-bright.css
@@ -13,7 +13,7 @@
 .cm-s-tomorrow-night-bright .CodeMirror-guttermarker { color: #e78c45; }
 .cm-s-tomorrow-night-bright .CodeMirror-guttermarker-subtle { color: #777; }
 .cm-s-tomorrow-night-bright .CodeMirror-linenumber { color: #424242; }
-.cm-s-tomorrow-night-bright .CodeMirror-cursor { border-left: 1px solid #6A6A6A !important; }
+.cm-s-tomorrow-night-bright .CodeMirror-cursor { border-left: 1px solid #6A6A6A; }
 
 .cm-s-tomorrow-night-bright span.cm-comment { color: #d27b53; }
 .cm-s-tomorrow-night-bright span.cm-atom { color: #a16a94; }
@@ -31,5 +31,5 @@
 .cm-s-tomorrow-night-bright span.cm-link { color: #a16a94; }
 .cm-s-tomorrow-night-bright span.cm-error { background: #d54e53; color: #6A6A6A; }
 
-.cm-s-tomorrow-night-bright .CodeMirror-activeline-background { background: #2a2a2a !important; }
+.cm-s-tomorrow-night-bright .CodeMirror-activeline-background { background: #2a2a2a; }
 .cm-s-tomorrow-night-bright .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/tomorrow-night-eighties.css
+++ b/theme/tomorrow-night-eighties.css
@@ -16,7 +16,7 @@
 .cm-s-tomorrow-night-eighties .CodeMirror-guttermarker { color: #f2777a; }
 .cm-s-tomorrow-night-eighties .CodeMirror-guttermarker-subtle { color: #777; }
 .cm-s-tomorrow-night-eighties .CodeMirror-linenumber { color: #515151; }
-.cm-s-tomorrow-night-eighties .CodeMirror-cursor { border-left: 1px solid #6A6A6A !important; }
+.cm-s-tomorrow-night-eighties .CodeMirror-cursor { border-left: 1px solid #6A6A6A; }
 
 .cm-s-tomorrow-night-eighties span.cm-comment { color: #d27b53; }
 .cm-s-tomorrow-night-eighties span.cm-atom { color: #a16a94; }
@@ -34,5 +34,5 @@
 .cm-s-tomorrow-night-eighties span.cm-link { color: #a16a94; }
 .cm-s-tomorrow-night-eighties span.cm-error { background: #f2777a; color: #6A6A6A; }
 
-.cm-s-tomorrow-night-eighties .CodeMirror-activeline-background { background: #343600 !important; }
+.cm-s-tomorrow-night-eighties .CodeMirror-activeline-background { background: #343600; }
 .cm-s-tomorrow-night-eighties .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/twilight.css
+++ b/theme/twilight.css
@@ -7,7 +7,7 @@
 .cm-s-twilight .CodeMirror-guttermarker { color: white; }
 .cm-s-twilight .CodeMirror-guttermarker-subtle { color: #aaa; }
 .cm-s-twilight .CodeMirror-linenumber { color: #aaa; }
-.cm-s-twilight .CodeMirror-cursor { border-left: 1px solid white !important; }
+.cm-s-twilight .CodeMirror-cursor { border-left: 1px solid white; }
 
 .cm-s-twilight .cm-keyword { color: #f9ee98; } /**/
 .cm-s-twilight .cm-atom { color: #FC0; }
@@ -28,5 +28,5 @@
 .cm-s-twilight .cm-link { color:#ad9361; font-style:italic; text-decoration:none; } /**/
 .cm-s-twilight .cm-error { border-bottom: 1px solid red; }
 
-.cm-s-twilight .CodeMirror-activeline-background { background: #27282E !important; }
+.cm-s-twilight .CodeMirror-activeline-background { background: #27282E; }
 .cm-s-twilight .CodeMirror-matchingbracket { outline:1px solid grey; color:white !important; }

--- a/theme/vibrant-ink.css
+++ b/theme/vibrant-ink.css
@@ -9,7 +9,7 @@
 .cm-s-vibrant-ink .CodeMirror-guttermarker { color: white; }
 .cm-s-vibrant-ink .CodeMirror-guttermarker-subtle { color: #d0d0d0; }
 .cm-s-vibrant-ink .CodeMirror-linenumber { color: #d0d0d0; }
-.cm-s-vibrant-ink .CodeMirror-cursor { border-left: 1px solid white !important; }
+.cm-s-vibrant-ink .CodeMirror-cursor { border-left: 1px solid white; }
 
 .cm-s-vibrant-ink .cm-keyword { color: #CC7832; }
 .cm-s-vibrant-ink .cm-atom { color: #FC0; }
@@ -30,5 +30,5 @@
 .cm-s-vibrant-ink .cm-link { color: blue; }
 .cm-s-vibrant-ink .cm-error { border-bottom: 1px solid red; }
 
-.cm-s-vibrant-ink .CodeMirror-activeline-background { background: #27282E !important; }
+.cm-s-vibrant-ink .CodeMirror-activeline-background { background: #27282E; }
 .cm-s-vibrant-ink .CodeMirror-matchingbracket { outline:1px solid grey; color:white !important; }

--- a/theme/xq-dark.css
+++ b/theme/xq-dark.css
@@ -28,7 +28,7 @@ THE SOFTWARE.
 .cm-s-xq-dark .CodeMirror-guttermarker { color: #FFBD40; }
 .cm-s-xq-dark .CodeMirror-guttermarker-subtle { color: #f8f8f8; }
 .cm-s-xq-dark .CodeMirror-linenumber { color: #f8f8f8; }
-.cm-s-xq-dark .CodeMirror-cursor { border-left: 1px solid white !important; }
+.cm-s-xq-dark .CodeMirror-cursor { border-left: 1px solid white; }
 
 .cm-s-xq-dark span.cm-keyword { color: #FFBD40; }
 .cm-s-xq-dark span.cm-atom { color: #6C8CD5; }
@@ -49,5 +49,5 @@ THE SOFTWARE.
 .cm-s-xq-dark span.cm-attribute { color: #FFF700; }
 .cm-s-xq-dark span.cm-error { color: #f00; }
 
-.cm-s-xq-dark .CodeMirror-activeline-background { background: #27282E !important; }
+.cm-s-xq-dark .CodeMirror-activeline-background { background: #27282E; }
 .cm-s-xq-dark .CodeMirror-matchingbracket { outline:1px solid grey; color:white !important; }

--- a/theme/xq-light.css
+++ b/theme/xq-light.css
@@ -39,5 +39,5 @@ THE SOFTWARE.
 .cm-s-xq-light span.cm-attribute { color: #7F007F; }
 .cm-s-xq-light span.cm-error { color: #f00; }
 
-.cm-s-xq-light .CodeMirror-activeline-background { background: #e8f2ff !important; }
+.cm-s-xq-light .CodeMirror-activeline-background { background: #e8f2ff; }
 .cm-s-xq-light .CodeMirror-matchingbracket { outline:1px solid grey;color:black !important;background:yellow; }

--- a/theme/yeti.css
+++ b/theme/yeti.css
@@ -19,7 +19,7 @@
   background-color: #E5E1DB;
   border: none;
 }
-.cm-s-yeti .CodeMirror-cursor { border-left: solid thin #d1c9c0 !important; }
+.cm-s-yeti .CodeMirror-cursor { border-left: solid thin #d1c9c0; }
 .cm-s-yeti .CodeMirror-linenumber { color: #adaba6; }
 .cm-s-yeti.CodeMirror-focused div.CodeMirror-selected { background: #DCD8D2; }
 .cm-s-yeti .CodeMirror-line::selection, .cm-s-yeti .CodeMirror-line > span::selection, .cm-s-yeti .CodeMirror-line > span > span::selection { background: #DCD8D2; }
@@ -40,5 +40,5 @@
 .cm-s-yeti span.cm-property { color: #a074c4; }
 .cm-s-yeti span.cm-builtin { color: #a074c4; }
 .cm-s-yeti span.cm-variable-3 { color: #96c0d8; }
-.cm-s-yeti .CodeMirror-activeline-background { background: #E7E4E0 !important; }
+.cm-s-yeti .CodeMirror-activeline-background { background: #E7E4E0; }
 .cm-s-yeti .CodeMirror-matchingbracket { text-decoration: underline; }

--- a/theme/zenburn.css
+++ b/theme/zenburn.css
@@ -10,7 +10,7 @@
 
 .cm-s-zenburn .CodeMirror-gutters { background: #3f3f3f !important; }
 .cm-s-zenburn .CodeMirror-foldgutter-open, .CodeMirror-foldgutter-folded { color: #999; }
-.cm-s-zenburn .CodeMirror-cursor { border-left: 1px solid white !important; }
+.cm-s-zenburn .CodeMirror-cursor { border-left: 1px solid white; }
 .cm-s-zenburn { background-color: #3f3f3f; color: #dcdccc; }
 .cm-s-zenburn span.cm-builtin { color: #dcdccc; font-weight: bold; }
 .cm-s-zenburn span.cm-comment { color: #7f9f7f; }


### PR DESCRIPTION
Also some general improvements to material.css and solarized.css

Lines like https://github.com/codemirror/CodeMirror/compare/master...vincentwoo:master#diff-33646e9ee4d04eedb98a991a636c2302L26 can get pretty dangerous - I think cases like this are a good reason to advocate for using SASS or any kind of preprocessor step to standardize theme CSS.