### PR TITLE
Use correct primary when selecting variables

### DIFF
--- a/addon/tern/tern.js
+++ b/addon/tern/tern.js
@@ -466,12 +466,13 @@
     ts.request(cm, {type: "refs"}, function(error, data) {
       if (error) return showError(ts, cm, error);
       var ranges = [], cur = 0;
+      var curPos = cm.getCursor();
       for (var i = 0; i < data.refs.length; i++) {
         var ref = data.refs[i];
         if (ref.file == name) {
           ranges.push({anchor: ref.start, head: ref.end});
-          if (cmpPos(cur, ref.start) >= 0 && cmpPos(cur, ref.end) <= 0)
-            cur = ranges.length - 1;
+          if (cmpPos(curPos, ref.start) >= 0 && cmpPos(curPos, ref.end) <= 0)
+            cur = i;
         }
       }
       cm.setSelections(ranges, cur);


### PR DESCRIPTION
This patch makes us use the correct primary number when selecting variable occurrences instead of using always 0.