### PR TITLE
[sublime] Make smartBackspace delete and not deindent

### DIFF
--- a/demo/sublime.html
+++ b/demo/sublime.html
@@ -69,7 +69,8 @@ option to <code>"sublime"</code>.</p>
     autoCloseBrackets: true,
     matchBrackets: true,
     showCursorWhenSelecting: true,
-    theme: "monokai"
+    theme: "monokai",
+    tabSize: 2
   });
 </script>
 

--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -417,11 +417,19 @@
     var cursor = cm.getCursor();
     var toStartOfLine = cm.getRange({line: cursor.line, ch: 0}, cursor);
     var column = CodeMirror.countColumn(toStartOfLine, null, cm.getOption("tabSize"));
+    var indentUnit = cm.getOption("indentUnit");
 
-    if (toStartOfLine && !/\S/.test(toStartOfLine) && column % cm.getOption("indentUnit") == 0)
-      return cm.indentSelection("subtract");
-    else
+    if (toStartOfLine && !/\S/.test(toStartOfLine) && column % indentUnit == 0) {
+      var prevIndent = new Pos(cursor.line,
+        CodeMirror.findColumn(toStartOfLine, column - indentUnit, indentUnit));
+
+      // If no smart delete is happening (due to tab sizing) just do a regular delete
+      if (prevIndent.ch == cursor.ch) return CodeMirror.Pass;
+
+      return cm.replaceRange("", prevIndent, cursor, "+delete");
+    } else {
       return CodeMirror.Pass;
+    }
   };
 
   cmds[map[cK + ctrl + "K"] = "delLineRight"] = function(cm) {

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -8211,7 +8211,7 @@
 
   // The inverse of countColumn -- find the offset that corresponds to
   // a particular column.
-  function findColumn(string, goal, tabSize) {
+  var findColumn = CodeMirror.findColumn = function(string, goal, tabSize) {
     for (var pos = 0, col = 0;;) {
       var nextTab = string.indexOf("\t", pos);
       if (nextTab == -1) nextTab = string.length;


### PR DESCRIPTION
Fixes #3449 

Basically, what's currently happening in sublime mode is that if you hit backspace and we think we can shave off a full indent, we tell CM to deindent.

This is fine if your cursor is right before the text that's getting shifted left (in this case, your cursor moves with the text), but if your cursor is surrounded by whitespace to the left and right, it stays in place.

This change makes `smartBackspace` behave more like backspace and less like a "deindenter". It figures out what text should be deleted to the immediate left of the cursor and then deletes it.

I also opened up the helper function `findColumn` which is super helpful for doing any kind of tab math. Is that acceptable?