### PR TITLE
Adjust CSS indent to align with parent context when closing blocks

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -364,12 +364,17 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
       var cx = state.context, ch = textAfter && textAfter.charAt(0);
       var indent = cx.indent;
       if (cx.type == "prop" && (ch == "}" || ch == ")")) cx = cx.prev;
-      if (cx.prev &&
-          (ch == "}" && (cx.type == "block" || cx.type == "top" || cx.type == "interpolation" || cx.type == "restricted_atBlock") ||
-           ch == ")" && (cx.type == "parens" || cx.type == "atBlock_parens") ||
-           ch == "{" && (cx.type == "at" || cx.type == "atBlock"))) {
-        indent = cx.indent - indentUnit;
-        cx = cx.prev;
+      if (cx.prev) {
+        if (ch == "}" && (cx.type == "block" || cx.type == "top" || cx.type == "interpolation" || cx.type == "restricted_atBlock")) {
+          // Resume indentation from parent context.
+          indent = cx.prev.indent;
+          cx = cx.prev;
+        } else if (ch == ")" && (cx.type == "parens" || cx.type == "atBlock_parens") ||
+            ch == "{" && (cx.type == "at" || cx.type == "atBlock")) {
+          // Dedent relative to current context.
+          indent = cx.indent - indentUnit;
+          cx = cx.prev;
+        }
       }
       return indent;
     },

--- a/mode/css/test.js
+++ b/mode/css/test.js
@@ -156,7 +156,7 @@
       "    [tag foo] {",
       "      [property font-family]: [variable Verdana], [atom sans-serif];",
       "    }",
-      "  }");
+      "}");
 
    MT("document_url",
       "[def @document] [tag url]([string http://blah]) { [qualifier .class] { } }");


### PR DESCRIPTION
Fixes the CSS indentation for closing braces to align with the outer block scope instead of just subtracting an indent level. The difference is only noticeable on especially complex formatting like the "css_document" test.

I noticed this issue while working on a mode for Closure Templates a.k.a. GSS where `@component` provides some unique indentation cases.