### PR TITLE
Advertise gfm mode from markdown's demo page.

### DIFF
--- a/mode/markdown/index.html
+++ b/mode/markdown/index.html
@@ -350,8 +350,10 @@ Output:
       });
     </script>
 
-    <p>Optionally depends on the XML mode for properly highlighted inline XML blocks.</p>
+    <p>You might want to use the <a href="../gfm/index.html">Github-Flavored Markdown mode</a> instead, which adds support for fenced code blocks and a few other things.</p>
 
+    <p>Optionally depends on the XML mode for properly highlighted inline XML blocks.</p>
+    
     <p><strong>MIME types defined:</strong> <code>text/x-markdown</code>.</p>
 
     <p><strong>Parsing/Highlighting Tests:</strong> <a href="../../test/index.html#markdown_*">normal</a>,  <a href="../../test/index.html#verbose,markdown_*">verbose</a>.</p>


### PR DESCRIPTION
More than once people have asked questions expecting markdown mode to support GFisms and were simply not aware of gfm mode existance. Hopefully this will make it more discoverable.

Page after the patch: https://rawgit.com/cben/CodeMirror/cben-patch-1/mode/markdown/
