### PR TITLE
Add mode for "Closure Stylesheets (GSS)"

### DIFF
--- a/mode/css/gss.html
+++ b/mode/css/gss.html
@@ -1,0 +1,103 @@
+<!doctype html>
+
+<title>CodeMirror: Closure Stylesheets (GSS) mode</title>
+<meta charset="utf-8"/>
+<link rel=stylesheet href="../../doc/docs.css">
+
+<link rel="stylesheet" href="../../lib/codemirror.css">
+<link rel="stylesheet" href="../../addon/hint/show-hint.css">
+<script src="../../lib/codemirror.js"></script>
+<script src="css.js"></script>
+<script src="../../addon/hint/show-hint.js"></script>
+<script src="../../addon/hint/css-hint.js"></script>
+<style>.CodeMirror {background: #f8f8f8;}</style>
+<div id=nav>
+  <a href="http://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+
+  <ul>
+    <li><a href="../../index.html">Home</a>
+    <li><a href="../../doc/manual.html">Manual</a>
+    <li><a href="https://github.com/codemirror/codemirror">Code</a>
+  </ul>
+  <ul>
+    <li><a href="../index.html">Language modes</a>
+    <li><a class=active href="#">Closure Stylesheets (GSS)</a>
+  </ul>
+</div>
+
+<article>
+<h2>Closure Stylesheets (GSS) mode</h2>
+<form><textarea id="code" name="code">
+/* Some example Closure Stylesheets */
+
+@provide 'some.styles';
+
+@require 'other.styles';
+
+@component {
+
+@def FONT_FAMILY           "Times New Roman", Georgia, Serif;
+@def FONT_SIZE_NORMAL      15px;
+@def FONT_NORMAL           normal FONT_SIZE_NORMAL FONT_FAMILY;
+
+@def BG_COLOR              rgb(235, 239, 249);
+
+@def DIALOG_BORDER_COLOR   rgb(107, 144, 218);
+@def DIALOG_BG_COLOR       BG_COLOR;
+
+@def LEFT_HAND_NAV_WIDTH    180px;
+@def LEFT_HAND_NAV_PADDING  3px;
+
+@defmixin size(WIDTH, HEIGHT) {
+  width: WIDTH;
+  height: HEIGHT;
+}
+
+body {
+  background-color: BG_COLOR;
+  margin: 0;
+  padding: 3em 6em;
+  font: FONT_NORMAL;
+  color: #000;
+}
+
+#navigation a {
+  font-weight: bold;
+  text-decoration: none !important;
+}
+
+.dialog {
+  background-color: DIALOG_BG_COLOR;
+  border: 1px solid DIALOG_BORDER_COLOR;
+}
+
+.content {
+  position: absolute;
+  margin-left: add(LEFT_HAND_NAV_PADDING,  /* padding left */
+                   LEFT_HAND_NAV_WIDTH,
+                   LEFT_HAND_NAV_PADDING); /* padding right */
+
+}
+
+.logo {
+  @mixin size(150px, 55px);
+  background-image: url('http://www.google.com/images/logo_sm.gif');
+}
+
+}
+</textarea></form>
+    <script>
+      var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
+        extraKeys: {"Ctrl-Space": "autocomplete"},
+        lineNumbers: true,
+        matchBrackets: "text/x-less",
+        mode: "text/x-gss"
+      });
+    </script>
+
+    <p>A mode for <a href="https://github.com/google/closure-stylesheets">Closure Stylesheets</a> (GSS).</p>
+    <p><strong>MIME type defined:</strong> <code>text/x-gss</code>.</p>
+
+    <p><strong>Parsing/Highlighting Tests:</strong> <a href="../../test/index.html#gss_*">normal</a>,  <a href="../../test/index.html#verbose,gss_*">verbose</a>.</p>
+
+  </article>

--- a/mode/css/gss_test.js
+++ b/mode/css/gss_test.js
@@ -1,0 +1,17 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+(function() {
+  "use strict";
+
+  var mode = CodeMirror.getMode({indentUnit: 2}, "gss");
+  function MT(name) { test.mode(name, mode, Array.prototype.slice.call(arguments, 1), "gss"); }
+
+  MT("atComponent",
+     "[def @component] {",
+     "[tag foo] {",
+     "  [property color]: [keyword black];",
+     "}",
+     "}");
+
+})();

--- a/mode/css/test.js
+++ b/mode/css/test.js
@@ -6,7 +6,7 @@
   function MT(name) { test.mode(name, mode, Array.prototype.slice.call(arguments, 1)); }
 
   // Error, because "foobarhello" is neither a known type or property, but
-  // property was expected (after "and"), and it should be in parenthese.
+  // property was expected (after "and"), and it should be in parentheses.
   MT("atMediaUnknownType",
      "[def @media] [attribute screen] [keyword and] [error foobarhello] { }");
 

--- a/mode/index.html
+++ b/mode/index.html
@@ -36,6 +36,7 @@ option.</p>
       <li><a href="brainfuck/index.html">Brainfuck</a></li>
       <li><a href="clike/index.html">C, C++, C#</a></li>
       <li><a href="clojure/index.html">Clojure</a></li>
+      <li><a href="css/gss.html">Closure Stylesheets (GSS)</a></li>
       <li><a href="cmake/index.html">CMake</a></li>
       <li><a href="cobol/index.html">COBOL</a></li>
       <li><a href="coffeescript/index.html">CoffeeScript</a></li>

--- a/mode/meta.js
+++ b/mode/meta.js
@@ -22,6 +22,7 @@
     {name: "Cobol", mime: "text/x-cobol", mode: "cobol", ext: ["cob", "cpy"]},
     {name: "C#", mime: "text/x-csharp", mode: "clike", ext: ["cs"], alias: ["csharp"]},
     {name: "Clojure", mime: "text/x-clojure", mode: "clojure", ext: ["clj"]},
+    {name: "Closure Stylesheets (GSS)", mime: "text/x-gss", mode: "css", ext: ["gss"]},
     {name: "CMake", mime: "text/x-cmake", mode: "cmake", ext: ["cmake", "cmake.in"], file: /^CMakeLists.txt$/},
     {name: "CoffeeScript", mime: "text/x-coffeescript", mode: "coffeescript", ext: ["coffee"], alias: ["coffee", "coffee-script"]},
     {name: "Common Lisp", mime: "text/x-common-lisp", mode: "commonlisp", ext: ["cl", "lisp", "el"], alias: ["lisp"]},

--- a/test/index.html
+++ b/test/index.html
@@ -20,6 +20,7 @@
 <script src="../mode/clike/clike.js"></script>
 <!-- clike must be after css or vim and sublime tests will fail -->
 <script src="../mode/gfm/gfm.js"></script>
+<script src="../mode/gss/gss.js"></script>
 <script src="../mode/haml/haml.js"></script>
 <script src="../mode/htmlmixed/htmlmixed.js"></script>
 <script src="../mode/javascript/javascript.js"></script>
@@ -100,6 +101,7 @@
 
     <script src="../mode/clike/test.js"></script>
     <script src="../mode/css/test.js"></script>
+    <script src="../mode/css/gss_test.js"></script>
     <script src="../mode/css/scss_test.js"></script>
     <script src="../mode/css/less_test.js"></script>
     <script src="../mode/gfm/test.js"></script>


### PR DESCRIPTION
The only difference from standard CSS so far is that it parses syntax properly inside `@component` blocks and also doesn't indent them.

Fixes #3470.