### PR TITLE
Allow setting raw HTML as placeholder option

### DIFF
--- a/addon/display/placeholder.js
+++ b/addon/display/placeholder.js
@@ -37,7 +37,7 @@
     var elt = cm.state.placeholder = document.createElement("pre");
     elt.style.cssText = "height: 0; overflow: visible";
     elt.className = "CodeMirror-placeholder";
-    elt.appendChild(document.createTextNode(cm.getOption("placeholder")));
+    elt.innerHTML = cm.getOption("placeholder");
     cm.display.lineSpace.insertBefore(elt, cm.display.lineSpace.firstChild);
   }
 


### PR DESCRIPTION
If you want to have more complicated or highlighted text in a CodeMirror placeholder, it can be difficult with the current addon.

This patch lets you at least pass HTML as the placeholder, which I think is a relatively safe change that gives a fair amount of power without additional complexity.