### PR TITLE
Update haxe.js

### DIFF
--- a/mode/haxe/haxe.js
+++ b/mode/haxe/haxe.js
@@ -48,7 +48,7 @@ CodeMirror.defineMode("haxe", function(config, parserConfig) {
         return false;
       escaped = !escaped && next == "\\";
     }
-    return escaped;
+    return true;
   }
 
   // Used as scratch variables to communicate multiple values without


### PR DESCRIPTION
fixes #3492 

returns true only once it sees an unescaped quote of matching type, even if it has to skip newlines to do it.

I can't find formal specs saying that haxe supports them, but it does. (see http://try.haxe.org/#5Eb5E for instance (notice the formatting is broken there as well ) ).