### PR TITLE
[markdown] Support an option for tildes as code fences.  

### DIFF
--- a/mode/gfm/gfm.js
+++ b/mode/gfm/gfm.js
@@ -112,7 +112,7 @@ CodeMirror.defineMode("gfm", function(config, modeConfig) {
   var markdownConfig = {
     underscoresBreakWords: false,
     taskLists: true,
-    fencedCodeBlocks: true,
+    fencedCodeBlocks: '```',
     strikethrough: true
   };
   for (var attr in modeConfig) {

--- a/mode/gfm/gfm.js
+++ b/mode/gfm/gfm.js
@@ -39,7 +39,7 @@ CodeMirror.defineMode("gfm", function(config, modeConfig) {
 
       // Hack to prevent formatting override inside code blocks (block and inline)
       if (state.codeBlock) {
-        if (stream.match(/^```/)) {
+        if (stream.match(/^```+/)) {
           state.codeBlock = false;
           return null;
         }
@@ -49,7 +49,7 @@ CodeMirror.defineMode("gfm", function(config, modeConfig) {
       if (stream.sol()) {
         state.code = false;
       }
-      if (stream.sol() && stream.match(/^```/)) {
+      if (stream.sol() && stream.match(/^```+/)) {
         stream.skipToEnd();
         state.codeBlock = true;
         return null;

--- a/mode/gfm/test.js
+++ b/mode/gfm/test.js
@@ -6,8 +6,6 @@
   function MT(name) { test.mode(name, mode, Array.prototype.slice.call(arguments, 1)); }
   var modeHighlightFormatting = CodeMirror.getMode({tabSize: 4}, {name: "gfm", highlightFormatting: true});
   function FT(name) { test.mode(name, modeHighlightFormatting, Array.prototype.slice.call(arguments, 1)); }
-  var modeFencedTildes = CodeMirror.getMode({tabSize: 4}, {name: "gfm", fencedCodeBlocks: "~~~"});
-  function TT(name) { test.mode(name, modeFencedTildes, Array.prototype.slice.call(arguments, 1)); }
 
   FT("codeBackticks",
      "[comment&formatting&formatting-code `][comment foo][comment&formatting&formatting-code `]");
@@ -53,26 +51,10 @@
      "[comment ```]",
      "bar");
 
-  MT("fencedCodeBlocksMultipleChars",
-     "[comment `````]",
-     "[comment foo]",
-     "",
-     "[comment `````]",
-     "bar");
-
-  TT("fencedCodeBlocksTildes",
-     "[comment ~~~]",
-     "[comment foo]",
-     "",
-     "[comment ~~~]",
-     "bar");
-
-  TT("fencedCodeBlocksTildesMultipleChars",
-     "[comment ~~~~]",
-     "[comment foo]",
-     "",
-     "[comment ~~~~]",
-     "bar");
+  MT("fencedCodeBlocksNoTildes",
+     "~~~",
+     "foo",
+     "~~~");
 
   MT("taskListAsterisk",
      "[variable-2 * []] foo]", // Invalid; must have space or x between []

--- a/mode/gfm/test.js
+++ b/mode/gfm/test.js
@@ -6,6 +6,8 @@
   function MT(name) { test.mode(name, mode, Array.prototype.slice.call(arguments, 1)); }
   var modeHighlightFormatting = CodeMirror.getMode({tabSize: 4}, {name: "gfm", highlightFormatting: true});
   function FT(name) { test.mode(name, modeHighlightFormatting, Array.prototype.slice.call(arguments, 1)); }
+  var modeFencedTildes = CodeMirror.getMode({tabSize: 4}, {name: "gfm", fencedCodeBlocks: "~~~"});
+  function TT(name) { test.mode(name, modeFencedTildes, Array.prototype.slice.call(arguments, 1)); }
 
   FT("codeBackticks",
      "[comment&formatting&formatting-code `][comment foo][comment&formatting&formatting-code `]");
@@ -49,6 +51,27 @@
      "[variable foo]",
      "",
      "[comment ```]",
+     "bar");
+
+  MT("fencedCodeBlocksMultipleChars",
+     "[comment `````]",
+     "[comment foo]",
+     "",
+     "[comment `````]",
+     "bar");
+
+  TT("fencedCodeBlocksTildes",
+     "[comment ~~~]",
+     "[comment foo]",
+     "",
+     "[comment ~~~]",
+     "bar");
+
+  TT("fencedCodeBlocksTildesMultipleChars",
+     "[comment ~~~~]",
+     "[comment foo]",
+     "",
+     "[comment ~~~~]",
      "bar");
 
   MT("taskListAsterisk",

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -8,6 +8,8 @@
   function FT(name) { test.mode(name, modeHighlightFormatting, Array.prototype.slice.call(arguments, 1)); }
   var modeAtxNoSpace = CodeMirror.getMode({tabSize: 4}, {name: "markdown", allowAtxHeaderWithoutSpace: true});
   function AtxNoSpaceTest(name) { test.mode(name, modeAtxNoSpace, Array.prototype.slice.call(arguments, 1)); }
+  var modeFenced = CodeMirror.getMode({tabSize: 4}, {name: "markdown", fencedCodeBlocks: true});
+  function FencedTest(name) { test.mode(name, modeFenced, Array.prototype.slice.call(arguments, 1)); }
 
   FT("formatting_emAsterisk",
      "[em&formatting&formatting-em *][em foo][em&formatting&formatting-em *]");
@@ -778,10 +780,52 @@
   MT("taskList",
      "[variable-2 * [ ]] bar]");
 
-  MT("fencedCodeBlocks",
+  MT("noFencedCodeBlocks",
+     "~~~",
+     "foo",
+     "~~~");
+
+  FencedTest("fencedCodeBlocks",
      "[comment ```]",
      "[comment foo]",
-     "[comment ```]");
+     "[comment ```]",
+     "bar");
+
+  FencedTest("fencedCodeBlocksMultipleChars",
+     "[comment `````]",
+     "[comment foo]",
+     "[comment ```]",
+     "[comment foo]",
+     "[comment `````]",
+     "bar");
+
+  FencedTest("fencedCodeBlocksTildes",
+     "[comment ~~~]",
+     "[comment foo]",
+     "[comment ~~~]",
+     "bar");
+
+  FencedTest("fencedCodeBlocksTildesMultipleChars",
+     "[comment ~~~~~]",
+     "[comment ~~~]",
+     "[comment foo]",
+     "[comment ~~~~~]",
+     "bar");
+
+  FencedTest("fencedCodeBlocksMultipleChars",
+     "[comment `````]",
+     "[comment foo]",
+     "[comment ```]",
+     "[comment foo]",
+     "[comment `````]",
+     "bar");
+
+  FencedTest("fencedCodeBlocksMixed",
+     "[comment ~~~]",
+     "[comment ```]",
+     "[comment foo]",
+     "[comment ~~~]",
+     "bar");
 
   // Tests that require XML mode
 


### PR DESCRIPTION
And also allow more than 3 \`s or \~s

These are part of the [CommonMark spec for fenced code blocks](http://spec.commonmark.org/0.22/#fenced-code-blocks)