### PR TITLE
a not-so-great fix to an indentation bug

### DIFF
--- a/mode/haxe/haxe.js
+++ b/mode/haxe/haxe.js
@@ -358,7 +358,8 @@ CodeMirror.defineMode("haxe", function(config, parserConfig) {
     if (value == "in") return cont();
   }
   function functiondef(type, value) {
-    if (type == "variable") {register(value); return cont(functiondef);}
+    //function names starting with upper-case letters are recognised as types, so cludging them together here.
+    if (type == "variable" || type == "type") {register(value); return cont(functiondef);}
     if (value == "new") return cont(functiondef);
     if (type == "(") return cont(pushlex(")"), pushcontext, commasep(funarg, ")"), poplex, typeuse, statement, popcontext);
   }


### PR DESCRIPTION
fixes #3500 

I don't know if 

1) there's a way to get haxe to, while in functiondef, for instance, be able to tell the compiler that what it thought was a type name is actually a variable name, and to indent/highlight correctly

or

2) there's a way that, assuming it's a type name, to still indent correctly

but it *is* possible to loosen the lexer to accept things marked as types as function names (in functiondef), and this fixes the indentation problem.  