### PR TITLE
haxe mode globalVars

### DIFF
--- a/mode/haxe/haxe.js
+++ b/mode/haxe/haxe.js
@@ -386,11 +386,10 @@ CodeMirror.defineMode("haxe", function(config, parserConfig) {
   }
 
   // Interface
-
   return {
     startState: function(basecolumn) {
       var defaulttypes = ["Int", "Float", "String", "Void", "Std", "Bool", "Dynamic", "Array"];
-      return {
+      var state = {
         tokenize: haxeTokenBase,
         reAllowed: true,
         kwAllowed: true,
@@ -403,6 +402,7 @@ CodeMirror.defineMode("haxe", function(config, parserConfig) {
       };
       if (parserConfig.globalVars && typeof parserConfig.globalVars == "object")
         state.globalVars = parserConfig.globalVars;
+      return state;
     },
 
     token: function(stream, state) {

--- a/mode/haxe/haxe.js
+++ b/mode/haxe/haxe.js
@@ -192,12 +192,20 @@ CodeMirror.defineMode("haxe", function(config, parserConfig) {
     return true;
   }
   function register(varname) {
+    function inList(list) {
+      for (var v = list; v; v = v.next)
+        if (v.name == varname) return true;
+      return false;
+    }
     var state = cx.state;
     if (state.context) {
       cx.marked = "def";
-      for (var v = state.localVars; v; v = v.next)
-        if (v.name == varname) return;
+      if (inList(state.localVars)) return;
       state.localVars = {name: varname, next: state.localVars};
+    } else {
+      if (inList(state.globalVars)) return;
+      if (parserConfig.globalVars)
+        state.globalVars = {name: varname, next: state.globalVars};
     }
   }
 
@@ -393,6 +401,8 @@ CodeMirror.defineMode("haxe", function(config, parserConfig) {
         context: parserConfig.localVars && {vars: parserConfig.localVars},
         indented: 0
       };
+      if (parserConfig.globalVars && typeof parserConfig.globalVars == "object")
+        state.globalVars = parserConfig.globalVars;
     },
 
     token: function(stream, state) {


### PR DESCRIPTION
porting javascript globalVars code to haxe.js to allow tracking of (previously declared in file) global variables/functions.

As with javasript mode, to enable you call fromAreaText with

    mode: {name:"haxe",globalVars: true},

see the javascript mode file for reference - 
https://github.com/codemirror/CodeMirror/blob/master/mode/javascript/javascript.js