### PR TITLE
Update manual.html

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -100,7 +100,7 @@
     easy way to combine scripts.) For example:</p>
 
     <pre data-lang="text/html">&lt;script src="lib/codemirror.js">&lt;/script>
-&lt;link rel="stylesheet" href="../lib/codemirror.css">
+&lt;link rel="stylesheet" href="lib/codemirror.css">
 &lt;script src="mode/javascript/javascript.js">&lt;/script></pre>
 
     <p>(Alternatively, use a module loader. <a href="#modloader">More


### PR DESCRIPTION
Hello. When I create my first codemirror script, I found it can't load the file lib/codemirror.css because the filepath is incorrect. the file 'codemirror.css' and 'codemirror.js' is in the same directory, the the html should be <link rel="stylesheet" href="lib/codemirror.css">. Thank you for your watching.