### PR TITLE
fixes #3513

### DIFF
--- a/mode/haxe/haxe.js
+++ b/mode/haxe/haxe.js
@@ -264,6 +264,7 @@ CodeMirror.defineMode("haxe", function(config, parserConfig) {
   }
   function expression(type) {
     if (atomicTypes.hasOwnProperty(type)) return cont(maybeoperator);
+    if (type == "type" ) return cont(maybeoperator);
     if (type == "function") return cont(functiondef);
     if (type == "keyword c") return cont(maybeexpression);
     if (type == "(") return cont(pushlex(")"), maybeexpression, expect(")"), poplex, maybeoperator);


### PR DESCRIPTION
Not 100% sure that this is the best way to deal with this, but pretty sure - 

If you're in an expression, and encounter what you think is a type, it's probably better to change your assumption and treat it as you would a variable/constant (Because that's what it probably is) rather than to forget everything.

I ran the test suite, and it didn't break anything, and the linter, which was quiet.