### PR TITLE
[gfm] limit the url regex to certain schemes

### DIFF
--- a/mode/gfm/gfm.js
+++ b/mode/gfm/gfm.js
@@ -92,11 +92,12 @@ CodeMirror.defineMode("gfm", function(config, modeConfig) {
           return "link";
         }
       }
-      if (stream.match(/^((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]|\([^\s()<>]*\))+(?:\([^\s()<>]*\)|[^\s`*!()\[\]{};:'".,<>?«»“”‘’]))/i) &&
+      if (stream.match(/^((?:coap|doi|javascript|aaa|aaas|about|acap|cap|cid|crid|data|dav|dict|dns|file|ftp|geo|go|gopher|h323|http|https|iax|icap|im|imap|info|ipp|iris|iris\.beep|iris\.xpc|iris\.xpcs|iris\.lwz|ldap|mailto|mid|msrp|msrps|mtqp|mupdate|news|nfs|ni|nih|nntp|opaquelocktoken|pop|pres|rtsp|service|session|shttp|sieve|sip|sips|sms|snmp|soap\.beep|soap\.beeps|tag|tel|telnet|tftp|thismessage|tn3270|tip|tv|urn|vemmi|ws|wss|xcon|xcon-userid|xmlrpc\.beep|xmlrpc\.beeps|xmpp|z39\.50r|z39\.50s|adiumxtra|afp|afs|aim|apt|attachment|aw|beshare|bitcoin|bolo|callto|chrome|chrome-extension|com-eventbrite-attendee|content|cvs|dlna-playsingle|dlna-playcontainer|dtn|dvb|ed2k|facetime|feed|finger|fish|gg|git|gizmoproject|gtalk|hcp|icon|ipn|irc|irc6|ircs|itms|jar|jms|keyparc|lastfm|ldaps|magnet|maps|market|message|mms|ms-help|msnim|mumble|mvn|notes|oid|palm|paparazzi|platform|proxy|psyc|query|res|resource|rmi|rsync|rtmp|secondlife|sftp|sgn|skype|smb|soldat|spotify|ssh|steam|svn|teamspeak|things|udp|unreal|ut2004|ventrilo|view-source|webcal|wtai|wyciwyg|xfire|xri|ymsgr:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]|\([^\s()<>]*\))+(?:\([^\s()<>]*\)|[^\s`*!()\[\]{};:'".,<>?«»“”‘’]))/i) &&
          stream.string.slice(stream.start - 2, stream.start) != "](") {
         // URLs
         // Taken from http://daringfireball.net/2010/07/improved_regex_for_matching_urls
         // And then (issue #1160) simplified to make it not crash the Chrome Regexp engine
+        // And then limited url schemes to the CommonMark list, so foo:bar isn't matched as a URL
         state.combineTokens = true;
         return "link";
       }

--- a/mode/gfm/test.js
+++ b/mode/gfm/test.js
@@ -133,6 +133,15 @@
   MT("vanillaLink",
      "foo [link http://www.example.com/] bar");
 
+  MT("vanillaLinkNoScheme",
+     "foo [link www.example.com] bar");
+
+  MT("vanillaLinkHttps",
+     "foo [link https://www.example.com/] bar");
+
+  MT("vanillaLinkDataSchema",
+     "foo [link data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==] bar");
+
   MT("vanillaLinkPunctuation",
      "foo [link http://www.example.com/]. bar");
 
@@ -141,6 +150,9 @@
 
   MT("vanillaLinkEmphasis",
      "foo [em *][em&link http://www.example.com/index.html][em *] bar");
+
+  MT("notALink",
+     "foo asfd:asdf bar");
 
   MT("notALink",
      "[comment ```css]",


### PR DESCRIPTION
Since foo:bar was matching as a regex (as reported in #2521 but still occurring for me), limit URI schemes to those in the CommonMark spec for autolinks http://spec.commonmark.org/0.22/#autolinks

The spec's list of uri schemes seems pretty long, so it might be better to limit it even more.  Not sure exactly how to pick the schemes that should be supported though.