### PR TITLE
closebrackets  - selection functionality change

### DIFF
--- a/addon/edit/closebrackets.js
+++ b/addon/edit/closebrackets.js
@@ -90,6 +90,16 @@
     });
   }
 
+  function contractSelection(sel){
+    if (sel.anchor.line<sel.head.line || (sel.anchor.line===sel.head.line&&sel.anchor.ch<sel.head.ch)){
+      sel.anchor.ch++;
+      sel.head.ch--;
+    }
+    if (sel.anchor.line>sel.head.line || (sel.anchor.line===sel.head.line&&sel.anchor.ch>sel.head.ch)){
+      sel.head.ch++;
+      sel.anchor.ch--;
+    }
+  }
   function handleChar(cm, ch) {
     var conf = getConfig(cm);
     if (!conf || cm.getOption("disableInput")) return CodeMirror.Pass;
@@ -145,6 +155,11 @@
         for (var i = 0; i < sels.length; i++)
           sels[i] = left + sels[i] + right;
         cm.replaceSelections(sels, "around");
+        var selections = cm.listSelections();
+        for (var i=0;i<selections.length;i++){
+          contractSelection(selections[i]);
+        }
+        cm.setSelections(selections);
       } else if (type == "both") {
         cm.replaceSelection(left + right, null);
         cm.triggerElectric(left + right);


### PR DESCRIPTION
Right now if you have a selection, and you enter a bracket/quote, surrounds it with quotation marks, and selects the entire quote:

<img width="96" alt="closebrackets_current" src="https://cloud.githubusercontent.com/assets/465632/9759924/a27bc244-56e8-11e5-9c4a-1d7320fb131b.png">

This change should change the behaviour to selecting the interior of the quote instead:

<img width="96" alt="closebrackets_proposed" src="https://cloud.githubusercontent.com/assets/465632/9759927/a86d3a5c-56e8-11e5-974b-3c06d226a313.png">


The motivating example for me was autocomplete, where after autocompleting a function the arguments are selected, so if you want to insert a string literal right now you have to delete the selection before you can enter the quotes. With the proposed fix, it'll be rather more fluid.

<img width="197" alt="closebrackets_timeline" src="https://cloud.githubusercontent.com/assets/465632/9759930/aebdb5d0-56e8-11e5-958e-8bf6f2bbad36.png">

I checked it works ok with multiple selections.
The test suite doesn't have any new things other than the scroll ones that are already broken.
I've passed it through the linter and it checks out.