### PR TITLE
Option for GitHub spice in GFM mode

### DIFF
--- a/mode/gfm/gfm.js
+++ b/mode/gfm/gfm.js
@@ -82,20 +82,22 @@ CodeMirror.defineMode("gfm", function(config, modeConfig) {
         state.ateSpace = true;
         return null;
       }
-      if (modeConfig.gitHubSpice && (stream.sol() || state.ateSpace)) {
+      if (stream.sol() || state.ateSpace) {
         state.ateSpace = false;
-        if(stream.match(/^(?:[a-zA-Z0-9\-_]+\/)?(?:[a-zA-Z0-9\-_]+@)?(?:[a-f0-9]{7,40}\b)/)) {
-          // User/Project@SHA
-          // User@SHA
-          // SHA
-          state.combineTokens = true;
-          return "link";
-        } else if (stream.match(/^(?:[a-zA-Z0-9\-_]+\/)?(?:[a-zA-Z0-9\-_]+)?#[0-9]+\b/)) {
-          // User/Project#Num
-          // User#Num
-          // #Num
-          state.combineTokens = true;
-          return "link";
+        if (modeConfig.gitHubSpice) {
+          if(stream.match(/^(?:[a-zA-Z0-9\-_]+\/)?(?:[a-zA-Z0-9\-_]+@)?(?:[a-f0-9]{7,40}\b)/)) {
+            // User/Project@SHA
+            // User@SHA
+            // SHA
+            state.combineTokens = true;
+            return "link";
+          } else if (stream.match(/^(?:[a-zA-Z0-9\-_]+\/)?(?:[a-zA-Z0-9\-_]+)?#[0-9]+\b/)) {
+            // User/Project#Num
+            // User#Num
+            // #Num
+            state.combineTokens = true;
+            return "link";
+          }
         }
       }
       if (stream.match(urlRE) &&

--- a/mode/gfm/gfm.js
+++ b/mode/gfm/gfm.js
@@ -14,6 +14,10 @@
 var urlRE = /^((?:coap|doi|javascript|aaa|aaas|about|acap|cap|cid|crid|data|dav|dict|dns|file|ftp|geo|go|gopher|h323|http|https|iax|icap|im|imap|info|ipp|iris|iris\.beep|iris\.xpc|iris\.xpcs|iris\.lwz|ldap|mailto|mid|msrp|msrps|mtqp|mupdate|news|nfs|ni|nih|nntp|opaquelocktoken|pop|pres|rtsp|service|session|shttp|sieve|sip|sips|sms|snmp|soap\.beep|soap\.beeps|tag|tel|telnet|tftp|thismessage|tn3270|tip|tv|urn|vemmi|ws|wss|xcon|xcon-userid|xmlrpc\.beep|xmlrpc\.beeps|xmpp|z39\.50r|z39\.50s|adiumxtra|afp|afs|aim|apt|attachment|aw|beshare|bitcoin|bolo|callto|chrome|chrome-extension|com-eventbrite-attendee|content|cvs|dlna-playsingle|dlna-playcontainer|dtn|dvb|ed2k|facetime|feed|finger|fish|gg|git|gizmoproject|gtalk|hcp|icon|ipn|irc|irc6|ircs|itms|jar|jms|keyparc|lastfm|ldaps|magnet|maps|market|message|mms|ms-help|msnim|mumble|mvn|notes|oid|palm|paparazzi|platform|proxy|psyc|query|res|resource|rmi|rsync|rtmp|secondlife|sftp|sgn|skype|smb|soldat|spotify|ssh|steam|svn|teamspeak|things|udp|unreal|ut2004|ventrilo|view-source|webcal|wtai|wyciwyg|xfire|xri|ymsgr:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]|\([^\s()<>]*\))+(?:\([^\s()<>]*\)|[^\s`*!()\[\]{};:'".,<>?«»“”‘’]))/i
 
 CodeMirror.defineMode("gfm", function(config, modeConfig) {
+  // Should GitHub spice be added (like linking #Num, SHA, etc.)
+  if (modeConfig.gitHubSpice === undefined)
+    modeConfig.gitHubSpice = true;
+  
   var codeDepth = 0;
   function blankLine(state) {
     state.code = false;
@@ -78,7 +82,7 @@ CodeMirror.defineMode("gfm", function(config, modeConfig) {
         state.ateSpace = true;
         return null;
       }
-      if (stream.sol() || state.ateSpace) {
+      if (modeConfig.gitHubSpice && (stream.sol() || state.ateSpace)) {
         state.ateSpace = false;
         if(stream.match(/^(?:[a-zA-Z0-9\-_]+\/)?(?:[a-zA-Z0-9\-_]+@)?(?:[a-f0-9]{7,40}\b)/)) {
           // User/Project@SHA

--- a/mode/gfm/gfm.js
+++ b/mode/gfm/gfm.js
@@ -17,7 +17,7 @@ CodeMirror.defineMode("gfm", function(config, modeConfig) {
   // Should GitHub spice be added (like linking #Num, SHA, etc.)
   if (modeConfig.gitHubSpice === undefined)
     modeConfig.gitHubSpice = true;
-  
+
   var codeDepth = 0;
   function blankLine(state) {
     state.code = false;


### PR DESCRIPTION
Does not affect default behavior, but does allow users to disable GitHub spice if needed using the `modeConfig` parameter.

By GitHub spice, I mean:

> User/Project@SHA
> User@SHA
> SHA
> User/Project#Num
> User#Num
> #Num