### PR TITLE
Provide option "somethingSelected" to open completion even if something is selcted

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -42,8 +42,9 @@
     this.widget = null;
     this.debounce = 0;
     this.tick = 0;
-    this.startPos = this.cm.getCursor();
+    this.startPos = this.cm.getCursor("start");
     this.startLen = this.cm.getLine(this.startPos.line).length;
+    if (options && options.somethingSelected == false ) this.startLen = this.startLen - this.cm.getSelection().length;
 
     var self = this;
     cm.on("cursorActivity", this.activityFunc = function() { self.cursorActivity(); });

--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -26,7 +26,7 @@
 
   CodeMirror.defineExtension("showHint", function(options) {
     // We want a single cursor position.
-    if (this.listSelections().length > 1 || this.somethingSelected()) return;
+    if (this.listSelections().length > 1 || (this.somethingSelected() && !(options && options.somethingSelected == false ))) return;
 
     if (this.state.completionActive) this.state.completionActive.close();
     var completion = this.state.completionActive = new Completion(this, options);


### PR DESCRIPTION
I'm developping a CodeMirror addon for https://github.com/angelozerr/tern-guess-types

For instance if you open tern completion for `document` and select `addEventListener` :

![](https://github.com/angelozerr/tern-guess-types/wiki/images/TernCompletion.png)

When you apply completion, tern guess types gives the capability to retrieve variables, functions for each function parameters. Here a screenshot which shows a list of variable with string type for the `addEventListener` `type` argument :

![](https://github.com/angelozerr/tern-guess-types/wiki/images/TernGuessTypes.png)

If you see this screenshot, the **type parameter is selected** and with CodeMirror when I call `cm.showHint(),` this.somethingSelected() return true and **completion cannot be opened**.

With this PR, I can call the showHint like this

```javascript
cm.showHint({hint: templateHint, somethingSelected: false});
```

and it works with my case.