### PR TITLE
Syntax highliting for C++14 numeric literals.

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -266,6 +266,11 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     return false;
   }
 
+  function cpp14Literal(stream) {
+    stream.eatWhile(/[\w\.']/);
+    return "number";
+  }
+
   function cpp11StringHook(stream, state) {
     stream.backUp(1);
     // Raw strings.
@@ -373,6 +378,16 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
       "U": cpp11StringHook,
       "L": cpp11StringHook,
       "R": cpp11StringHook,
+      "0": cpp14Literal,
+      "1": cpp14Literal,
+      "2": cpp14Literal,
+      "3": cpp14Literal,
+      "4": cpp14Literal,
+      "5": cpp14Literal,
+      "6": cpp14Literal,
+      "7": cpp14Literal,
+      "8": cpp14Literal,
+      "9": cpp14Literal,
       token: function(stream, state, style) {
         if (style == "variable" && stream.peek() == "(" &&
             (state.prevToken == ";" || state.prevToken == null ||

--- a/mode/clike/test.js
+++ b/mode/clike/test.js
@@ -30,4 +30,13 @@
      "  [keyword for] (;;)",
      "    [variable x][operator ++];",
      "[keyword return];");
+
+  var mode_cpp = CodeMirror.getMode({indentUnit: 2}, "text/x-c++src");
+  function MTCPP(name) { test.mode(name, mode_cpp, Array.prototype.slice.call(arguments, 1)); }
+
+  MTCPP("cpp14_literal",
+    "[number 10'000];",
+    "[number 0b10'000];",
+    "[number 0x10'000];",
+    "[string '100000'];");
 })();


### PR DESCRIPTION
In C++14, the single-quote character may be used arbitrarily
as a digit separator in numeric literals.

https://en.wikipedia.org/wiki/C%2B%2B14#Digit_separators