### PR TITLE
fixes #3542  - Haxe mode - ellipses not correctly highlighted when preceded directly by integer

### DIFF
--- a/mode/haxe/haxe.js
+++ b/mode/haxe/haxe.js
@@ -66,7 +66,11 @@ CodeMirror.defineMode("haxe", function(config, parserConfig) {
       stream.eatWhile(/[\da-f]/i);
       return ret("number", "number");
     } else if (/\d/.test(ch) || ch == "-" && stream.eat(/\d/)) {
-      stream.match(/^\d*(?:\.\d*)?(?:[eE][+\-]?\d+)?/);
+      if (stream.match(/^\d*\.\./,false)){
+        stream.match(/^\d*/);
+      } else {
+        stream.match(/^\d*(?:\.\d*)?(?:[eE][+\-]?\d+)?/);
+      }
       return ret("number", "number");
     } else if (state.reAllowed && (ch == "~" && stream.eat(/\//))) {
       toUnescaped(stream, "/");


### PR DESCRIPTION
checks out in the linter, doesn't cause any bugs in the test suite