### PR TITLE
修正merge插件的ie8兼容性

### DIFF
--- a/addon/merge/merge.js
+++ b/addon/merge/merge.js
@@ -640,7 +640,12 @@
       mark.clear();
       cm.removeLineClass(from, "wrap", "CodeMirror-merge-collapsed-line");
     }
-    widget.addEventListener("click", clear);
+    if (widget.addEventListener) {
+      widget.addEventListener("click", clear);
+    }
+    else {
+      widget.attachEvent("onclick", clear);
+    }
     return {mark: mark, clear: clear};
   }
 


### PR DESCRIPTION
addEventListener() doesn't work in IE8.I use attachEvent() instead when addEventListener() is not being supported. All tests paassed.