### PR TITLE
New option: allowDroppedFileTypes

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3823,6 +3823,9 @@
       var loadFile = function(file, i) {
         var reader = new FileReader;
         reader.onload = operation(cm, function() {
+          if(this.options.allowDroppedFileTypes !== undefined && this.options.allowDroppedFileTypes.indexOf(file.type) === -1)
+            return;
+          
           text[i] = reader.result;
           if (++read == n) {
             pos = clipPos(cm.doc, pos);

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3821,11 +3821,11 @@
     if (files && files.length && window.FileReader && window.File) {
       var n = files.length, text = Array(n), read = 0;
       var loadFile = function(file, i) {
+        if(this.options.allowDroppedFileTypes !== undefined && this.options.allowDroppedFileTypes.indexOf(file.type) === -1)
+            return;
+
         var reader = new FileReader;
         reader.onload = operation(cm, function() {
-          if(this.options.allowDroppedFileTypes !== undefined && this.options.allowDroppedFileTypes.indexOf(file.type) === -1)
-            return;
-          
           text[i] = reader.result;
           if (++read == n) {
             pos = clipPos(cm.doc, pos);

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3822,7 +3822,7 @@
       var n = files.length, text = Array(n), read = 0;
       var loadFile = function(file, i) {
         if(this.options.allowDroppedFileTypes !== undefined && this.options.allowDroppedFileTypes.indexOf(file.type) === -1)
-            return;
+          return;
 
         var reader = new FileReader;
         reader.onload = operation(cm, function() {


### PR DESCRIPTION
Dropping an image, PDF, or other special file type results in unreadable characters being added to the editor. Plus, if the file is large enough (like images typically are), it'll freeze the browser. This fixes the issue by giving an option to specify which file types are allowed to be dropped. All others will be ignored.

This does not affect the default behavior however.