### PR TITLE
rpm spec mode fixes

### DIFF
--- a/mode/rpm/rpm.js
+++ b/mode/rpm/rpm.js
@@ -34,10 +34,10 @@ CodeMirror.defineMIME("text/x-rpm-changes", "rpm-changes");
 // Quick and dirty spec file highlighting
 
 CodeMirror.defineMode("rpm-spec", function() {
-  var arch = /^(i386|i586|i686|x86_64|ppc64|ppc|ia64|s390x|s390|sparc64|sparcv9|sparc|noarch|alphaev6|alpha|hppa|mipsel)/;
+  var arch = /^(i386|i586|i686|x86_64|ppc64le|ppc64|ppc|ia64|s390x|s390|sparc64|sparcv9|sparc|noarch|alphaev6|alpha|hppa|mipsel)/;
 
-  var preamble = /^(Name|Version|Release|License|Summary|Url|Group|Source|BuildArch|BuildRequires|BuildRoot|AutoReqProv|Provides|Requires(\(\w+\))?|Obsoletes|Conflicts|Recommends|Source\d*|Patch\d*|ExclusiveArch|NoSource|Supplements):/;
-  var section = /^%(debug_package|package|description|prep|build|install|files|clean|changelog|preinstall|preun|postinstall|postun|pre|post|triggerin|triggerun|pretrans|posttrans|verifyscript|check|triggerpostun|triggerprein|trigger)/;
+  var preamble = /^[a-zA-Z0-9()]+:/;
+  var section = /^%(debug_package|package|description|prep|build|install|files|clean|changelog|preinstall|preun|postinstall|postun|pretrans|posttrans|pre|post|triggerin|triggerun|verifyscript|check|triggerpostun|triggerprein|trigger)/;
   var control_flow_complex = /^%(ifnarch|ifarch|if)/; // rpm control flow macros
   var control_flow_simple = /^%(else|endif)/; // rpm control flow macros
   var operators = /^(\!|\?|\<\=|\<|\>\=|\>|\=\=|\&\&|\|\|)/; // operators in control flow macros
@@ -55,8 +55,8 @@ CodeMirror.defineMode("rpm-spec", function() {
       if (ch == "#") { stream.skipToEnd(); return "comment"; }
 
       if (stream.sol()) {
-        if (stream.match(preamble)) { return "preamble"; }
-        if (stream.match(section)) { return "section"; }
+        if (stream.match(preamble)) { return "header"; }
+        if (stream.match(section)) { return "atom"; }
       }
 
       if (stream.match(/^\$\w+/)) { return "def"; } // Variables like '$RPM_BUILD_ROOT'
@@ -73,21 +73,29 @@ CodeMirror.defineMode("rpm-spec", function() {
         if (stream.eol()) { state.controlFlow = false; }
       }
 
-      if (stream.match(arch)) { return "number"; }
+      if (stream.match(arch)) {
+        if (stream.eol()) { state.controlFlow = false; }
+        return "number";
+      }
 
       // Macros like '%make_install' or '%attr(0775,root,root)'
       if (stream.match(/^%[\w]+/)) {
         if (stream.match(/^\(/)) { state.macroParameters = true; }
-        return "macro";
+        return "keyword";
       }
       if (state.macroParameters) {
         if (stream.match(/^\d+/)) { return "number";}
         if (stream.match(/^\)/)) {
           state.macroParameters = false;
-          return "macro";
+          return "keyword";
         }
       }
-      if (stream.match(/^%\{\??[\w \-]+\}/)) { return "macro"; } // Macros like '%{defined fedora}'
+
+      // Macros like '%{defined fedora}'
+      if (stream.match(/^%\{\??[\w \-\:\!]+\}/)) {
+        if (stream.eol()) { state.controlFlow = false; }
+        return "def";
+      }
 
       //TODO: Include bash script sub-parser (CodeMirror supports that)
       stream.next();


### PR DESCRIPTION
When developing an rpm syntax highlighting plugin for Brackets I made a number of fixes to the rpm spec mode.

1. CSS classes names didn't exist. Updated to use classes that do exist.
2. Add support for more architectures, preambles and sections.
3. Fix clearing of control flow state.