### PR TITLE
Support for Ceylon language

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -449,6 +449,7 @@ stoskov
 Sungho Kim
 sverweij
 Taha Jahangir
+Tako Schotanus
 Takuji Shimokawa
 Tarmil
 tel

--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -190,7 +190,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
         pushContext(state, stream.column(), type);
       }
 
-      if (style == "variable" &&
+      if ((style == "variable" || style == "variable-3") &&
           ((state.prevToken == "def" ||
             (parserConfig.typeFirstDefinitions && typeBefore(stream, state) &&
              isTopScope(state.context) && stream.match(/^\s*\(/, false)))))

--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -651,4 +651,45 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     modeProps: {fold: ["brace", "include"]}
   });
 
+  def("text/x-ceylon", {
+    name: "clike",
+    keywords: words("abstracts alias assembly assert assign break case catch class continue dynamic else" +
+                    " exists extends finally for function given if import in interface is let module new" +
+                    " nonempty object of out outer package return satisfies super switch then this throw" +
+                    " try value void while"),
+    types: function(word) {
+        // In Ceylon all identifiers that start with an uppercase are types
+        var first = word.charAt(0);
+        return (first === first.toUpperCase() && first !== first.toLowerCase());
+    },
+    blockKeywords: words("case catch class dynamic else finally for function if interface module new object switch try while"),
+    defKeywords: words("class dynamic function interface module object package value"),
+    builtin: words("abstract actual aliased annotation by default deprecated doc final formal late license" +
+                   " native optional sealed see serializable shared suppressWarnings tagged throws variable"),
+    isOperatorChar: /[+\-*&%=<>!?|^~:\/]/,
+    multiLineStrings: true,
+    typeFirstDefinitions: true,
+    atoms: words("true false null larger smaller equal empty finished"),
+    indentSwitch: false,
+    hooks: {
+      "@": function(stream) {
+        stream.eatWhile(/[\w\$_]/);
+        return "meta";
+      },
+      '"': function(stream, state) {
+        if (!stream.match('""')) return false;
+        state.tokenize = tokenTripleString;
+        return state.tokenize(stream, state);
+      },
+      "'": function(stream) {
+        stream.eatWhile(/[\w\$_\xa1-\uffff]/);
+        return "atom";
+      }
+    },
+    modeProps: {
+        fold: ["brace", "import"],
+        closeBrackets: {triples: '"'}
+    }
+  });
+
 });

--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -25,8 +25,8 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
       multiLineStrings = parserConfig.multiLineStrings,
       indentStatements = parserConfig.indentStatements !== false,
       indentSwitch = parserConfig.indentSwitch !== false,
-      namespaceSeparator = parserConfig.namespaceSeparator;
-  var isOperatorChar = /[+\-*&%=<>!?|\/]/;
+      namespaceSeparator = parserConfig.namespaceSeparator,
+      isOperatorChar = parserConfig.isOperatorChar || /[+\-*&%=<>!?|\/]/;
 
   var curPunc, isDefKeyword;
 

--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -67,17 +67,17 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
       stream.eatWhile(/[\w\$_\xa1-\uffff]/);
 
     var cur = stream.current();
-    if (keywords.propertyIsEnumerable(cur)) {
-      if (blockKeywords.propertyIsEnumerable(cur)) curPunc = "newstatement";
-      if (defKeywords.propertyIsEnumerable(cur)) isDefKeyword = true;
+    if (contains(keywords, cur)) {
+      if (contains(blockKeywords, cur)) curPunc = "newstatement";
+      if (contains(defKeywords, cur)) isDefKeyword = true;
       return "keyword";
     }
-    if (types.propertyIsEnumerable(cur)) return "variable-3";
-    if (builtin.propertyIsEnumerable(cur)) {
-      if (blockKeywords.propertyIsEnumerable(cur)) curPunc = "newstatement";
+    if (contains(types, cur)) return "variable-3";
+    if (contains(builtin, cur)) {
+      if (contains(blockKeywords, cur)) curPunc = "newstatement";
       return "builtin";
     }
-    if (atoms.propertyIsEnumerable(cur)) return "atom";
+    if (contains(atoms, cur)) return "atom";
     return "variable";
   }
 
@@ -237,6 +237,13 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     var obj = {}, words = str.split(" ");
     for (var i = 0; i < words.length; ++i) obj[words[i]] = true;
     return obj;
+  }
+  function contains(words, word) {
+    if (typeof words === "function") {
+      return words(word);
+    } else {
+      return words.propertyIsEnumerable(word);
+    }
   }
   var cKeywords = "auto if break case register continue return default do sizeof " +
     "static else struct switch extern typedef float union for " +

--- a/mode/clike/index.html
+++ b/mode/clike/index.html
@@ -258,6 +258,50 @@ public class HttpServer(private val appServer: AppServer) {
 }
 </textarea></div>
 
+<h2>Ceylon mode</h2>
+
+<div><textarea id="ceylon-code">
+"Produces the [[stream|Iterable]] that results from repeated
+ application of the given [[function|next]] to the given
+ [[first]] element of the stream, until the function first
+ returns [[finished]]. If the given function never returns 
+ `finished`, the resulting stream is infinite.
+
+ For example:
+
+     loop(0)(2.plus).takeWhile(10.largerThan)
+
+ produces the stream `{ 0, 2, 4, 6, 8 }`."
+tagged("Streams")
+shared {Element+} loop&lt;Element&gt;(
+        "The first element of the resulting stream."
+        Element first)(
+        "The function that produces the next element of the
+         stream, given the current element. The function may
+         return [[finished]] to indicate the end of the 
+         stream."
+        Element|Finished next(Element element))
+    =&gt; let (start = first)
+    object satisfies {Element+} {
+        first =&gt; start;
+        empty =&gt; false;
+        function nextElement(Element element)
+                =&gt; next(element);
+        iterator()
+                =&gt; object satisfies Iterator&lt;Element&gt; {
+            variable Element|Finished current = start;
+            shared actual Element|Finished next() {
+                if (!is Finished result = current) {
+                    current = nextElement(result);
+                    return result;
+                }
+                else {
+                    return finished;
+                }
+            }
+        };
+    };
+</textarea></div>
 
     <script>
       var cEditor = CodeMirror.fromTextArea(document.getElementById("c-code"), {
@@ -290,6 +334,11 @@ public class HttpServer(private val appServer: AppServer) {
           matchBrackets: true,
           mode: "text/x-kotlin"
       });
+      var ceylonEditor = CodeMirror.fromTextArea(document.getElementById("ceylon-code"), {
+          lineNumbers: true,
+          matchBrackets: true,
+          mode: "text/x-ceylon"
+      });
       var mac = CodeMirror.keyMap.default == CodeMirror.keyMap.macDefault;
       CodeMirror.keyMap.default[(mac ? "Cmd" : "Ctrl") + "-Space"] = "autocomplete";
     </script>
@@ -305,6 +354,7 @@ public class HttpServer(private val appServer: AppServer) {
     (Java), <code>text/x-csharp</code> (C#),
     <code>text/x-objectivec</code> (Objective-C),
     <code>text/x-scala</code> (Scala), <code>text/x-vertex</code>
-    and <code>x-shader/x-fragment</code> (shader programs),
-    <code>text/x-squirrel</code> (Squirrel).</p>
+    <code>x-shader/x-fragment</code> (shader programs),
+    <code>text/x-squirrel</code> (Squirrel) and
+    <code>text/x-ceylon</code> (Ceylon)</p>
 </article>

--- a/mode/index.html
+++ b/mode/index.html
@@ -35,6 +35,7 @@ option.</p>
       <li><a href="asterisk/index.html">Asterisk dialplan</a></li>
       <li><a href="brainfuck/index.html">Brainfuck</a></li>
       <li><a href="clike/index.html">C, C++, C#</a></li>
+      <li><a href="clike/index.html">Ceylon</a></li>
       <li><a href="clojure/index.html">Clojure</a></li>
       <li><a href="css/gss.html">Closure Stylesheets (GSS)</a></li>
       <li><a href="cmake/index.html">CMake</a></li>


### PR DESCRIPTION
This PR adds support for the [Ceylon programming language](http://ceylon-lang.org) to the existing "clike" mode.

I added a couple of minor features to the "clike" configuration, mostly to be able to pass a function to define keywords instead of a fixed list of words (this because in Ceylon all "types" start with an uppercase letter, so this is a much better test for us than trying to list a large number of often-used type names).

I also made the `isOperatorChar` configurable because we have a couple more symbols that are used as operators.

Anyway, if you have any remarks, just let me know.

PS: Very nice job on CodeMirror! It's a great piece of software. We're using it here in our online "Web IDE" (so people can try out bits of code): http://trybeta.ceylon-lang.org/