### PR TITLE
Allow markdown styles to be overridden

### DIFF
--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -10,6 +10,35 @@
   function AtxNoSpaceTest(name) { test.mode(name, modeAtxNoSpace, Array.prototype.slice.call(arguments, 1)); }
   var modeFenced = CodeMirror.getMode({tabSize: 4}, {name: "markdown", fencedCodeBlocks: true});
   function FencedTest(name) { test.mode(name, modeFenced, Array.prototype.slice.call(arguments, 1)); }
+  var modeOverrideClasses = CodeMirror.getMode({tabsize: 4}, {
+    name: "markdown",
+    strikethrough: true,
+    tokenTypeOverrides: {
+      "header" : "override-header",
+      "code" : "override-code",
+      "quote" : "override-quote",
+      "list1" : "override-list1",
+      "list2" : "override-list2",
+      "list3" : "override-list3",
+      "hr" : "override-hr",
+      "image" : "override-image",
+      "linkInline" : "override-link-inline",
+      "linkEmail" : "override-link-email",
+      "linkText" : "override-link-text",
+      "linkHref" : "override-link-href",
+      "em" : "override-em",
+      "strong" : "override-strong",
+      "strikethrough" : "override-strikethrough"
+  }});
+  function TokenTypeOverrideTest(name) { test.mode(name, modeOverrideClasses, Array.prototype.slice.call(arguments, 1)); }
+  var modeFormattingOverride = CodeMirror.getMode({tabsize: 4}, {
+    name: "markdown",
+    highlightFormatting: true,
+    tokenTypeOverrides: {
+      "formatting" : "override-formatting"
+  }});
+  function FormatTokenTypeOverrideTest(name) { test.mode(name, modeFormattingOverride, Array.prototype.slice.call(arguments, 1)); }
+
 
   FT("formatting_emAsterisk",
      "[em&formatting&formatting-em *][em foo][em&formatting&formatting-em *]");
@@ -774,6 +803,76 @@
      "\\",
      "[em *foo*]");
 
+  // Class override tests
+  TokenTypeOverrideTest("overrideHeader1",
+    "[override-header&override-header-1 # Foo]");
+
+  TokenTypeOverrideTest("overrideHeader2",
+    "[override-header&override-header-2 ## Foo]");
+
+  TokenTypeOverrideTest("overrideHeader3",
+    "[override-header&override-header-3 ### Foo]");
+
+  TokenTypeOverrideTest("overrideHeader4",
+    "[override-header&override-header-4 #### Foo]");
+
+  TokenTypeOverrideTest("overrideHeader5",
+    "[override-header&override-header-5 ##### Foo]");
+
+  TokenTypeOverrideTest("overrideHeader6",
+    "[override-header&override-header-6 ###### Foo]");
+
+  TokenTypeOverrideTest("overrideCode",
+    "[override-code `foo`]");
+
+  TokenTypeOverrideTest("overrideCodeBlock",
+    "[override-code ```]",
+    "[override-code foo]",
+    "[override-code ```]");
+
+  TokenTypeOverrideTest("overrideQuote",
+    "[override-quote&override-quote-1 > foo]",
+    "[override-quote&override-quote-1 > bar]");
+
+  TokenTypeOverrideTest("overrideQuoteNested",
+    "[override-quote&override-quote-1 > foo]",
+    "[override-quote&override-quote-1 >][override-quote&override-quote-2 > bar]",
+    "[override-quote&override-quote-1 >][override-quote&override-quote-2 >][override-quote&override-quote-3 > baz]");
+
+  TokenTypeOverrideTest("overrideLists",
+    "[override-list1 - foo]",
+    "",
+    "    [override-list2 + bar]",
+    "",
+    "        [override-list3 * baz]",
+    "",
+    "            [override-list1 1. qux]",
+    "",
+    "                [override-list2 - quux]");
+
+  TokenTypeOverrideTest("overrideHr",
+    "[override-hr * * *]");
+
+  TokenTypeOverrideTest("overrideImage",
+    "[override-image ![[foo]]][override-link-href&url (http://example.com/)]")
+
+  TokenTypeOverrideTest("overrideLinkText",
+    "[override-link-text [[foo]]][override-link-href&url (http://example.com)]");
+
+  TokenTypeOverrideTest("overrideLinkEmailAndInline",
+    "[override-link-email <][override-link-inline foo@example.com>]");
+
+  TokenTypeOverrideTest("overrideEm",
+    "[override-em *foo*]");
+
+  TokenTypeOverrideTest("overrideStrong",
+    "[override-strong **foo**]");
+
+  TokenTypeOverrideTest("overrideStrikethrough",
+    "[override-strikethrough ~~foo~~]");
+
+  FormatTokenTypeOverrideTest("overrideFormatting",
+    "[override-formatting-escape \\*]");
 
   // Tests to make sure GFM-specific things aren't getting through
 


### PR DESCRIPTION
The `markdown` mode now supports styling overrides. The configuration
object passed to the class now accepts a `classOverrides` object, which
allows the user to sepcify different CSS classes for elements. This is
useful for the case where the default CSS classes are reused for
multiple elements (e.g. `list1` maps to `variable-2` by default) and
more customized styling is desired.

Unit tests have been added to cover all types of styling overrides.