### PR TITLE
Multiplex addon: Add open and close tokens when highlighting delimiters

### DIFF
--- a/addon/mode/multiplex.js
+++ b/addon/mode/multiplex.js
@@ -51,7 +51,7 @@ CodeMirror.multiplexingMode = function(outer /*, others */) {
             if (!other.parseDelimiters) stream.match(other.open);
             state.innerActive = other;
             state.inner = CodeMirror.startState(other.mode, outer.indent ? outer.indent(state.outer, "") : 0);
-            return other.delimStyle;
+            return other.delimStyle && (other.delimStyle + " " + other.delimStyle + "-open");
           } else if (found != -1 && found < cutOff) {
             cutOff = found;
           }
@@ -70,7 +70,7 @@ CodeMirror.multiplexingMode = function(outer /*, others */) {
         if (found == stream.pos && !curInner.parseDelimiters) {
           stream.match(curInner.close);
           state.innerActive = state.inner = null;
-          return curInner.delimStyle;
+          return curInner.delimStyle && (curInner.delimStyle + " " + curInner.delimStyle + "-close");
         }
         if (found > -1) stream.string = oldContent.slice(0, found);
         var innerToken = curInner.mode.token(stream, state.inner);
@@ -80,7 +80,7 @@ CodeMirror.multiplexingMode = function(outer /*, others */) {
           state.innerActive = state.inner = null;
 
         if (curInner.innerStyle) {
-          if (innerToken) innerToken = innerToken + ' ' + curInner.innerStyle;
+          if (innerToken) innerToken = innerToken + " " + curInner.innerStyle;
           else innerToken = curInner.innerStyle;
         }
 

--- a/addon/mode/multiplex_test.js
+++ b/addon/mode/multiplex_test.js
@@ -29,5 +29,5 @@
 
   MT(
     "stexInsideMarkdown",
-    "[strong **Equation:**] [delim $][inner&tag \\pi][delim $]");
+    "[strong **Equation:**] [delim&delim-open $][inner&tag \\pi][delim&delim-close $]");
 })();

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2488,7 +2488,9 @@ editor.setOption("extraKeys", {
       Pass <code>"\n"</code> for <code>open</code> or <code>close</code>
       if you want to switch on a blank line.
       <ul><li>When <code>delimStyle</code> is specified, it will be the token
-      style returned for the delimiter tokens.</li>
+      style returned for the delimiter tokens (as well as
+      <code>[delimStyle]-open</code> on the opening token and
+      <code>[delimStyle]-close</code> on the closing token).</li>
       <li>When <code>innerStyle</code> is specified, it will be the token
       style added for each inner mode token.</li>
       <li>When <code>parseDelimiters</code> is true, the content of


### PR DESCRIPTION
This simple change adds extra `open` and `close` token styles to multiplexing delimiters when `delimStyle` is set. This makes it easy to style open and close delimiter tokens as in this example:

<img width="615" alt="screen shot 2015-10-03 at 16 13 23" src="https://cloud.githubusercontent.com/assets/23947/10263549/f4f28b8e-69e9-11e5-857c-168abcd74719.png">

For example, if `delimStyle` is set to `delim`, then the opening delimiter gets the following token styles: `cm-delim` and `cm-delim-open` and the closing delimiter gets `cm-delim` and `cm-delim-close`.