### PR TITLE
Updated Ceylon mode

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -678,7 +678,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
       return "string";
     }
   }
-  
+
   def("text/x-ceylon", {
     name: "clike",
     keywords: words("abstracts alias assembly assert assign break case catch class continue dynamic else" +
@@ -721,7 +721,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
         stream.eatWhile(/[\w\$_\xa1-\uffff]/);
         return "atom";
       },
-      token: function(stream, state, style) {
+      token: function(_stream, state, style) {
           if ((style == "variable" || style == "variable-3") &&
               state.prevToken == ".") {
             return "variable-2";

--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -716,7 +716,13 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
       "'": function(stream) {
         stream.eatWhile(/[\w\$_\xa1-\uffff]/);
         return "atom";
-      }
+      },
+      token: function(stream, state, style) {
+          if ((style == "variable" || style == "variable-3") &&
+              state.prevToken == ".") {
+            return "variable-2";
+          }
+        }
     },
     modeProps: {
         fold: ["brace", "import"],

--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -26,6 +26,8 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
       indentStatements = parserConfig.indentStatements !== false,
       indentSwitch = parserConfig.indentSwitch !== false,
       namespaceSeparator = parserConfig.namespaceSeparator,
+      isPunctuationChar = parserConfig.isPunctuationChar || /[\[\]{}\(\),;\:\.]/,
+      isNumberChar = parserConfig.isNumberChar || /\d/,
       isOperatorChar = parserConfig.isOperatorChar || /[+\-*&%=<>!?|\/]/,
       endStatement = parserConfig.endStatement || /^[;:,]$/;
 
@@ -41,11 +43,11 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
       state.tokenize = tokenString(ch);
       return state.tokenize(stream, state);
     }
-    if (/[\[\]{}\(\),;\:\.]/.test(ch)) {
+    if (isPunctuationChar.test(ch)) {
       curPunc = ch;
       return null;
     }
-    if (/\d/.test(ch)) {
+    if (isNumberChar.test(ch)) {
       stream.eatWhile(/[\w\.]/);
       return "number";
     }
@@ -692,7 +694,9 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     defKeywords: words("class dynamic function interface module object package value"),
     builtin: words("abstract actual aliased annotation by default deprecated doc final formal late license" +
                    " native optional sealed see serializable shared suppressWarnings tagged throws variable"),
+    isPunctuationChar: /[\[\]{}\(\),;\:\.`]/,
     isOperatorChar: /[+\-*&%=<>!?|^~:\/]/,
+    isNumberChar: /[\d#$]/,
     multiLineStrings: true,
     typeFirstDefinitions: true,
     atoms: words("true false null larger smaller equal empty finished"),

--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -190,7 +190,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
         pushContext(state, stream.column(), type);
       }
 
-      if ((style == "variable" || style == "variable-3") &&
+      if (style == "variable" &&
           ((state.prevToken == "def" ||
             (parserConfig.typeFirstDefinitions && typeBefore(stream, state) &&
              isTopScope(state.context) && stream.match(/^\s*\(/, false)))))
@@ -672,6 +672,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     typeFirstDefinitions: true,
     atoms: words("true false null larger smaller equal empty finished"),
     indentSwitch: false,
+    styleDefs: false,
     hooks: {
       "@": function(stream) {
         stream.eatWhile(/[\w\$_]/);


### PR DESCRIPTION
Affecting all modes:

 - Made punctuation and number characters configurable.
 - Undid a change I made in my previous PR because I noticed similar functionality was already supported with the existing `styleDefs` configuration option.

Affecting only the Ceylon mode:

 - Strings now support interpolation (code within strings)
 - Not using `def` style anymore
 - Style members using `variable-2`
