### PR TITLE
fix vertical scroll jitter on OSX trackpads

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -4004,7 +4004,7 @@
       // actually possible. Otherwise, it causes vertical scroll
       // jitter on OSX trackpads when deltaX is small and deltaY
       // is large:
-      // https://github.com/jupyter/notebook/issues/513#issuecomment-146073284
+      // https://github.com/codemirror/CodeMirror/pull/3579
       if (!dy || (dy && canScrollY))
         e_preventDefault(e);
       display.wheelStartX = null; // Abort measurement, if in progress

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3971,8 +3971,9 @@
 
     var display = cm.display, scroll = display.scroller;
     // Quit if there's nothing to scroll here
-    if (!(dx && scroll.scrollWidth > scroll.clientWidth ||
-          dy && scroll.scrollHeight > scroll.clientHeight)) return;
+    var canScrollX = scroll.scrollWidth > scroll.clientWidth;
+    var canScrollY = scroll.scrollHeight > scroll.clientHeight;
+    if (!(dx && canScrollX || dy && canScrollY)) return;
 
     // Webkit browsers on OS X abort momentum scrolls when the target
     // of the scroll event is removed from the scrollable element.
@@ -3996,10 +3997,16 @@
     // scrolling entirely here. It'll be slightly off from native, but
     // better than glitching out.
     if (dx && !gecko && !presto && wheelPixelsPerUnit != null) {
-      if (dy)
+      if (dy && canScrollY)
         setScrollTop(cm, Math.max(0, Math.min(scroll.scrollTop + dy * wheelPixelsPerUnit, scroll.scrollHeight - scroll.clientHeight)));
       setScrollLeft(cm, Math.max(0, Math.min(scroll.scrollLeft + dx * wheelPixelsPerUnit, scroll.scrollWidth - scroll.clientWidth)));
-      e_preventDefault(e);
+      // Only prevent default scrolling if vertical scrolling is
+      // actually possible. Otherwise, it causes vertical scroll
+      // jitter on OSX trackpads when deltaX is small and deltaY
+      // is large:
+      // https://github.com/jupyter/notebook/issues/513#issuecomment-146073284
+      if (!dy || (dy && canScrollY))
+        e_preventDefault(e);
       display.wheelStartX = null; // Abort measurement, if in progress
       return;
     }


### PR DESCRIPTION
This fixes an issue (jupyter/notebook#513) we see when using a trackpad to vertically scroll a page with several CodeMirror instances, none of which have vertical overflow. A full description/explanation of the cause can be found in the [issue comment](https://github.com/jupyter/notebook/issues/513#issuecomment-146073284). 

Basically, preventing the default action on a small `deltaX` wheel event prevents the page from scrolling vertically. Since humans are imprecise, and OSX track pads support simultaneous `deltaX` and `deltaY`, scrolling such pages is jittery because CodeMirror squashes some percentage of the events where `deltaX` is not zero.

This works around the issue by only preventing the default if there was either no vertical scroll delta, or if there is actually content which could be vertically scrolled.

This PR assumes you have prevented the default in order to avoid horizontally scrolling the page *in addition* to horizontally scrolling the CodeMirror content (which seems reasonable to me). If you think it's not worth the bother, we can just remove the `preventDefault`.