### PR TITLE
Restore true as a Scala keyword

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -478,9 +478,9 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     keywords: words(
 
       /* scala */
-      "abstract case catch class def do else extends false final finally for forSome if " +
+      "abstract case catch class def do else extends final finally for forSome if " +
       "implicit import lazy match new null object override package private protected return " +
-      "sealed super this throw trait true try type val var while with yield _ : = => <- <: " +
+      "sealed super this throw trait try type val var while with yield _ : = => <- <: " +
       "<% >: # @ " +
 
       /* package scala */

--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -480,7 +480,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
       /* scala */
       "abstract case catch class def do else extends false final finally for forSome if " +
       "implicit import lazy match new null object override package private protected return " +
-      "sealed super this throw trait try type val var while with yield _ : = => <- <: " +
+      "sealed super this throw trait true try type val var while with yield _ : = => <- <: " +
       "<% >: # @ " +
 
       /* package scala */


### PR DESCRIPTION
Removed in 3d5d9a4af38facd8c2d79abbe74ead61470ca97b as it had been
mispelled when introduced in eb495233e3813d04c20e495dcf88217e093261fc.

After talking with @marijnh, will remove false as Scala keyword in favor of true/false being defined as atoms.