### PR TITLE
Allow passing options to toggleComment

### DIFF
--- a/addon/comment/comment.js
+++ b/addon/comment/comment.js
@@ -21,22 +21,27 @@
   }
 
   CodeMirror.commands.toggleComment = function(cm) {
-    var minLine = Infinity, ranges = cm.listSelections(), mode = null;
+    cm.toggleComment();
+  };
+
+  CodeMirror.defineExtension("toggleComment", function(options) {
+    if (!options) options = noOptions;
+    var minLine = Infinity, ranges = this.listSelections(), mode = null;
     for (var i = ranges.length - 1; i >= 0; i--) {
       var from = ranges[i].from(), to = ranges[i].to();
       if (from.line >= minLine) continue;
       if (to.line >= minLine) to = Pos(minLine, 0);
       minLine = from.line;
       if (mode == null) {
-        if (cm.uncomment(from, to)) mode = "un";
-        else { cm.lineComment(from, to); mode = "line"; }
+        if (cm.uncomment(from, to, options)) mode = "un";
+        else { cm.lineComment(from, to, options); mode = "line"; }
       } else if (mode == "un") {
-        cm.uncomment(from, to);
+        cm.uncomment(from, to, options);
       } else {
-        cm.lineComment(from, to);
+        cm.lineComment(from, to, options);
       }
     }
-  };
+  });
 
   CodeMirror.defineExtension("lineComment", function(from, to, options) {
     if (!options) options = noOptions;

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2313,9 +2313,12 @@ editor.setOption("extraKeys", {
       demo</a>.</dd>
 
       <dt id="addon_comment"><a href="../addon/comment/comment.js"><code>comment/comment.js</code></a></dt>
-      <dd>Addon for commenting and uncommenting code. Adds three
+      <dd>Addon for commenting and uncommenting code. Adds four
       methods to CodeMirror instances:
       <dl>
+        <dt id="toggleComment"><code><strong>toggleComment</strong>(from: {line, ch}, to: {line, ch}, ?options: object)</code></dt>
+        <dd>Tries to uncomment the current selection, and if that
+        fails, line-comments it.</dd>
         <dt id="lineComment"><code><strong>lineComment</strong>(from: {line, ch}, to: {line, ch}, ?options: object)</code></dt>
         <dd>Set the lines in the given range to be line comments. Will
         fall back to <code>blockComment</code> when no line comment
@@ -2353,8 +2356,8 @@ editor.setOption("extraKeys", {
       </dl>
       The addon also defines
       a <code>toggleComment</code> <a href="#commands">command</a>,
-      which will try to uncomment the current selection, and if that
-      fails, line-comments it.</dd>
+      which is a shorthand command for calling
+      <code>toggleComment</code> with no options.</dd>
 
       <dt id="addon_foldcode"><a href="../addon/fold/foldcode.js"><code>fold/foldcode.js</code></a></dt>
       <dd>Helps with code folding. Adds a <code>foldCode</code> method

--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -240,7 +240,9 @@
     });
   };
 
-  map[ctrl + "/"] = "toggleComment";
+  map[ctrl + "/"] = function(cm) {
+    cm.toggleComment({ indent: true });
+  }
 
   cmds[map[ctrl + "J"] = "joinLines"] = function(cm) {
     var ranges = cm.listSelections(), joined = [];


### PR DESCRIPTION
The `toggleComment` helper is very useful, and the sublime keymap uses it by default. However, the actual sublime behavior for that keystroke is to comment with indentation.

This change makes `toggleComment` a first class extension method, and leaves the command (of the same name) to just call the extension. The new extension also takes an options object to allow more customization.