### PR TITLE
Smarter indenting in multiline linecommenting

### DIFF
--- a/addon/comment/comment.js
+++ b/addon/comment/comment.js
@@ -57,7 +57,14 @@
 
     self.operation(function() {
       if (options.indent) {
-        var baseString = firstLine.slice(0, firstNonWS(firstLine));
+        var baseString = null;
+        for (var i = from.line; i < end; ++i) {
+          var line = self.getLine(i);
+          var whitespace = line.slice(0, firstNonWS(line));
+          if (baseString == null || baseString.length > whitespace.length) {
+            baseString = whitespace;
+          }
+        }
         for (var i = from.line; i < end; ++i) {
           var line = self.getLine(i), cut = baseString.length;
           if (!blankLines && !nonWS.test(line)) continue;

--- a/test/comment_test.js
+++ b/test/comment_test.js
@@ -79,7 +79,7 @@ namespace = "comment_";
 
   test("indented", "javascript", function(cm) {
     cm.lineComment(Pos(1, 0), Pos(2), {indent: true});
-  }, simpleProg, "function foo() {\n  // return bar;\n  // }");
+  }, simpleProg, "function foo() {\n//   return bar;\n// }");
 
   test("singleEmptyLine", "javascript", function(cm) {
     cm.setCursor(1);


### PR DESCRIPTION
When indenting multiple lines with `lineComment` and `indent: true`, you currently get behavior like this:

```ruby
def test
  p ‘comment me’
end

# after commenting the last two lines…

def test
  # p ‘comment me’
  # end
```

Which messes up the indentation of the block. Preferably, it would look like (and does in sublime, at least):

```ruby
def test
#   p ‘comment me’
# end
```

This change makes `lineComment` smarter by looking for the minimum indent level of the selected range, and only commenting at that depth. It’s not 100% smart in that it doesn’t use column positioning to account for mixed tab usage, but its better than what we have right now.
