### PR TITLE
Fix TypeScript mode to highlight "boolean" not "bool"

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -56,7 +56,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
         "static": kw("static"),
 
         // types
-        "string": type, "number": type, "bool": type, "any": type
+        "string": type, "number": type, "boolean": type, "any": type
       };
 
       for (var attr in tsKeywords) {


### PR DESCRIPTION
Hey there. This PR fixes the type name for boolean variables in TypeScript, which is spelled "boolean", not "bool" (which I guess was infered from C++ - EDIT: actually looks like it was initially named bool and then they fixed it - https://typescript.codeplex.com/workitem/135).

Thanks!