### PR TITLE
Merge addon: Use npm's copy of diff-match-patch for CommonJS requires

### DIFF
--- a/addon/merge/merge.js
+++ b/addon/merge/merge.js
@@ -3,17 +3,21 @@
 
 // declare global: diff_match_patch, DIFF_INSERT, DIFF_DELETE, DIFF_EQUAL
 
-(function(mod) {
+(function(mod, root) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
-    mod(require("../../lib/codemirror"), require("diff_match_patch"));
+    mod(require("../../lib/codemirror"), require("diff-match-patch"), root);
   else if (typeof define == "function" && define.amd) // AMD
-    define(["../../lib/codemirror", "diff_match_patch"], mod);
+    define(["../../lib/codemirror", "diff_match_patch"], mod, root);
   else // Plain browser env
-    mod(CodeMirror);
-})(function(CodeMirror) {
+    mod(CodeMirror, diff_match_patch, root);
+})(function(CodeMirror, diff_match_patch, root) {
   "use strict";
   var Pos = CodeMirror.Pos;
   var svgNS = "http://www.w3.org/2000/svg";
+
+  var DIFF_INSERT = 'DIFF_INSERT' in diff_match_patch ? diff_match_patch.DIFF_INSERT : root.DIFF_INSERT;
+  var DIFF_DELETE = 'DIFF_DELETE' in diff_match_patch ? diff_match_patch.DIFF_DELETE : root.DIFF_DELETE;
+  var DIFF_EQUAL = 'DIFF_EQUAL' in diff_match_patch ? diff_match_patch.DIFF_EQUAL : root.DIFF_EQUAL;
 
   function DiffView(mv, type) {
     this.mv = mv;
@@ -772,4 +776,4 @@
   CodeMirror.commands.goPrevDiff = function(cm) {
     return goNearbyDiff(cm, -1);
   };
-});
+}, this);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "directories": {"lib": "./lib"},
     "scripts": {"test": "node ./test/run.js"},
+    "dependencies": {"diff-match-patch": "^1.0.0"},
     "devDependencies": {"node-static": "0.6.0",
                         "phantomjs": "1.9.2-5",
                         "blint": ">=0.1.1"},


### PR DESCRIPTION
This lists `diff-match-patch` as a formal requirement in package json and updates the UMD wrapper in the merge addon to properly use it (afaict it currently just requires it and throws it away). We could probably use the [`diff_match_patch` module on npm](https://www.npmjs.com/package/diff_match_patch) (note the underscores), but it has no README and I simply trust @ForbesLindesay more as a maintainer.

Since these packages (responsibly :stuck_out_tongue_closed_eyes:) attach the `DIFF_INSERT`, etc. enum values to the module and not the global scope, we also check the module to see if they exist there before falling back to the global versions (which don't exist in the CJS versions).