### PR TITLE
Handle <constructor> tags in htmlmixed mode (fixes mozilla bug 1214663)

### DIFF
--- a/mode/htmlmixed/htmlmixed.js
+++ b/mode/htmlmixed/htmlmixed.js
@@ -91,10 +91,11 @@
     function html(stream, state) {
       var tagName = state.htmlState.tagName;
       var tagInfo = tagName && tags[tagName.toLowerCase()];
+      var isTagInfoArray = Object.prototype.toString.call(tagInfo) === "[object Array]";
 
       var style = htmlMode.token(stream, state.htmlState), modeSpec;
 
-      if (tagInfo && /\btag\b/.test(style) && stream.current() === ">" &&
+      if (isTagInfoArray && /\btag\b/.test(style) && stream.current() === ">" &&
           (modeSpec = findMatchingMode(tagInfo, stream))) {
         var mode = CodeMirror.getMode(config, modeSpec);
         var endTagA = getTagRegexp(tagName, true), endTag = getTagRegexp(tagName, false);


### PR DESCRIPTION
This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1214663.  The HTML mixed syntax mode is breaking the editor when encountering a `<constructor>` tag, so instead of checking that tagInfo exists, we need to make sure it's actually an array before continuing into findMatchingMode.

You can see the problem if you update the modes index.html demo to include this tag:

    <constructor>
      foobar
    </constructor>