### PR TITLE
[dart mode] support for triple-quoted strings and string interpolation

### DIFF
--- a/mode/dart/dart.js
+++ b/mode/dart/dart.js
@@ -26,10 +26,21 @@
     return obj;
   }
 
+  function pushInterpolationStack(state) {
+    (state.interpolationStack || (state.interpolationStack = [])).push(state.tokenize);
+  }
+
+  function popInterpolationStack(state) {
+    return (state.interpolationStack || (state.interpolationStack = [])).pop();
+  }
+
+  function sizeInterpolationStack(state) {
+    return (state.interpolationStack || (state.interpolationStack = [])).length;
+  }
+
   CodeMirror.defineMIME("application/dart", {
     name: "clike",
     keywords: set(keywords),
-    multiLineStrings: true,
     blockKeywords: set(blockKeywords),
     builtin: set(builtins),
     atoms: set(atoms),
@@ -37,9 +48,78 @@
       "@": function(stream) {
         stream.eatWhile(/[\w\$_]/);
         return "meta";
+      },
+
+      // custom string handling to deal with triple-quoted strings and string interpolation
+      "'": function(stream, state) {
+        return tokenString("'", stream, state, false);
+      },
+      "\"": function(stream, state) {
+        return tokenString("\"", stream, state, false);
+      },
+      "r": function(stream, state) {
+        var peek = stream.peek();
+        if (peek == "'" || peek == "\"") {
+          return tokenString(stream.next(), stream, state, true);
+        }
+        return false;
+      },
+
+      "}": function(_stream, state) {
+        // "}" is end of interpolation, if interpolation stack is non-empty
+        if (sizeInterpolationStack(state) > 0) {
+          state.tokenize = popInterpolationStack(state);
+          return null;
+        }
+        return false;
       }
     }
   });
+
+  function tokenString(quote, stream, state, raw) {
+    var tripleQuoted = false;
+    if (stream.eat(quote)) {
+      if (stream.eat(quote)) tripleQuoted = true;
+      else return "string"; //empty string
+    }
+    function tokenStringHelper(stream, state) {
+      var escaped = false;
+      while (!stream.eol()) {
+        if (!raw && !escaped && stream.peek() == "$") {
+          pushInterpolationStack(state);
+          state.tokenize = tokenInterpolation;
+          return "string";
+        }
+        var next = stream.next();
+        if (next == quote && !escaped && (!tripleQuoted || stream.match(quote + quote))) {
+          state.tokenize = null;
+          break;
+        }
+        escaped = !escaped && next == "\\";
+      }
+      return "string";
+    }
+    state.tokenize = tokenStringHelper;
+    return tokenStringHelper(stream, state);
+  }
+
+  function tokenInterpolation(stream, state) {
+    stream.eat("$");
+    if (stream.eat("{")) {
+      // let clike handle the content of ${...},
+      // we take over again when "}" appears (see hooks).
+      state.tokenize = null;
+    } else {
+      state.tokenize = tokenInterpolationIdentifier;
+    }
+    return null;
+  }
+
+  function tokenInterpolationIdentifier(stream, state) {
+    stream.eatWhile(/[\w_]/);
+    state.tokenize = popInterpolationStack(state);
+    return "variable";
+  }
 
   CodeMirror.registerHelper("hintWords", "application/dart", keywords.concat(atoms).concat(builtins));
 


### PR DESCRIPTION
- Previously, triple-quoted multi-line strings could be closed with a single quote, e.g. CodeMirror thought the following was a legal string literal: ```'''This string literal is not terminated correctly'```. Also reported here: dart-lang/dart-pad#667.
- String interpolation with ```$identifier``` and ```${expression}``` now works