### PR TITLE
[javascript mode] style metaproperty as keyword

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -358,7 +358,9 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (type == "import") return cont(pushlex("stat"), afterImport, poplex);
     return pass(pushlex("stat"), expression, expect(";"), poplex);
   }
-  function expression(type) {
+  function expression(type, value) {
+    // Currently, new.target is the only valid metaproperty
+    if (type === "keyword c" && value === "new") return cont(metaproperty);
     return expressionInner(type, false);
   }
   function expressionNoComma(type) {
@@ -437,6 +439,16 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   }
   function property(type) {
     if (type == "variable") {cx.marked = "property"; return cont();}
+  }
+  function metaproperty(type) {
+    if (type !== ".") return pass();
+    return cont(metapropertySuffix);
+    function metapropertySuffix(type, value) {
+      if (type !== "variable") return pass();
+      if (value !== "target") return pass();
+      cx.marked = "keyword";
+      return cont();
+    }
   }
   function objprop(type, value) {
     if (type == "async") {

--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -413,6 +413,14 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (type == ".") return cont(property, me);
     if (type == "[") return cont(pushlex("]"), maybeexpression, expect("]"), poplex, me);
   }
+  function memberExpressionContinuation(type, value) {
+    var me = memberExpressionContinuation;
+    if (type == "quasi") { return pass(quasi, me); }
+    if (type == ";") return;
+    if (type == "(") return contCommasep(expressionNoComma, ")", "call", me);
+    if (type == ".") return cont(property, me);
+    if (type == "[") return cont(pushlex("]"), maybeexpression, expect("]"), poplex, me);
+  }
   function quasi(type, value) {
     if (type != "quasi") return pass();
     if (value.slice(value.length - 2) != "${") return cont(quasi);
@@ -447,7 +455,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
       if (type !== "variable") return pass();
       if (value !== "target") return pass();
       cx.marked = "keyword";
-      return cont();
+      return cont(memberExpressionContinuation);
     }
   }
   function objprop(type, value) {

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -159,8 +159,8 @@
      "}");
 
   MT("new_target",
-     "[keyword function] [def F]([def taget]) {",
-     "  [keyword if] ([variable target]) {",
+     "[keyword function] [def F]([def target]) {",
+     "  [keyword if] ([variable-2 target] [operator &&] [keyword new].[keyword target].[property name]) {",
      "    [keyword return] [keyword new]",
      "      .[keyword target];",
      "  }",

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -158,6 +158,14 @@
      "  [keyword return] [variable-2 x];",
      "}");
 
+  MT("new_target",
+     "[keyword function] [def F]([def taget]) {",
+     "  [keyword if] ([variable target]) {",
+     "    [keyword return] [keyword new]",
+     "      .[keyword target];",
+     "  }",
+     "}");
+
   var jsonld_mode = CodeMirror.getMode(
     {indentUnit: 2},
     {name: "javascript", jsonld: true}


### PR DESCRIPTION
Add a mechanism for styling metaproperties, which should be simple to extend
if new ones are added in the future.