### PR TITLE
fix(search) advance stream position even if there is a zero length match

### DIFF
--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -29,7 +29,7 @@
       query.lastIndex = stream.pos;
       var match = query.exec(stream.string);
       if (match && match.index == stream.pos) {
-        stream.pos += match[0].length;
+        stream.pos += match[0].length ? match[0].length : 1;
         return "searching";
       } else if (match) {
         stream.pos = match.index;


### PR DESCRIPTION
E.g. if someone search for `\b` in regex mode the length of the match is `0` and then in [`readToken`](https://github.com/codemirror/CodeMirror/blob/c375d82c98e0e2ce728a78d1a308471994730b9f/lib/codemirror.js#L6733-L6740) it will [call the `token` function](https://github.com/codemirror/CodeMirror/blob/c375d82c98e0e2ce728a78d1a308471994730b9f/lib/codemirror.js#L6736) However since `pos` does not change it [errors out](https://github.com/codemirror/CodeMirror/blob/c375d82c98e0e2ce728a78d1a308471994730b9f/lib/codemirror.js#L6739) `throw new Error("Mode " + mode.name + " failed to advance stream.");` 

# After the fix

Seems to work fine :rose:

![image](https://cloud.githubusercontent.com/assets/874898/10811717/19b0cc1e-7e63-11e5-9ba0-5245545cedef.png)
