### PR TITLE
[dart mode] fix escaping in raw strings

### DIFF
--- a/mode/dart/dart.js
+++ b/mode/dart/dart.js
@@ -95,7 +95,7 @@
           state.tokenize = null;
           break;
         }
-        escaped = !escaped && next == "\\";
+        escaped = !raw && !escaped && next == "\\";
       }
       return "string";
     }


### PR DESCRIPTION
In a raw string, a character following a "\" is not escaped.