### PR TITLE
Fix material.css cm-error state

### DIFF
--- a/theme/material.css
+++ b/theme/material.css
@@ -32,10 +32,6 @@
 .cm-s-material .cm-atom { color: #F77669; }
 .cm-s-material .cm-number { color: #F77669; }
 .cm-s-material .cm-def { color: rgba(233, 237, 237, 1); }
-.cm-s-material .cm-error {
-  color: rgba(255, 255, 255, 1.0);
-  background-color: #EC5F67;
-}
 .cm-s-material .cm-string { color: #C3E88D; }
 .cm-s-material .cm-string-2 { color: #80CBC4; }
 .cm-s-material .cm-comment { color: #546E7A; }
@@ -47,6 +43,10 @@
 .cm-s-material .cm-qualifier { color: #DECB6B; }
 .cm-s-material .cm-variable-3 { color: #DECB6B; }
 .cm-s-material .cm-tag { color: rgba(255, 83, 112, 1); }
+.cm-s-material .cm-error {
+  color: rgba(255, 255, 255, 1.0);
+  background-color: #EC5F67;
+}
 .cm-s-material .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;


### PR DESCRIPTION
it seems `.cm-error` lost some specificity in [this commit](https://github.com/codemirror/CodeMirror/commit/a7d443ec82c1806d24e25ad8014a4d8651409320#diff-33646e9ee4d04eedb98a991a636c2302L35) that causes the error state to have same color as the tag.

![c22ad46c-7656-11e5-808f-b3136875428a](https://cloud.githubusercontent.com/assets/10403/10956424/c49d1eac-8318-11e5-918f-2cadfa41dccb.png)

EDIT: As I look at that commit again, I don't think that was actually the problem - I think it's always been an issue. And `cm-tag` seems to have to rules as well. 