### PR TITLE
added even/odd classes to generated lines

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -867,7 +867,7 @@
       var lineView = view[i];
       if (lineView.hidden) {
       } else if (!lineView.node || lineView.node.parentNode != container) { // Not drawn yet
-        var node = buildLineElement(cm, lineView, lineN, dims);
+        var node = buildLineElement(cm, lineView, lineN, dims, i);
         container.insertBefore(node, cur);
       } else { // Already drawn
         while (cur != lineView.node) cur = rm(cur);
@@ -929,14 +929,14 @@
 
   // Wrapper around buildLineContent which will reuse the structure
   // in display.externalMeasured when possible.
-  function getLineContent(cm, lineView) {
+  function getLineContent(cm, lineView, lineIndex) {
     var ext = cm.display.externalMeasured;
     if (ext && ext.line == lineView.line) {
       cm.display.externalMeasured = null;
       lineView.measure = ext.measure;
       return ext.built;
     }
-    return buildLineContent(cm, lineView);
+    return buildLineContent(cm, lineView, lineIndex);
   }
 
   // Redraw the line's text. Interacts with the background and text
@@ -1018,8 +1018,8 @@
   }
 
   // Build a line's DOM representation from scratch
-  function buildLineElement(cm, lineView, lineN, dims) {
-    var built = getLineContent(cm, lineView);
+  function buildLineElement(cm, lineView, lineN, dims, lineIndex) {
+    var built = getLineContent(cm, lineView, lineIndex);
     lineView.text = lineView.node = built.pre;
     if (built.bgClass) lineView.bgClass = built.bgClass;
     if (built.textClass) lineView.textClass = built.textClass;
@@ -2556,12 +2556,12 @@
 
   // Render a line into the hidden node display.externalMeasured. Used
   // when measurement is needed for a line that's not in the viewport.
-  function updateExternalMeasurement(cm, line) {
+  function updateExternalMeasurement(cm, line, lineIndex) {
     line = visualLine(line);
     var lineN = lineNo(line);
     var view = cm.display.externalMeasured = new LineView(cm.doc, line, lineN);
     view.lineN = lineN;
-    var built = view.built = buildLineContent(cm, view);
+    var built = view.built = buildLineContent(cm, view, lineIndex);
     view.text = built.pre;
     removeChildrenAndAdd(cm.display.lineMeasure, built.pre);
     return view;
@@ -2587,7 +2587,7 @@
   // character. Functions like coordsChar, that need to do a lot of
   // measurements in a row, can thus ensure that the set-up work is
   // only done once.
-  function prepareMeasureForLine(cm, line) {
+  function prepareMeasureForLine(cm, line, lineIndex) {
     var lineN = lineNo(line);
     var view = findViewForLine(cm, lineN);
     if (view && !view.text) {
@@ -2597,7 +2597,7 @@
       cm.curOp.forceUpdate = true;
     }
     if (!view)
-      view = updateExternalMeasurement(cm, line);
+      view = updateExternalMeasurement(cm, line, lineIndex);
 
     var info = mapFromLineView(view, line, lineN);
     return {
@@ -2816,7 +2816,7 @@
   // on a bidi boundary.
   function cursorCoords(cm, pos, context, lineObj, preparedMeasure, varHeight) {
     lineObj = lineObj || getLine(cm.doc, pos.line);
-    if (!preparedMeasure) preparedMeasure = prepareMeasureForLine(cm, lineObj);
+    if (!preparedMeasure) preparedMeasure = prepareMeasureForLine(cm, lineObj, lineIndex);
     function get(ch, right) {
       var m = measureCharPrepared(cm, preparedMeasure, ch, right ? "right" : "left", varHeight);
       if (right) m.left = m.right; else m.right = m.left;
@@ -2896,7 +2896,7 @@
     var preparedMeasure = prepareMeasureForLine(cm, lineObj);
 
     function getX(ch) {
-      var sp = cursorCoords(cm, Pos(lineNo, ch), "line", lineObj, preparedMeasure);
+      var sp = cursorCoords(cm, Pos(lineNo, ch), "line", lineObj, preparedMeasure, lineNo);
       wrongLine = true;
       if (innerOff > sp.bottom) return sp.left - adjust;
       else if (innerOff < sp.top) return sp.left + adjust;
@@ -6898,12 +6898,16 @@
   // specific stretches of text, and is used by the measuring code.
   // The returned object contains the DOM node, this map, and
   // information about line-wide styles that were set by the mode.
-  function buildLineContent(cm, lineView) {
+  function buildLineContent(cm, lineView, lineIndex) {
     // The padding-right forces the element to have a 'border', which
     // is needed on Webkit to be able to get line-level bounding
     // rectangles for it (in measureChar).
+	var classNames = {
+		true: 'odd', 
+		false: 'even'
+	}
     var content = elt("span", null, null, webkit ? "padding-right: .1px" : null);
-    var builder = {pre: elt("pre", [content], "CodeMirror-line"), content: content,
+    var builder = {pre: elt("pre", [content], "CodeMirror-line" + " " + classNames[0 == lineIndex%2]), content: content,
                    col: 0, pos: 0, cm: cm,
                    splitSpaces: (ie || webkit) && cm.getOption("lineWrapping")};
     lineView.measure = {};


### PR DESCRIPTION
Hi, I added even/odd class to generated lines, so I'm not forced to wirte tricky CSS for zebras in lines (such as: .CodeMirror-code > div:nth-child(even) > .CodeMirror-line{background:#dddddd;}, that works well, but won't work if you change the DOM elements hierarchy, and this CSS code is ugly).
Sorry I have no time to test (and don't know how to do it).

Thanks for this amazing library!