### PR TITLE
Scoping measureText to be inside the function textHeight to eliminate stale references (IE11)

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2930,20 +2930,20 @@
     }
   }
 
-  var measureText;
+ 
   // Compute the default text height.
   function textHeight(display) {
     if (display.cachedTextHeight != null) return display.cachedTextHeight;
-    if (measureText == null) {
-      measureText = elt("pre");
-      // Measure a bunch of lines, for browsers that compute
-      // fractional heights.
-      for (var i = 0; i < 49; ++i) {
-        measureText.appendChild(document.createTextNode("x"));
-        measureText.appendChild(elt("br"));
-      }
+
+    var measureText = elt("pre");
+    // Measure a bunch of lines, for browsers that compute
+    // fractional heights.
+    for (var i = 0; i < 49; ++i) {
       measureText.appendChild(document.createTextNode("x"));
+      measureText.appendChild(elt("br"));
     }
+    measureText.appendChild(document.createTextNode("x"));
+
     removeChildrenAndAdd(display.measure, measureText);
     var height = measureText.offsetHeight / 50;
     if (height > 3) display.cachedTextHeight = height;

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2930,7 +2930,6 @@
     }
   }
 
- 
   // Compute the default text height.
   function textHeight(display) {
     if (display.cachedTextHeight != null) return display.cachedTextHeight;


### PR DESCRIPTION
… textHeight to eliminate stale references

See issue #3633 