### PR TITLE
change selected item in hint options on mousemove

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -295,6 +295,13 @@
       setTimeout(function(){cm.focus();}, 20);
     });
 
+    CodeMirror.on(hints, "mousemove", function(e) {
+      var t = getHintElement(hints, e.target || e.srcElement);
+      if (t && t.hintId != null) {
+        widget.changeActive(t.hintId);
+      }
+    });
+
     CodeMirror.signal(data, "select", completions[0], hints.firstChild);
     return true;
   }


### PR DESCRIPTION
## Enhancement

### Issue
currently only cursor keys change the highlighted option and allow hitting Enter to select it.
If the user moves the mouse over the select box, there is no visual feedback (unless hover styling is applied) to show the option that will be selected when clicked. If hover styling is applied, 2 items in the list will be highlighted; the active one and the hovered one.

### Solution
this PR allows the user to switch between keyboard and mouse navigation of the hint options by using the mouse move event to change the selected option.