### PR TITLE
Typo

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -712,7 +712,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
         f: s.f,
 
         prevLine: s.prevLine,
-        thisLine: s.this,
+        thisLine: s.thisLine,
 
         block: s.block,
         htmlState: s.htmlState && CodeMirror.copyState(htmlMode, s.htmlState),


### PR DESCRIPTION
Apart from affecting markdown feature, it can break whole CM in older browsers (like IE8).

In my case I've inlined CM with a bunch of addons, and got IE syntax error, rendering whole CM inlined script unparseable. That's because `s.this` uses risky `this` in place of property name.