### PR TITLE
[dart mode] add "as" to keywords

### DIFF
--- a/mode/dart/dart.js
+++ b/mode/dart/dart.js
@@ -15,7 +15,7 @@
     "implements get native operator set typedef with enum throw rethrow " +
     "assert break case continue default in return new deferred async await " +
     "try catch finally do else for if switch while import library export " +
-    "part of show hide is").split(" ");
+    "part of show hide is as").split(" ");
   var blockKeywords = "try catch finally do else for if switch while".split(" ");
   var atoms = "true false null".split(" ");
   var builtins = "void bool num int double dynamic var String".split(" ");


### PR DESCRIPTION
`import "package:foo/foo.dart" as bar;` should highlight "as" as a keyword.