### PR TITLE
haml + liquid: Current behavior sees the closing %} as a haml tag begin.

### DIFF
--- a/mode/haml/haml.js
+++ b/mode/haml/haml.js
@@ -85,8 +85,10 @@
           state.tokenize = rubyInQuote(")");
           return state.tokenize(stream, state);
         } else if (ch == "{") {
-          state.tokenize = rubyInQuote("}");
-          return state.tokenize(stream, state);
+          if (!stream.match(/^\{%.*/)) {
+            state.tokenize = rubyInQuote("}");
+            return state.tokenize(stream, state);
+          }
         }
       }
 


### PR DESCRIPTION
The result is that the rest of the file after the %} doesnt highlight correctly.
Proposed fix: Dont go into quote mode when stream is '{%'.