### PR TITLE
[annotatescrollbar addon] Add an id attribute to annotations

### DIFF
--- a/addon/scroll/annotatescrollbar.js
+++ b/addon/scroll/annotatescrollbar.js
@@ -100,6 +100,9 @@
       elt.style.cssText = "position: absolute; right: 0px; width: " + Math.max(cm.display.barWidth - 1, 2) + "px; top: "
         + (top + this.buttonHeight) + "px; height: " + height + "px";
       elt.className = this.options.className;
+      if (ann.id) {
+        ann.setAttribute("annotation-id", ann.id);
+      }
     }
     this.div.textContent = "";
     this.div.appendChild(frag);


### PR DESCRIPTION
I mainly want this so that I can bring the annotation into view when it's clicked. It's useful when files are large enough that finding the annotation by hand would be difficult.