### PR TITLE
Introducing options.updateWhenComposing

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1299,21 +1299,23 @@
         if (!eventInWidget(display, e)) e_preventDefault(e);
       });
 
-      on(te, "compositionstart", function() {
-        var start = cm.getCursor("from");
-        if (input.composing) input.composing.range.clear()
-        input.composing = {
-          start: start,
-          range: cm.markText(start, cm.getCursor("to"), {className: "CodeMirror-composing"})
-        };
-      });
-      on(te, "compositionend", function() {
-        if (input.composing) {
-          input.poll();
-          input.composing.range.clear();
-          input.composing = null;
-        }
-      });
+      if (!cm.options.updateWhenComposing) {
+        on(te, "compositionstart", function() {
+          var start = cm.getCursor("from");
+          if (input.composing) input.composing.range.clear()
+          input.composing = {
+            start: start,
+            range: cm.markText(start, cm.getCursor("to"), {className: "CodeMirror-composing"})
+          };
+        });
+        on(te, "compositionend", function() {
+          if (input.composing) {
+            input.poll();
+            input.composing.range.clear();
+            input.composing = null;
+          }
+        });
+      }
     },
 
     prepareSelection: function() {
@@ -1576,35 +1578,37 @@
 
       on(div, "paste", function(e) { handlePaste(e, cm); })
 
-      on(div, "compositionstart", function(e) {
-        var data = e.data;
-        input.composing = {sel: cm.doc.sel, data: data, startData: data};
-        if (!data) return;
-        var prim = cm.doc.sel.primary();
-        var line = cm.getLine(prim.head.line);
-        var found = line.indexOf(data, Math.max(0, prim.head.ch - data.length));
-        if (found > -1 && found <= prim.head.ch)
-          input.composing.sel = simpleSelection(Pos(prim.head.line, found),
-                                                Pos(prim.head.line, found + data.length));
-      });
-      on(div, "compositionupdate", function(e) {
-        input.composing.data = e.data;
-      });
-      on(div, "compositionend", function(e) {
-        var ours = input.composing;
-        if (!ours) return;
-        if (e.data != ours.startData && !/\u200b/.test(e.data))
-          ours.data = e.data;
-        // Need a small delay to prevent other code (input event,
-        // selection polling) from doing damage when fired right after
-        // compositionend.
-        setTimeout(function() {
-          if (!ours.handled)
-            input.applyComposition(ours);
-          if (input.composing == ours)
-            input.composing = null;
-        }, 50);
-      });
+      if (!cm.options.updateWhenComposing) {
+        on(div, "compositionstart", function(e) {
+          var data = e.data;
+          input.composing = {sel: cm.doc.sel, data: data, startData: data};
+          if (!data) return;
+          var prim = cm.doc.sel.primary();
+          var line = cm.getLine(prim.head.line);
+          var found = line.indexOf(data, Math.max(0, prim.head.ch - data.length));
+          if (found > -1 && found <= prim.head.ch)
+            input.composing.sel = simpleSelection(Pos(prim.head.line, found),
+                                                  Pos(prim.head.line, found + data.length));
+        });
+        on(div, "compositionupdate", function(e) {
+          input.composing.data = e.data;
+        });
+        on(div, "compositionend", function(e) {
+          var ours = input.composing;
+          if (!ours) return;
+          if (e.data != ours.startData && !/\u200b/.test(e.data))
+            ours.data = e.data;
+          // Need a small delay to prevent other code (input event,
+          // selection polling) from doing damage when fired right after
+          // compositionend.
+          setTimeout(function() {
+            if (!ours.handled)
+              input.applyComposition(ours);
+            if (input.composing == ours)
+              input.composing = null;
+          }, 50);
+        });
+      }
 
       on(div, "touchstart", function() {
         input.forceCompositionEnd();


### PR DESCRIPTION
This option (defaulting to `false`) makes CodeMirror ignore composing events, which switches off mobile keyboard suggestions and makes mobile experience align closely with the desktop for highlighting and change handling.

The purpose of the option is rich code editing and IDEs, which provide custom completions and rich contextual services.

These IDE features tend to conflict with mobile touch keyboard suggestions.

The key downside is IME is disabled or severely handicapped when this option is enabled. Given that most programming languages tend to stick with English and ASCII, lack of IME is often a reasonable tradeoff.