### PR TITLE
Fixing hidding keyboard on arrow keys on mobile.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1692,8 +1692,13 @@
       try { var rng = range(start.node, start.offset, end.offset, end.node); }
       catch(e) {} // Our model of the DOM might be outdated, in which case the range we try to set can be impossible
       if (rng) {
-        sel.removeAllRanges();
-        sel.addRange(rng);
+        if (this.cm.state.focused && start.offset == end.offset) {
+          sel.collapse(start.node, start.offset);
+        }
+        else {
+          sel.removeAllRanges();
+          sel.addRange(rng);
+        }
         if (old && sel.anchorNode == null) sel.addRange(old);
         else if (gecko) this.startGracePeriod();
       }


### PR DESCRIPTION
Fixing #3653 *Arrow keys hide keyboard - Chrome mobile 46*

When these conditions are met:
* inputStyle is contenteditable
* editor is focused
* new selection is collapsed (zero-length)

Use `selection.collapse()` instead of `selection.removeAllRanges(); selection.addRange()`

Tested on Chrome mobile, Opera, FireFox, **no regressions.**

The original problem is fixed on Chrome/Opera, still persists in FireFox.

Also note that Shift+Arrow still makes keyboard disappear. Perhaps, one more special case needs to be added (in this case the code would skip removeAllRanges and only do addRange). The condition for that other special case would be something like 'new selection completely engulfs the old selection'.