### PR TITLE
Fix mobile shift arrows

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1692,18 +1692,13 @@
       try { var rng = range(start.node, start.offset, end.offset, end.node); }
       catch(e) {} // Our model of the DOM might be outdated, in which case the range we try to set can be impossible
       if (rng) {
-        if (gecko && this.cm.state.focused && start.offset == end.offset) {
+        if (!gecko && this.cm.state.focused) {
           sel.collapse(start.node, start.offset);
+          if (!rng.collapsed)
+            sel.addRange(rng);
         }
         else {
-          var simpleExtension =
-            !gecko &&
-            this.cm.state.focused && sel.rangeCount==1
-            && old.startContainer && rng.isPointInRange(old.startContainer, old.startOffset)
-            && old.endContainer && rng.isPointInRange(old.endContainer, old.endOffset);
-          if (!simpleExtension)
-            sel.removeAllRanges();
-
+          sel.removeAllRanges();
           sel.addRange(rng);
         }
         if (old && sel.anchorNode == null) sel.addRange(old);

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1692,11 +1692,12 @@
       try { var rng = range(start.node, start.offset, end.offset, end.node); }
       catch(e) {} // Our model of the DOM might be outdated, in which case the range we try to set can be impossible
       if (rng) {
-        if (this.cm.state.focused && start.offset == end.offset) {
+        if (gecko && this.cm.state.focused && start.offset == end.offset) {
           sel.collapse(start.node, start.offset);
         }
         else {
           var simpleExtension =
+            !gecko &&
             this.cm.state.focused && sel.rangeCount==1
             && old.startContainer && rng.isPointInRange(old.startContainer, old.startOffset)
             && old.endContainer && rng.isPointInRange(old.endContainer, old.endOffset);

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1692,8 +1692,13 @@
       try { var rng = range(start.node, start.offset, end.offset, end.node); }
       catch(e) {} // Our model of the DOM might be outdated, in which case the range we try to set can be impossible
       if (rng) {
-        sel.removeAllRanges();
-        sel.addRange(rng);
+        if (this.cm.state.focused && start.offset == end.offset) {
+          sel.collapse(start.node, start.offset);
+        }
+        else {
+          sel.removeAllRanges();
+          sel.addRange(rng);
+        }
         if (old && sel.anchorNode == null) sel.addRange(old);
         else if (gecko) this.startGracePeriod();
       }

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1696,7 +1696,13 @@
           sel.collapse(start.node, start.offset);
         }
         else {
-          sel.removeAllRanges();
+          var simpleExtension =
+            this.cm.state.focused && sel.rangeCount==1
+            && old.startContainer && rng.isPointInRange(old.startContainer, old.startOffset)
+            && old.endContainer && rng.isPointInRange(old.endContainer, old.endOffset);
+          if (!simpleExtension)
+            sel.removeAllRanges();
+
           sel.addRange(rng);
         }
         if (old && sel.anchorNode == null) sel.addRange(old);


### PR DESCRIPTION
This includes #3672 *Fixing hidding keyboard on arrow keys on mobile.*
extending it with support of Shift-selection.

The crux of the problem (at least on Chrome mobile and Opera) is `selection.removeAllRanges`, which causes the keyboard to hide. Assuming that intermittent selection loss hints the keyboard is not needed.

The fix (after previous more complex logic turned into one simple method):
* IF running in gecko  OR  editor is  NOT focused,
 * use old method `removeAllRanges` + `addRange`
* ELSE
 * `collapse` selection to the beginning of new selected range
 * IF new selected range is non-empty, `addRange`

That so far fixes all the onscreen keyboard quirks for Chrome/Opera mobile.
FireFox acts weird, so the logic is left doing old `removeAllRanges`/`addRange`. It doesn't feel hopeless though, need to debug more on FF.