### PR TITLE
Jumptoline addon and added yo search demo.

### DIFF
--- a/addon/search/jumpToLine.js
+++ b/addon/search/jumpToLine.js
@@ -33,7 +33,7 @@
       if (!posStr) return;
 
       var clnMatch = /^\s*([\+\-]?\d+)\s*\:\s*(\d+)\s*$/.exec(posStr);
-      var prcMatch = /^\s*([\+\-]?\d+(\.\d+))\%\s*/.exec(posStr);
+      var prcMatch = /^\s*([\+\-]?\d+(\.\d+)?)\%\s*/.exec(posStr);
       var lnMatch = /^\s*\:?\s*([\+\-]?\d+)\s*/.exec(posStr);
       if (clnMatch) {
         try {
@@ -48,7 +48,7 @@
       else if (prcMatch) {
         try {
           var prc = parseFloat(prcMatch[1]);
-          var line = cm.lineCount()*prc/100;
+          var line = Math.round(cm.lineCount()*prc/100);
           if ('+-'.indexOf(prcMatch[1].charAt(0))>=0)
             line = cur.line+line+1;
         }

--- a/addon/search/jumpToLine.js
+++ b/addon/search/jumpToLine.js
@@ -1,0 +1,72 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+// Define search commands. Depends on dialog.js or another
+// implementation of the openDialog method.
+
+// Replace works a little oddly -- it will do the replace on the next
+// Ctrl-G (or whatever is bound to findNext) press. You prevent a
+// replace by making sure the match is no longer selected when hitting
+// Ctrl-G.
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"), require("./searchcursor"), require("../dialog/dialog"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror", "./searchcursor", "../dialog/dialog"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  "use strict";
+
+  function dialog(cm, text, shortText, deflt, f) {
+    if (cm.openDialog) cm.openDialog(text, f, {value: deflt, selectValueOnOpen: true});
+    else f(prompt(shortText, deflt));
+  }
+
+  var jumpDialog =
+    'Jump to line: <input type="text" style="width: 10em" class="CodeMirror-search-field"/> <span style="color: #888" class="CodeMirror-search-hint">(Use line:column or scroll% syntax)</span>';
+
+  function jumpToLine(cm) {
+    var cur = cm.getCursor();
+     dialog(cm, jumpDialog, 'Jump to line:', (cur.line+1)+':'+(cur.ch+1), function(posStr) {
+      if (!posStr) return;
+
+      var clnMatch = /^\s*([\+\-]?\d+)\s*\:\s*(\d+)\s*$/.exec(posStr);
+      var prcMatch = /^\s*([\+\-]?\d+(\.\d+))\%\s*/.exec(posStr);
+      var lnMatch = /^\s*\:?\s*(\d+)\s*/.exec(posStr);
+      if (clnMatch) {
+        try {
+          var line = parseInt(clnMatch[1]);
+          var ch = parseInt(clnMatch[2]);
+          if ('+-'.indexOf(clnMatch[1].charAt(0))>=0)
+            line = cur.line+line;
+        }
+        catch (error) { return; }
+        cm.setCursor(line-1, ch-1);
+      }
+      else if (prcMatch) {
+        try {
+          var prc = parseFloat(prcMatch[1]);
+          var line = cm.lineCount()*prc/100;
+          if ('+-'.indexOf(prcMatch[1].charAt(0))>=0)
+            line = cur.line+line;
+        }
+        catch (error) { return; }
+        cm.setCursor(line-1, cur.ch);
+      }
+      else if (lnMatch) {
+        try {
+          var line = parseInt(lnMatch[1]);
+          if ('+-'.indexOf(lnMatch[1].charAt(0))>=0)
+            line = cur.line+line;
+        }
+        catch (error) { return; }
+        cm.setCursor(line-1, cur.ch);
+      }
+     })
+  }
+
+  CodeMirror.commands.jumpToLine = jumpToLine;
+  CodeMirror.keyMap.default["Alt-G"] = "jumpToLine";
+});

--- a/addon/search/jumpToLine.js
+++ b/addon/search/jumpToLine.js
@@ -34,13 +34,13 @@
 
       var clnMatch = /^\s*([\+\-]?\d+)\s*\:\s*(\d+)\s*$/.exec(posStr);
       var prcMatch = /^\s*([\+\-]?\d+(\.\d+))\%\s*/.exec(posStr);
-      var lnMatch = /^\s*\:?\s*(\d+)\s*/.exec(posStr);
+      var lnMatch = /^\s*\:?\s*([\+\-]?\d+)\s*/.exec(posStr);
       if (clnMatch) {
         try {
           var line = parseInt(clnMatch[1]);
           var ch = parseInt(clnMatch[2]);
           if ('+-'.indexOf(clnMatch[1].charAt(0))>=0)
-            line = cur.line+line;
+            line = cur.line+line+1;
         }
         catch (error) { return; }
         cm.setCursor(line-1, ch-1);
@@ -50,7 +50,7 @@
           var prc = parseFloat(prcMatch[1]);
           var line = cm.lineCount()*prc/100;
           if ('+-'.indexOf(prcMatch[1].charAt(0))>=0)
-            line = cur.line+line;
+            line = cur.line+line+1;
         }
         catch (error) { return; }
         cm.setCursor(line-1, cur.ch);
@@ -59,7 +59,7 @@
         try {
           var line = parseInt(lnMatch[1]);
           if ('+-'.indexOf(lnMatch[1].charAt(0))>=0)
-            line = cur.line+line;
+            line = cur.line+line+1;
         }
         catch (error) { return; }
         cm.setCursor(line-1, cur.ch);

--- a/demo/search.html
+++ b/demo/search.html
@@ -85,11 +85,14 @@ var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
       <dt>Shift-Ctrl-G / Shift-Cmd-G</dt><dd>Find previous</dd>
       <dt>Shift-Ctrl-F / Cmd-Option-F</dt><dd>Replace</dd>
       <dt>Shift-Ctrl-R / Shift-Cmd-Option-F</dt><dd>Replace all</dd>
-      <dt>Alt-F</dt><dd>Persistent search (dialog doesn't autoclose, enter to find next, shift-enter to find previous)</dd>
+      <dt>Alt-F</dt><dd>Persistent search (dialog doesn't autoclose, enter to find next, shift-enter to find previous)</dd>//
+      <dt>Alt-G</dt><dd>Jump to line</dd>
     </dl>
     <p>Searching is enabled by
     including <a href="../addon/search/search.js">addon/search/search.js</a>
     and <a href="../addon/search/searchcursor.js">addon/search/searchcursor.js</a>.
+    <p>Jump to line -
+    including <a href="../addon/search/jumpToLine.js">addon/search/jumpToLine.js</a>.
     For good-looking input dialogs, you also want to include
     <a href="../addon/dialog/dialog.js">addon/dialog/dialog.js</a>
     and <a href="../addon/dialog/dialog.css">addon/dialog/dialog.css</a>.</p>

--- a/demo/search.html
+++ b/demo/search.html
@@ -14,6 +14,7 @@
 <script src="../addon/search/search.js"></script>
 <script src="../addon/scroll/annotatescrollbar.js"></script>
 <script src="../addon/search/matchesonscrollbar.js"></script>
+<script src="../addon/search/jumpToLine.js"></script>
 <style type="text/css">
       .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
       dt {font-family: monospace; color: #666;}

--- a/demo/search.html
+++ b/demo/search.html
@@ -92,9 +92,8 @@ var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
     <p>Searching is enabled by
     including <a href="../addon/search/search.js">addon/search/search.js</a>
     and <a href="../addon/search/searchcursor.js">addon/search/searchcursor.js</a>.
-    <p>Jump to line -
-    including <a href="../addon/search/jumpToLine.js">addon/search/jumpToLine.js</a>.
-    For good-looking input dialogs, you also want to include
+    Jump to line - including <a href="../addon/search/jumpToLine.js">addon/search/jumpToLine.js</a>.</p>
+    <p>For good-looking input dialogs, you also want to include
     <a href="../addon/dialog/dialog.js">addon/dialog/dialog.js</a>
     and <a href="../addon/dialog/dialog.css">addon/dialog/dialog.css</a>.</p>
   </article>

--- a/demo/search.html
+++ b/demo/search.html
@@ -85,7 +85,8 @@ var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
       <dt>Shift-Ctrl-G / Shift-Cmd-G</dt><dd>Find previous</dd>
       <dt>Shift-Ctrl-F / Cmd-Option-F</dt><dd>Replace</dd>
       <dt>Shift-Ctrl-R / Shift-Cmd-Option-F</dt><dd>Replace all</dd>
-      <dt>Alt-F</dt><dd>Persistent search (dialog doesn't autoclose, enter to find next, shift-enter to find previous)</dd>//
+      <dt>Alt-F</dt><dd>Persistent search (dialog doesn't autoclose,
+      enter to find next, shift-enter to find previous)</dd>
       <dt>Alt-G</dt><dd>Jump to line</dd>
     </dl>
     <p>Searching is enabled by

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2234,6 +2234,13 @@ editor.setOption("extraKeys", {
       of <a href="#addon_dialog"><code>openDialog</code></a> when
       available to make prompting for search queries less ugly.</dd>
 
+      <dt id="addon_jumptoline"><a href="../addon/search/jumpToLine.js"><code>search/jumpToLine.js</code></a></dt>
+      <dd>Implements jumpToLine command and binding <code>Alt-G</code> to it.
+      Accepts <code>linenumber</code>, <code>+/-linenumber</code>, <code>line:char</code>,
+      <code>scroll%</code> and <code>:linenumber</code> formats.
+      This will make use of <a href="#addon_dialog"><code>openDialog</code></a>
+      when available to make prompting for line number neater.</dd>
+
       <dt id="addon_matchesonscrollbar"><a href="../addon/search/matchesonscrollbar.js"><code>search/matchesonscrollbar.js</code></a></dt>
       <dd>Adds a <code>showMatchesOnScrollbar</code> method to editor
       instances, which should be given a query (string or regular


### PR DESCRIPTION
See [#3030 for previous discussion](https://github.com/codemirror/CodeMirror/issues/3030#issuecomment-161665462)

This adds jumpToLine.js addon and jumpToLine command bound to Alt-G as @marijnh suggested.

The accepted inputs are:

* `linenumber` (one-based)
* `:linenumber` same as above, to match habitual format for 'go to line' in Chrome DevTools
* `+linenumber` and `-linenumber` for line relative to current
* `line:column`
* `%scroll` for position on scrollbar (proportional to line count, not character count neither pixel height)
* `+scroll%` and `-scroll%` for position on scrollbar relative to current

In case when character offset/column is not specified, we jump to line preserving offset/column as possible.