### PR TITLE
:memo: give the command a nice name

### DIFF
--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -243,7 +243,7 @@
     });
   };
 
-  map[ctrl + "/"] = function(cm) {
+  cmds[map[ctrl + "/"] = "toggleCodeComment"] = function(cm) {
     cm.toggleComment({ indent: true });
   }
 


### PR DESCRIPTION
Similar to *all other custom commands* in the same file. Good to have a `name` that users can refer to (and IDE developers can show in their command registry) :rose:

refs https://github.com/TypeScriptBuilder/tsb/issues/50