### PR TITLE
Link text runmode script in the correct location

### DIFF
--- a/demo/runmode.html
+++ b/demo/runmode.html
@@ -43,7 +43,7 @@ function doHighlight() {
 
     <p>Running a CodeMirror mode outside of the editor.
     The <code>CodeMirror.runMode</code> function, defined
-    in <code><a href="../addon/runmode/runmode.js">lib/runmode.js</a></code> takes the following arguments:</p>
+    in <code><a href="../addon/runmode/runmode.js">addon/runmode/runmode.js</a></code> takes the following arguments:</p>
 
     <dl>
       <dt><code>text (string)</code></dt>


### PR DESCRIPTION
There is a typo on the runmode page which refers to runmode being in the `lib` folder.