### PR TITLE
Accept either element node, or document fragment for runmode

### DIFF
--- a/addon/runmode/runmode.js
+++ b/addon/runmode/runmode.js
@@ -16,7 +16,7 @@ CodeMirror.runMode = function(string, modespec, callback, options) {
   var ie = /MSIE \d/.test(navigator.userAgent);
   var ie_lt9 = ie && (document.documentMode == null || document.documentMode < 9);
 
-  if (callback.nodeType == 1) {
+  if (callback.nodeType == Node.ELEMENT_NODE || callback.nodeType == Node.DOCUMENT_FRAGMENT_NODE) {
     var tabSize = (options && options.tabSize) || CodeMirror.defaults.tabSize;
     var node = callback, col = 0;
     node.innerHTML = "";


### PR DESCRIPTION
Note we are using document fragments for updating selection and cursors already.

A document fragment, in short, is a parentless element.