### PR TITLE
Correct typo in codemirror.css (`actuall` vs `actual`)

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -165,7 +165,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 }
 
 /* The fake, visible scrollbars. Used to force redraw during scrolling
-   before actuall scrolling happens, thus preventing shaking and
+   before actual scrolling happens, thus preventing shaking and
    flickering artifacts. */
 .CodeMirror-vscrollbar, .CodeMirror-hscrollbar, .CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
   position: absolute;


### PR DESCRIPTION
There was a typo in one of the comments (`actuall` vs `actual`).