### PR TITLE
Fix typo in manual

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -3251,8 +3251,8 @@ editor.setOption("extraKeys", {
     <p>CodeMirror has a robust VIM mode that attempts to faithfully
     emulate VIM's most useful features. It can be enabled by
     including <a href="../keymap/vim.js"><code>keymap/vim.js</code>
-    </a> and setting the <code>keymap</code> option to
-    <code>vim</code>.</p>
+    </a> and setting the <code>keyMap</code> option to
+    <code>"vim"</code>.</p>
 
     <h3 id="vimapi_configuration">Configuration</h3>
 


### PR DESCRIPTION
It took me forever to figure out why vim mode wasn't working, and all because the manual said to set the "keymap" option and not the "keyMap" option. I also added quotes to make it clear that "vim" is a string.