### PR TITLE
Attach CodeMirror to the window explicitly

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -13,7 +13,7 @@
   else if (typeof define == "function" && define.amd) // AMD
     return define([], mod);
   else // Plain browser env
-    this.CodeMirror = mod();
+    window.CodeMirror = mod();
 })(function() {
   "use strict";
 


### PR DESCRIPTION
When minified the context could change breaking the global export of CodeMirror.