### PR TITLE
IE8 thinks 'default' is a keyword

### DIFF
--- a/addon/search/jump-to-line.js
+++ b/addon/search/jump-to-line.js
@@ -45,5 +45,5 @@
     });
   };
 
-  CodeMirror.keyMap.default["Alt-G"] = "jumpToLine";
+  CodeMirror.keyMap["default"]["Alt-G"] = "jumpToLine";
 });


### PR DESCRIPTION
[codemirror.js](https://github.com/codemirror/CodeMirror/blob/master/lib/codemirror.js#L5800) takes care not to utter the name of "default" disrespectfully:

``` javascript
  keyMap["default"] = mac ? keyMap.macDefault : keyMap.pcDefault;
        ^^^^^^^^^^^
```

(and so does [keymap/sublime.js](https://github.com/codemirror/CodeMirror/blob/master/keymap/sublime.js#L20) by the way)

Let's follow the suit here, as IE8 genuinely barfs on jump-to-line.js loading. And if I concatenate codemirror with addons, the whole lot syntax-fails.