### PR TITLE
[markdown mode] fix escaped brackets in link def

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -620,7 +620,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   }
 
   function footnoteLink(stream, state) {
-    if (stream.match(/^[^\]]*\]:/, false)) {
+    if (stream.match(/^([^\]\\]|\\.)*\]:/, false)) {
       state.f = footnoteLinkInside;
       stream.next(); // Consume [
       if (modeCfg.highlightFormatting) state.formatting = "link";
@@ -639,7 +639,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       return returnType;
     }
 
-    stream.match(/^[^\]]+/, true);
+    stream.match(/^([^\]\\]|\\.)+/, true);
 
     return tokenTypes.linkText;
   }

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -696,6 +696,15 @@
      "[link [[foo]]:] [string&url http://example.com/]",
      "(bar\" hello");
 
+  MT("labelEscape",
+     "[link [[foo \\]] ]]:] [string&url http://example.com/]");
+
+  MT("labelEscapeColon",
+     "[link [[foo \\]]: bar]]:] [string&url http://example.com/]");
+
+  MT("labelEscapeEnd",
+     "[[foo\\]]: http://example.com/");
+
   MT("linkWeb",
      "[link <http://example.com/>] foo");
 


### PR DESCRIPTION
Example: `[foo\[bar\]foo]: https://example.com`