### PR TITLE
Fix options of doc.extendSelections.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -7454,7 +7454,7 @@
       extendSelection(this, clipPos(this, head), other && clipPos(this, other), options);
     }),
     extendSelections: docMethodOp(function(heads, options) {
-      extendSelections(this, clipPosArray(this, heads, options));
+      extendSelections(this, clipPosArray(this, heads), options);
     }),
     extendSelectionsBy: docMethodOp(function(f, options) {
       extendSelections(this, map(this.sel.ranges, f), options);


### PR DESCRIPTION
The options argument of `doc.extendSelections` has currently no effect, because it is passed to `clipPosArray` instead of `extendSelections`.