### PR TITLE
Update manual entry of extendSelectionsBy.

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -1350,7 +1350,7 @@ editor.setOption("extraKeys", {
       <dd>An equivalent
       of <a href="#extendSelection"><code>extendSelection</code></a>
       that acts on all selections at once.</dd>
-      <dt id="extendSelectionsBy"><code><strong>doc.extendSelectionsBy</strong>(f: function(range: {anchor, head}) → {anchor, head}), ?options: object)</code></dt>
+      <dt id="extendSelectionsBy"><code><strong>doc.extendSelectionsBy</strong>(f: function(range: {anchor, head}) → {line, ch}), ?options: object)</code></dt>
       <dd>Applies the given function to all existing selections, and
       calls <a href="#extendSelections"><code>extendSelections</code></a>
       on the result.</dd>


### PR DESCRIPTION
The manual entry of `extendSelectionsBy` currently states that the first argument is expected to be a function which maps a `{anchor, head}` range to another range. The actual implementation expects the function to return `{line, ch}` positions. 