### PR TITLE
doc.extendSelectionsBy should clip extended ranges.

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -7457,7 +7457,8 @@
       extendSelections(this, clipPosArray(this, heads, options));
     }),
     extendSelectionsBy: docMethodOp(function(f, options) {
-      extendSelections(this, map(this.sel.ranges, f), options);
+      var heads = map(this.sel.ranges, f);
+      extendSelections(this, clipPosArray(this, heads), options);
     }),
     setSelections: docMethodOp(function(ranges, primary, options) {
       if (!ranges.length) return;


### PR DESCRIPTION
The mapped ranges of `doc.extendSelectionsBy` should be clipped before `extendSelections` is invoked. 
This avoids an exception to be thrown if one of the ranges falls outside of the document. Additionally this is more consistent with the behavior of `doc.extendSelections`. 