### PR TITLE
Add mode for GitHub Flavored Markdown with YAML front matter

### DIFF
--- a/mode/yaml-markdown/index.html
+++ b/mode/yaml-markdown/index.html
@@ -1,0 +1,114 @@
+<!doctype html>
+
+<title>CodeMirror: GitHub Flavored Markdown with YAML front matter mode</title>
+<meta charset="utf-8"/>
+<link rel=stylesheet href="../../doc/docs.css">
+
+<link rel="stylesheet" href="../../lib/codemirror.css">
+<script src="../../lib/codemirror.js"></script>
+<script src="../../addon/mode/overlay.js"></script>
+<script src="../markdown/markdown.js"></script>
+<script src="../gfm/gfm.js"></script>
+<script src="../yaml/yaml.js"></script>
+<script src="yaml-markdown.js"></script>
+<style>.CodeMirror { border-top: 1px solid #ddd; border-bottom: 1px solid #ddd; }</style>
+<div id=nav>
+  <a href="http://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+
+  <ul>
+    <li><a href="../../index.html">Home</a>
+    <li><a href="../../doc/manual.html">Manual</a>
+    <li><a href="https://github.com/codemirror/codemirror">Code</a>
+  </ul>
+  <ul>
+    <li><a href="../index.html">Language modes</a>
+    <li><a class=active href="#">YAML-Markdown</a>
+  </ul>
+</div>
+
+<article>
+<h2>GitHub Flavored Markdown with YAML front matter mode</h2>
+<form><textarea id="code" name="code">
+---
+receipt:     Oz-Ware Purchase Invoice
+date:        2007-08-06
+customer:
+    given:   Dorothy
+    family:  Gale
+
+items:
+    - part_no:   A4786
+      descrip:   Water Bucket (Filled)
+      price:     1.47
+      quantity:  4
+
+    - part_no:   E1628
+      descrip:   High Heeled "Ruby" Slippers
+      size:       8
+      price:     100.27
+      quantity:  1
+
+bill-to:  &id001
+    street: |
+            123 Tornado Alley
+            Suite 16
+    city:   East Centerville
+    state:  KS
+
+ship-to:  *id001
+
+specialDelivery:  >
+    Follow the Yellow Brick
+    Road to the Emerald City.
+    Pay no attention to the
+    man behind the curtain.
+---
+
+GitHub Flavored Markdown
+========================
+
+Everything from markdown plus GFM features:
+
+## URL autolinking
+
+Underscores_are_allowed_between_words.
+
+## Strikethrough text
+
+GFM adds syntax to strikethrough text, which is missing from standard Markdown.
+
+~~Mistaken text.~~
+~~**works with other fomatting**~~
+
+~~spans across
+lines~~
+
+## Fenced code blocks (and syntax highlighting)
+
+```javascript
+for (var i = 0; i &lt; items.length; i++) {
+    console.log(items[i], i); // log them
+}
+```
+
+## Task Lists
+
+- [ ] Incomplete task list item
+- [x] **Completed** task list item
+
+## A bit of GitHub spice
+
+* SHA: be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2
+* User@SHA ref: mojombo@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2
+* User/Project@SHA: mojombo/god@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2
+* \#Num: #1
+* User/#Num: mojombo#1
+* User/Project#Num: mojombo/god#1
+
+See http://github.github.com/github-flavored-markdown/.
+</textarea></form>
+    <script>
+      var editor = CodeMirror.fromTextArea(document.getElementById("code"), {mode: 'yaml-markdown'});
+    </script>
+
+  </article>

--- a/mode/yaml-markdown/yaml-markdown.js
+++ b/mode/yaml-markdown/yaml-markdown.js
@@ -1,0 +1,64 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+(function (mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"), require("../gfm/gfm"), require("../yaml/yaml"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror", "../gfm/gfm", "../yaml/yaml"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function (CodeMirror) {
+
+  // a mixed mode for Markdown text with an optional YAML front matter
+  CodeMirror.defineMode("yaml-markdown", function (config) {
+    var gfmMode = CodeMirror.getMode(config, {name: "gfm"});
+    var yamlMode = CodeMirror.getMode(config, {name: "yaml"});
+
+    return {
+      startState: function () {
+        var gfmState = gfmMode.startState();
+        var yamlState = yamlMode.startState();
+        return {
+          firstLine: true,
+          mode: gfmMode,
+          gfmState: gfmState,
+          yamlState: yamlState
+        };
+      },
+      copyState: function (state) {
+        return {
+          mode: state.mode,
+          gfmState: gfmMode.copyState(state.gfmState),
+          yamlState: state.yamlState
+        };
+      },
+      token: function (stream, state) {
+        if (state.firstLine && stream.match(/---/, false)) {
+          state.firstLine = false;
+          state.mode = yamlMode;
+          return yamlMode.token(stream, state.yamlState);
+        } else if (state.mode == yamlMode && stream.match(/---/, false)) {
+          state.mode = gfmMode;
+          return yamlMode.token(stream, state.yamlState);
+        } else if (state.mode == yamlMode) {
+          return state.mode.token(stream, state.yamlState);
+        } else {
+          return state.mode.token(stream, state.gfmState);
+        }
+      },
+      innerMode: function (state) {
+        if (state.mode == gfmMode) {
+          return gfmMode.innerMode(state.gfmState);
+        } else {
+          return {mode: yamlMode, state: state};
+        }
+      },
+      blankLine: function (state) {
+        if (state.mode == gfmMode) {
+          return gfmMode.blankLine(state.gfmState)
+        }
+      }
+    };
+  });
+});


### PR DESCRIPTION
Markdown with YAML front matter is widely used in various Jekyll-like static website generator. This mode is developed when I create [Semantic Resume](https://semantic-resume.chunlianglyu.com/), where I cannot find existing implementations. I hope it would be useful for others.