### PR TITLE
Julia syntax improvements (Closes #3725)

### DIFF
--- a/mode/julia/julia.js
+++ b/mode/julia/julia.js
@@ -18,35 +18,34 @@ CodeMirror.defineMode("julia", function(_conf, parserConf) {
     return new RegExp("^((" + words.join(")|(") + "))\\b");
   }
 
-  var operators = parserConf.operators || /^\.?[|&^\\%*+\-<>!=\/]=?|\?|~|:|\$|\.[<>]|<<=?|>>>?=?|\.[<>=]=|->?|\/\/|\bin\b/;
+  var operators = parserConf.operators || /^\.?[|&^\\%*+\-<>!=\/]=?|\?|~|:|\$|\.[<>]|<<=?|>>>?=?|\.[<>=]=|->?|\/\/|\bin\b(?!\()|[\u2208\u2209](?!\()/;
   var delimiters = parserConf.delimiters || /^[;,()[\]{}]/;
-  var identifiers = parserConf.identifiers|| /^[_A-Za-z\u00A1-\uFFFF][_A-Za-z0-9\u00A1-\uFFFF]*!*/;
+  var identifiers = parserConf.identifiers || /^[_A-Za-z\u00A1-\uFFFF][_A-Za-z0-9\u00A1-\uFFFF]*!*/;
   var blockOpeners = ["begin", "function", "type", "immutable", "let", "macro", "for", "while", "quote", "if", "else", "elseif", "try", "finally", "catch", "do"];
   var blockClosers = ["end", "else", "elseif", "catch", "finally"];
   var keywordList = ['if', 'else', 'elseif', 'while', 'for', 'begin', 'let', 'end', 'do', 'try', 'catch', 'finally', 'return', 'break', 'continue', 'global', 'local', 'const', 'export', 'import', 'importall', 'using', 'function', 'macro', 'module', 'baremodule', 'type', 'immutable', 'quote', 'typealias', 'abstract', 'bitstype', 'ccall'];
-  var builtinList = ['true', 'false', 'enumerate', 'open', 'close', 'nothing', 'NaN', 'Inf', 'print', 'println', 'Int', 'Int8', 'Uint8', 'Int16', 'Uint16', 'Int32', 'Uint32', 'Int64', 'Uint64', 'Int128', 'Uint128', 'Bool', 'Char', 'Float16', 'Float32', 'Float64', 'Array', 'Vector', 'Matrix', 'String', 'UTF8String', 'ASCIIString', 'error', 'warn', 'info', '@printf'];
+  var builtinList = ['true', 'false', 'nothing', 'NaN', 'Inf'];
 
   //var stringPrefixes = new RegExp("^[br]?('|\")")
-  var stringPrefixes = /^(`|'|"{3}|([br]?"))/;
+  var stringPrefixes = /^(`|'|"{3}|([brv]?"))/;
   var keywords = wordRegexp(keywordList);
   var builtins = wordRegexp(builtinList);
   var openers = wordRegexp(blockOpeners);
   var closers = wordRegexp(blockClosers);
   var macro = /^@[_A-Za-z][_A-Za-z0-9]*/;
-  var symbol = /^:[_A-Za-z][_A-Za-z0-9]*/;
+  var symbol = /^:[_A-Za-z\u00A1-\uFFFF][_A-Za-z0-9\u00A1-\uFFFF]*!*/;
+  var typeAssertion = /^::[^,)"=$.]+(\.{3}\)|,\))?(?=\s*[,)"=]|$)/;
 
-  function in_array(state) {
-    var ch = cur_scope(state);
-    if(ch=="[" || ch=="{") {
+  function inArray(state) {
+    var ch = currentScope(state);
+    if (ch=="[" || ch=="{") {
       return true;
     }
-    else {
-      return false;
-    }
+    return false;
   }
 
-  function cur_scope(state) {
-    if(state.scopes.length==0) {
+  function currentScope(state) {
+    if (state.scopes.length == 0) {
       return null;
     }
     return state.scopes[state.scopes.length - 1];
@@ -54,20 +53,34 @@ CodeMirror.defineMode("julia", function(_conf, parserConf) {
 
   // tokenizers
   function tokenBase(stream, state) {
+    //Handle multiline comments
+    if (stream.match(/^#=\s*/)) {
+      state.scopes.push('#=');
+    }
+    if (currentScope(state) == '#=' && stream.match(/^=#/)) {
+      state.scopes.pop();
+      return 'comment';
+    }
+    if (state.scopes.indexOf('#=') >= 0) {
+      if (!stream.match(/.*?(?=(#=|=#))/)) {
+        stream.skipToEnd();
+      }
+      return 'comment';
+    }
+
     // Handle scope changes
     var leaving_expr = state.leaving_expr;
-    if(stream.sol()) {
+    if (stream.sol()) {
       leaving_expr = false;
     }
     state.leaving_expr = false;
-    if(leaving_expr) {
-      if(stream.match(/^'+/)) {
+    if (leaving_expr) {
+      if (stream.match(/^'+/)) {
         return 'operator';
       }
-
     }
 
-    if(stream.match(/^\.{2,3}/)) {
+    if (stream.match(/^\.{2,3}/)) {
       return 'operator';
     }
 
@@ -76,52 +89,56 @@ CodeMirror.defineMode("julia", function(_conf, parserConf) {
     }
 
     var ch = stream.peek();
-    // Handle Comments
+
+    // Handle single line comments
     if (ch === '#') {
         stream.skipToEnd();
         return 'comment';
     }
-    if(ch==='[') {
+
+    if (ch === '[') {
       state.scopes.push("[");
     }
 
-    if(ch==='{') {
+    if (ch === '{') {
       state.scopes.push("{");
     }
 
-    var scope=cur_scope(state);
+    var scope=currentScope(state);
 
-    if(scope==='[' && ch===']') {
+    if (scope === '[' && ch === ']') {
       state.scopes.pop();
-      state.leaving_expr=true;
+      state.leaving_expr = true;
     }
 
-    if(scope==='{' && ch==='}') {
+    if (scope === '{' && ch === '}') {
       state.scopes.pop();
-      state.leaving_expr=true;
+      state.leaving_expr = true;
     }
 
-    if(ch===')') {
+    if (ch === ')') {
       state.leaving_expr = true;
     }
 
     var match;
-    if(!in_array(state) && (match=stream.match(openers, false))) {
+    if (!inArray(state) && (match=stream.match(openers, false))) {
       state.scopes.push(match);
     }
 
-    if(!in_array(state) && stream.match(closers, false)) {
+    if (!inArray(state) && stream.match(closers, false)) {
       state.scopes.pop();
     }
 
-    if(in_array(state)) {
-      if(stream.match(/^end/)) {
+    if (inArray(state)) {
+      if (state.lastToken == 'end' && stream.match(/^:/)) {
+        return 'operator';
+      }
+      if (stream.match(/^end(?=])/)) {
         return 'number';
       }
-
     }
 
-    if(stream.match(/^=>/)) {
+    if (stream.match(/^=>/)) {
       return 'operator';
     }
 
@@ -134,6 +151,7 @@ CodeMirror.defineMode("julia", function(_conf, parserConf) {
       if (stream.match(/^\d*\.(?!\.)\d+([ef][\+\-]?\d+)?/i)) { floatLiteral = true; }
       if (stream.match(/^\d+\.(?!\.)\d*/)) { floatLiteral = true; }
       if (stream.match(/^\.\d+/)) { floatLiteral = true; }
+      if (stream.match(/^0x\.[0-9a-f]+p[\+\-]?\d+/i)) { floatLiteral = true; }
       if (floatLiteral) {
           // Float literals may be "imaginary"
           stream.match(imMatcher);
@@ -162,20 +180,28 @@ CodeMirror.defineMode("julia", function(_conf, parserConf) {
       }
     }
 
-    if(stream.match(/^(::)|(<:)/)) {
+    if (stream.match(/^<:/)) {
       return 'operator';
     }
 
+    if (stream.match(typeAssertion)) {
+      return 'builtin';
+    }
+
     // Handle symbols
-    if(!leaving_expr && stream.match(symbol)) {
-      return 'string';
+    if (!leaving_expr && stream.match(symbol)) {
+      return 'builtin';
+    }
+
+    // Handle parametric types
+    if (stream.match(/^{[^}]*}(?=\()/)) {
+      return 'builtin';
     }
 
     // Handle operators and Delimiters
     if (stream.match(operators)) {
       return 'operator';
     }
-
 
     // Handle Strings
     if (stream.match(stringPrefixes)) {
@@ -186,7 +212,6 @@ CodeMirror.defineMode("julia", function(_conf, parserConf) {
     if (stream.match(macro)) {
       return 'meta';
     }
-
 
     if (stream.match(delimiters)) {
       return null;
@@ -200,11 +225,11 @@ CodeMirror.defineMode("julia", function(_conf, parserConf) {
       return 'builtin';
     }
 
-
     if (stream.match(identifiers)) {
-      state.leaving_expr=true;
+      state.leaving_expr = true;
       return 'variable';
     }
+
     // Handle non-detected items
     stream.next();
     return ERRORCLASS;
@@ -280,7 +305,7 @@ CodeMirror.defineMode("julia", function(_conf, parserConf) {
 
     indent: function(state, textAfter) {
       var delta = 0;
-      if(textAfter=="end" || textAfter=="]" || textAfter=="}" || textAfter=="else" || textAfter=="elseif" || textAfter=="catch" || textAfter=="finally") {
+      if (textAfter=="end" || textAfter=="]" || textAfter=="}" || textAfter=="else" || textAfter=="elseif" || textAfter=="catch" || textAfter=="finally") {
         delta = -1;
       }
       return (state.scopes.length + delta) * _conf.indentUnit;


### PR DESCRIPTION
Closes #3725

This changes Julia syntax highlighting to match the one used in Julia's GitHub repo. The changes include

- Proper handling of multiline comments
- Better handling of multiline string
- Highlight of function calls and function definitions
- Handling of type parameters and assertions
- Some other tweaks and improvements