### PR TITLE
Added style for builtin keywords in monokai theme

### DIFF
--- a/theme/monokai.css
+++ b/theme/monokai.css
@@ -16,6 +16,7 @@
 
 .cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute { color: #a6e22e; }
 .cm-s-monokai span.cm-keyword { color: #f92672; }
+.cm-s-monokai span.cm-builtin { color: #66d9ef; }
 .cm-s-monokai span.cm-string { color: #e6db74; }
 
 .cm-s-monokai span.cm-variable { color: #f8f8f2; }


### PR DESCRIPTION
Noticed when datatypes in hive were not highlighted. They are parsed as builtins and highlighted in other themes. Colour used is sublime text light blue, same as variable-3.

Hive query sample below:

_Before fix_
<img width="1084" alt="screen shot 2015-12-23 at 2 29 20 pm" src="https://cloud.githubusercontent.com/assets/2195458/11973719/230db204-a983-11e5-9870-649d3c5f56db.png">

_After fix_
<img width="1113" alt="screen shot 2015-12-23 at 2 26 27 pm" src="https://cloud.githubusercontent.com/assets/2195458/11973724/443480a2-a983-11e5-9c0b-2f1c7210e6f6.png">