### PR TITLE
Support Clojure Ratios.

### DIFF
--- a/mode/clojure/clojure.js
+++ b/mode/clojure/clojure.js
@@ -96,6 +96,9 @@ CodeMirror.defineMode("clojure", function (options) {
             if ( '.' == stream.peek() ) {
                 stream.eat('.');
                 stream.eatWhile(tests.digit);
+            } else if ('/' == stream.peek() ) {
+                stream.eat('/');
+                stream.eatWhile(tests.digit);
             }
 
             if ( stream.eat(tests.exponent) ) {

--- a/mode/clojure/index.html
+++ b/mode/clojure/index.html
@@ -78,6 +78,9 @@
          \tab \return \backspace
          \u1000 \uAaAa \u9F9F)
 
+;; Let's play with numbers
+(+ 1 -1 1/2 -1/2 -0.5 0.5)
+
 </textarea></form>
     <script>
       var editor = CodeMirror.fromTextArea(document.getElementById("code"), {});


### PR DESCRIPTION
Clojure has Ratio literals with an integer numerator and denominator, e.g. `1/2`. Currently, the Clojure mode only recognises the numerator as a number and therefore messes the highlighting up on the rest of the Ratio.

This patch fixes that by accepting `/` in the middle of a number as an alternative to `.`.