### PR TITLE
Added jsx flag to javascript mode

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -162,15 +162,15 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   function tokenJsx(stream, state) {
     var ch = stream.next();
     if (ch == ">") {
-      return ret(">", "bracket");
+      return ret(">");
     } else if (ch == "/" && stream.eat(">")) {
-      return ret("/>", "bracket");
+      return ret("/>");
     } else if (ch == "<" && stream.eat("/")) {
-      return ret("</", "bracket");
+      return ret("</");
     } else if (ch == "<") {
-      return ret("<", "bracket");
+      return ret("<");
     } else if (ch == "=") {
-      return ret("=", "operator");
+      return ret("=");
     } else if (ch == ".") {
       return ret(".");
     } else if (ch == "{") {
@@ -522,7 +522,6 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   }
   function continueJsx(type) {
     if (type == "}") {
-      cx.marked = "bracket";
       cx.state.tokenize = tokenJsx;
       return cont();
     }

--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -312,7 +312,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
       if (combinator(type, content)) {
         while(cc.length && cc[cc.length - 1].lex)
           cc.pop()();
-        if (cx.marked) return cx.marked;
+        if (typeof cx.marked == "string") return cx.marked;
         if (type == "variable" && inScope(state, content)) return "variable-2";
         return style;
       }


### PR DESCRIPTION
I've added a JSX flag to javascript mode.

Originally I chose to try switching between XML and JS modes... but quickly realized I'd need a stack to keep track of the start and end of expressions... which is exactly what the JS mode already does! So rather than making a public API out of the JS mode, considering that JSX really *isn't* XML and really *is* just an extension to JS, I just added JSX directly into the javascript mode (akin to TypeScript... this is much simpler when closely coupled with JS, I think).

I notice a PR was opened for JSX yesterday (https://github.com/codemirror/CodeMirror/pull/3742)... but since this is already fully working (for both highlighting and indentation), I wanted to offer up this approach! (and I just finished this morning... it still would need tests and a little cleanup, but wanted to get it up ASAP)

Normal stuff:
<img width="721" alt="screen shot 2015-12-28 at 12 02 02 pm" src="https://cloud.githubusercontent.com/assets/1198882/12024637/dc5ce51a-ad5a-11e5-9136-94d8c86a6f70.png">

Edge cases:
<img width="735" alt="screen shot 2015-12-28 at 11 53 43 am" src="https://cloud.githubusercontent.com/assets/1198882/12024579/4c8c2c7a-ad5a-11e5-9a40-f13f90d12eb6.png">

