### PR TITLE
Fix ASN.1 and TTCN-CFG mode names in mode.js

### DIFF
--- a/mode/meta.js
+++ b/mode/meta.js
@@ -14,7 +14,7 @@
   CodeMirror.modeInfo = [
     {name: "APL", mime: "text/apl", mode: "apl", ext: ["dyalog", "apl"]},
     {name: "PGP", mimes: ["application/pgp", "application/pgp-keys", "application/pgp-signature"], mode: "asciiarmor", ext: ["pgp"]},
-    {name: "ASN.1", mime: "text/x-ttcn-asn", mode: "asn.1", ext: ["asn", "asn1"]},
+    {name: "ASN.1", mime: "text/x-ttcn-asn", mode: "asn1", ext: ["asn", "asn1"]},
     {name: "Asterisk", mime: "text/x-asterisk", mode: "asterisk", file: /^extensions\.conf$/i},
     {name: "Brainfuck", mime: "text/x-brainfuck", mode: "brainfuck", ext: ["b", "bf"]},
     {name: "C", mime: "text/x-csrc", mode: "clike", ext: ["c", "h"]},
@@ -137,7 +137,7 @@
     {name: "Tornado", mime: "text/x-tornado", mode: "tornado"},
     {name: "troff", mime: "troff", mode: "troff", ext: ["1", "2", "3", "4", "5", "6", "7", "8", "9"]},
     {name: "TTCN", mime: "text/x-ttcn", mode: "ttcn", ext: ["ttcn", "ttcn3", "ttcnpp"]},
-    {name: "TTCN_CFG", mime: "text/x-ttcn-cfg", mode: "ttcn-cfg", ext: ["cfg"]},
+    {name: "TTCN_CFG", mime: "text/x-ttcn-cfg", mode: "ttcncfg", ext: ["cfg"]},
     {name: "Turtle", mime: "text/turtle", mode: "turtle", ext: ["ttl"]},
     {name: "TypeScript", mime: "application/typescript", mode: "javascript", ext: ["ts"], alias: ["ts"]},
     {name: "Twig", mime: "text/x-twig", mode: "twig"},


### PR DESCRIPTION
These two modes were using unsupported characters in the mode name which
prevented integrating them into Gerrit. In fact, Gerrit uses the mode
name specified in this file as the name of a generated method. As Java
method names cannot include dots or dashes, this leads to a failed
compilation.