### PR TITLE
Documentation HTML Cleanup

### DIFF
--- a/demo/btree.html
+++ b/demo/btree.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 
 <title>CodeMirror: B-Tree visualization</title>
 <meta charset="utf-8"/>
@@ -26,9 +26,7 @@
 <article>
 <h2>B-Tree visualization</h2>
 <form><textarea id="code" name="code">type here, see a summary of the document b-tree below</textarea></form>
-      </div>
       <div style="display: inline-block; height: 402px; overflow-y: auto" id="output"></div>
-    </div>
 
     <script id="me">
 var editor = CodeMirror.fromTextArea(document.getElementById("code"), {

--- a/demo/tern.html
+++ b/demo/tern.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 
 <title>CodeMirror: Tern Demo</title>
 <meta charset="utf-8"/>
@@ -76,7 +76,7 @@ baz.
 
 var randomStr = myMod.randomElt(myMod.strList);
 var randomInt = myMod.randomElt(myMod.intList);
-</textarea></p>
+</textarea></form>
 
 <p>Demonstrates integration of <a href="http://ternjs.net/">Tern</a>
 and CodeMirror. The following keys are bound:</p>

--- a/demo/xmlcomplete.html
+++ b/demo/xmlcomplete.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 
 <title>CodeMirror: XML Autocomplete Demo</title>
 <meta charset="utf-8"/>
@@ -31,7 +31,7 @@
 <form><textarea id="code" name="code"><!-- write some xml below -->
 </textarea></form>
 
-    <p>Press <strong>ctrl-space</strong>, or type a '<' character to
+    <p>Press <strong>ctrl-space</strong>, or type a '&lt;' character to
     activate autocompletion. This demo defines a simple schema that
     guides completion. The schema can be customized—see
     the <a href="../doc/manual.html#addon_xml-hint">manual</a>.</p>

--- a/doc/internals.html
+++ b/doc/internals.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 
 <title>CodeMirror: Internals</title>
 <meta charset="utf-8"/>
@@ -500,4 +500,5 @@ composing is finished, but many don't fire anything when the character
 is updated <em>during</em> composition. So we poll, whenever the
 editor is focused, to provide immediate updates of the display.</p>
 
+</section>
 </article>

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 
 <title>CodeMirror: User Manual</title>
 <meta charset="utf-8"/>
@@ -3350,7 +3350,7 @@ editor.setOption("extraKeys", {
       be set to a certain position after the operation finishes, it
       can return a cursor object.</dd>
 
-      <dt id="vimapi_defineActon"><strong><code>defineAction(name: string, fn: function(cm: CodeMirror, ?actionArgs: object))</strong></code></dt>
+      <dt id="vimapi_defineActon"><strong><code>defineAction(name: string, fn: function(cm: CodeMirror, ?actionArgs: object))</code></strong></dt>
       <dd>Defines an action command, similar to
       <strong><code>defineMotion</code></strong>. Action commands
       can have arbitrary behavior, making them more flexible than

--- a/doc/releases.html
+++ b/doc/releases.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 
 <title>CodeMirror: Release History</title>
 <meta charset="utf-8"/>
@@ -408,7 +408,7 @@
   <p class="rel">16-01-2014: <a href="http://codemirror.net/codemirror-3.21.zip">Version 3.21</a>:</p>
 
   <ul class="rel-note">
-    <li>Auto-indenting a block will no longer add trailing whitespace to blank lines.</a>
+    <li>Auto-indenting a block will no longer add trailing whitespace to blank lines.</li>
     <li>Marking text has a new option <a href="manual.html#markText"><code>clearWhenEmpty</code></a> to control auto-removal.</li>
     <li>Several bugfixes in the handling of bidirectional text.</li>
     <li>The <a href="../mode/xml/index.html">XML</a> and <a href="../mode/css/index.html">CSS</a> modes were largely rewritten. <a href="../mode/css/less.html">LESS</a> support was added to the CSS mode.</li>

--- a/mode/asn.1/index.html
+++ b/mode/asn.1/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 
 <title>CodeMirror: ASN.1 mode</title>
 <meta charset="utf-8"/>
@@ -73,6 +73,5 @@
     <p>The development of this mode has been sponsored by <a href="http://www.ericsson.com/">Ericsson
     </a>.</p>
     <p>Coded by Asmelash Tsegay Gebretsadkan </p>
-    </article>
 </article>
 

--- a/mode/handlebars/index.html
+++ b/mode/handlebars/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 
 <title>CodeMirror: Handlebars mode</title>
 <meta charset="utf-8"/>
@@ -67,8 +67,7 @@
         mode: {name: "handlebars", base: "text/html"}
       });
     </script>
-    </script>
-
+    
     <p>Handlebars syntax highlighting for CodeMirror.</p>
 
     <p><strong>MIME types defined:</strong> <code>text/x-handlebars-template</code></p>

--- a/mode/mumps/index.html
+++ b/mode/mumps/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 
 <title>CodeMirror: MUMPS mode</title>
 <meta charset="utf-8"/>
@@ -73,7 +73,7 @@ SET2() ;EF. Return error code (also called from XUSRB)
  IF '$LENGTH($PIECE(XUSER(1),U,2)) QUIT 21 ;p419, p434
  Q 0
  ;
-  </textarea>
+  </textarea></div>
     <script>
       var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
          mode: "mumps",

--- a/mode/nginx/index.html
+++ b/mode/nginx/index.html
@@ -1,5 +1,5 @@
-<!doctype html>
-
+﻿<!doctype html>
+<head>
 <title>CodeMirror: NGINX mode</title>
 <meta charset="utf-8"/>
 <link rel=stylesheet href="../../doc/docs.css">

--- a/mode/pig/index.html
+++ b/mode/pig/index.html
@@ -1,5 +1,4 @@
-<!doctype html>
-
+﻿<!doctype html>
 <title>CodeMirror: Pig Latin mode</title>
 <meta charset="utf-8"/>
 <link rel=stylesheet href="../../doc/docs.css">
@@ -51,5 +50,4 @@ STORE c INTO "\path\to\output";
 
     <p><strong>MIME type defined:</strong> <code>text/x-pig</code>
     (PIG code)
-</html>
 </article>

--- a/mode/tiki/tiki.css
+++ b/mode/tiki/tiki.css
@@ -15,7 +15,7 @@
 }
 
 .cm-tw-box {
-	border-top-width: 0px ! important;
+	border-top-width: 0px !important;
 	border-style: solid;
 	border-width: 1px;
 	border-color: inherit;


### PR DESCRIPTION
We've been using CodeMirror 5.10 in a project which is being edited in Visual Studio.  For the sake of convenience, we just put the whole CodeMirror tree into the VS project.   

This has the side effect of various global error checking (mostly Resharper) running across the whole project, which then highlights a number of minor complaints about html tag errors in some of CodeMirror's documentation.

This PR contains fixes for most of them - I've wilfully breached the guidelines about one-fix-per-PR, and if you'd prefer it done like that instead, it's no problem.

Alternatively, if this PR doesn't suit the project's style in some way, I'm not bothered if it doesn't get merged at all, I just thought it might be useful.