### PR TITLE
fix matching bracket colour on mbo theme

### DIFF
--- a/theme/mbo.css
+++ b/theme/mbo.css
@@ -33,5 +33,5 @@
 .cm-s-mbo span.cm-qualifier { color: #ffffec; }
 
 .cm-s-mbo .CodeMirror-activeline-background { background: #494b41; }
-.cm-s-mbo .CodeMirror-matchingbracket { color: #222 !important; }
+.cm-s-mbo .CodeMirror-matchingbracket { color: #ffb928 !important; }
 .cm-s-mbo .CodeMirror-matchingtag { background: rgba(255, 255, 255, .37); }


### PR DESCRIPTION
A very small tweak: `#222` on a `#2c2c2c` background is barely visible.

Before:
<img width="304" alt="screen shot 2016-01-15 at 14 47 03" src="https://cloud.githubusercontent.com/assets/1547215/12354610/5d121474-bb97-11e5-8a5e-a5eb6f3e9a54.png">

After:
<img width="337" alt="screen shot 2016-01-15 at 14 46 39" src="https://cloud.githubusercontent.com/assets/1547215/12354611/5d14066c-bb97-11e5-86fe-1847218ec31a.png">