### PR TITLE
Fix token type for beginning spaces inside string in Clojure mode

### DIFF
--- a/mode/clojure/clojure.js
+++ b/mode/clojure/clojure.js
@@ -142,7 +142,7 @@ CodeMirror.defineMode("clojure", function (options) {
             }
 
             // skip spaces
-            if (stream.eatSpace()) {
+            if (state.mode != "string" && stream.eatSpace()) {
                 return null;
             }
             var returnType = null;


### PR DESCRIPTION
Hi. 
  This is a bug one of our users [reported awhile back](https://github.com/LightTable/Clojure/pull/12) with the Clojure mode returning an incorrect token type. For a given string that starts with a space e.g. `" test"`, the token definition doesn't recognize the space as part of the string. This also means the token type for the space inside the string returns null when "string" is expected. I've demonstrated this with the following screenshots. Before the fix:

<img width="1440" alt="screen shot 2016-01-17 at 10 39 24 am" src="https://cloud.githubusercontent.com/assets/11994/12378278/f2c33f00-bd06-11e5-9ada-3829bff6dd01.png">

After the fix:

<img width="1440" alt="screen shot 2016-01-17 at 10 41 36 am" src="https://cloud.githubusercontent.com/assets/11994/12378284/00d30e0e-bd07-11e5-83e8-abd97adede1e.png">

Let me know if there's anything else you'd like me to do. It would be great to get this fix in so LightTable can stop using a fork of the Clojure mode. Thanks for all your hard work!
Cheers, Gabriel