### PR TITLE
Add clojurescript mime type

### DIFF
--- a/mode/clojure/clojure.js
+++ b/mode/clojure/clojure.js
@@ -243,5 +243,6 @@ CodeMirror.defineMode("clojure", function (options) {
 });
 
 CodeMirror.defineMIME("text/x-clojure", "clojure");
+CodeMirror.defineMIME("text/x-clojurescript", "clojure");
 
 });


### PR DESCRIPTION
In LightTable we depend on [a clojurescript mime type](https://github.com/LightTable/LightTable/blob/9d3c40f4fa70bcefa40b4f0c708edf3b16dba55f/deploy/settings/default/default.behaviors#L311-L312). While the syntax highlighting is the same as clojure, clojurescript is its own language with differing builtins e.g. *clojurescript-version* instead of *clojure-version*. We would eventually like to [update builtins](https://github.com/codemirror/CodeMirror/blob/5.10.0/mode/clojure/clojure.js#L36-L37) to have correct clojurescript ones as well.