### PR TITLE
Allow namespaced forms to smartly indent in clojure mode

### DIFF
--- a/mode/clojure/clojure.js
+++ b/mode/clojure/clojure.js
@@ -59,7 +59,8 @@ CodeMirror.defineMode("clojure", function (options) {
         sign: /[+-]/,
         exponent: /e/i,
         keyword_char: /[^\s\(\[\;\)\]]/,
-        symbol: /[\w*+!\-\._?:<>\/\xa1-\uffff]/
+        symbol: /[\w*+!\-\._?:<>\/\xa1-\uffff]/,
+        block_indent: /^(?:def|with)[^\/]+$|\/(?:def|with)/
     };
 
     function stateStack(indent, type, prev) { // represents a state stack object
@@ -190,7 +191,7 @@ CodeMirror.defineMode("clojure", function (options) {
                         }
 
                         if (keyWord.length > 0 && (indentKeys.propertyIsEnumerable(keyWord) ||
-                                                   /^(?:def|with)/.test(keyWord))) { // indent-word
+                                                   tests.block_indent.test(keyWord))) { // indent-word
                             pushStack(state, indentTemp + INDENT_WORD_SKIP, ch);
                         } else { // non-indent word
                             // we continue eating the spaces


### PR DESCRIPTION
Hi again. This is another fix a LightTable user [submitted awhile back](https://github.com/LightTable/Clojure/pull/19). As pointed in that issue, namespace qualified `with-*` calls aren't indented properly e.g.:
```clj
(namespace/with-open [a b]
                     (dothing a))
```

With this fix they are:
```clj
(namespace/with-open [a b]
  (dothing a))
```

Pulling block_indent into tests seemed reasonable so I left it as is. Let me know if there's anything you'd like tweaked here. Thanks!