### PR TITLE
Fix anonymous fn with params indentation in Scala

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -497,7 +497,7 @@
     ),
     types: words(
       "AnyVal App Application Array BufferedIterator BigDecimal BigInt Char Console Either " +
-      "Enumeration Equiv Error Exception Fractional Function IndexedSeq Integral Iterable " +
+      "Enumeration Equiv Error Exception Fractional Function IndexedSeq Int Integral Iterable " +
       "Iterator List Map Numeric Nil NotNull Option Ordered Ordering PartialFunction PartialOrdering " +
       "Product Proxy Range Responder Seq Serializable Set Specializable Stream StringBuilder " +
       "StringContext Symbol Throwable Traversable TraversableOnce Tuple Unit Vector " +

--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -519,6 +519,16 @@
         stream.eatWhile(/[\w\$_]/);
         return "meta";
       },
+      "{": function(stream, state) {
+        // match a single full line with params of multi-line anonymous fn, e.g.:
+        // { a =>\n
+        // { (aa: Int, bb: Int) =>\n
+        var singleLineParams = /^(\w|[:.,() ])+=>$/;
+        if (!stream.match(singleLineParams, true)) // eat the line, if matches
+          return false;
+        pushContext(state, stream.column(), "}");
+        return null;
+      },
       '"': function(stream, state) {
         if (!stream.match('""')) return false;
         state.tokenize = tokenTripleString;


### PR DESCRIPTION
- [x] `Int` type was not defined in scala
- [x] fix indentation in scala-mode for anonymous functions with params
  * for now, loses coloring of params in multiline mode (but still much better than before IMHO), but do not affect one-line mode. this could be improved in separate PR, but need to think how to do it properly.

from:
<img width="555" alt="screen shot 2016-01-19 at 13 42 41" src="https://cloud.githubusercontent.com/assets/213426/12417719/adc9ade6-beb2-11e5-8527-e6746df9a69f.png">


to:
<img width="421" alt="screen shot 2016-01-19 at 13 38 14" src="https://cloud.githubusercontent.com/assets/213426/12417678/5fc8622c-beb2-11e5-8aef-096b3a19cf79.png">

patch from https://github.com/andypetrella/spark-notebook/pull/551