### PR TITLE
Fix for #3780: Overwrite cursor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.swp
 .idea
 *.iml
+/nbproject

--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -84,7 +84,14 @@
 }
 
 /* Can style cursor different in overwrite (non-insert) mode */
-.CodeMirror-overwrite .CodeMirror-cursor {}
+.CodeMirror-overwrite .CodeMirror-cursor {
+	width: auto;
+	background-color: black;
+	color: white;
+	border-left: 0;
+	line-height: normal;
+	white-space: pre;
+}
 
 .cm-tab { display: inline-block; text-decoration: inherit; }
 

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2321,15 +2321,19 @@
   // Draws a cursor for the given range
   function drawSelectionCursor(cm, head, output) {
     var pos = cursorCoords(cm, head, "div", null, null, !cm.options.singleCursorHeightPerLine);
-
-    var cursor = output.appendChild(elt("div", "\u00a0", "CodeMirror-cursor"));
+    var content = "\u00a0";
+    if (cm.state.overwrite) {
+      var next = movePos(cm.doc, head, 1, 0);
+      content = next ? (getBetween(cm.doc, head, next)[0] || content) : content;
+    }
+    var cursor = output.appendChild(elt("div", content, "CodeMirror-cursor"));
     cursor.style.left = pos.left + "px";
     cursor.style.top = pos.top + "px";
     cursor.style.height = Math.max(0, pos.bottom - pos.top) * cm.options.cursorHeight + "px";
 
     if (pos.other) {
       // Secondary cursor, shown when on a 'jump' in bi-directional text
-      var otherCursor = output.appendChild(elt("div", "\u00a0", "CodeMirror-cursor CodeMirror-secondarycursor"));
+      var otherCursor = output.appendChild(elt("div", content, "CodeMirror-cursor CodeMirror-secondarycursor"));
       otherCursor.style.display = "";
       otherCursor.style.left = pos.other.left + "px";
       otherCursor.style.top = pos.other.top + "px";
@@ -5235,13 +5239,13 @@
       return new Range(Pos(pos.line, start), Pos(pos.line, end));
     },
 
-    toggleOverwrite: function(value) {
+    toggleOverwrite: function(value) {		
       if (value != null && value == this.state.overwrite) return;
       if (this.state.overwrite = !this.state.overwrite)
         addClass(this.display.cursorDiv, "CodeMirror-overwrite");
       else
         rmClass(this.display.cursorDiv, "CodeMirror-overwrite");
-
+	  updateSelection(this);
       signal(this, "overwriteToggle", this, this.state.overwrite);
     },
     hasFocus: function() { return this.display.input.getField() == activeElt(); },


### PR DESCRIPTION
This is a fix to have a blinking overwrite cursor using minor additions in `codemirror.js` and styling of `.CodeMirror-overwrite .CodeMirror-cursor` in `codemirror.css`.

When `state.overwrite` is true, the `CodeMirror-cursor`'s text is either the next character or, if the next character is empty, the `"\u00a0"` it has for insert mode. The css simply adjusts some things to put the inverted character in the cursor in the right place.

The result is a typical blinking overwrite cursor. It can be seen in action from the `This is CodeMirror` example in `index.html`, and presumably all other examples.

Works fine in Opera, Chrome and Edge, but there is a CSS issues in FireFox. I have not yet extensively tested all features and edge cases. I'd like to poll interest in this fix before continuing with it.