### PR TITLE
[active-line addon] Add active line number

### DIFF
--- a/addon/selection/active-line.js
+++ b/addon/selection/active-line.js
@@ -18,6 +18,7 @@
   "use strict";
   var WRAP_CLASS = "CodeMirror-activeline";
   var BACK_CLASS = "CodeMirror-activeline-background";
+  var GUTT_CLASS = "CodeMirror-activeline-gutter";
 
   CodeMirror.defineOption("styleActiveLine", false, function(cm, val, old) {
     var prev = old && old != CodeMirror.Init;
@@ -36,6 +37,7 @@
     for (var i = 0; i < cm.state.activeLines.length; i++) {
       cm.removeLineClass(cm.state.activeLines[i], "wrap", WRAP_CLASS);
       cm.removeLineClass(cm.state.activeLines[i], "background", BACK_CLASS);
+      cm.removeLineClass(cm.state.activeLines[i], "gutter", GUTT_CLASS);
     }
   }
 
@@ -60,6 +62,7 @@
       for (var i = 0; i < active.length; i++) {
         cm.addLineClass(active[i], "wrap", WRAP_CLASS);
         cm.addLineClass(active[i], "background", BACK_CLASS);
+        cm.addLineClass(active[i], "gutter", GUTT_CLASS);
       }
       cm.state.activeLines = active;
     });

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2736,8 +2736,10 @@ editor.setOption("extraKeys", {
       <dt id="addon_active-line"><a href="../addon/selection/active-line.js"><code>selection/active-line.js</code></a></dt>
       <dd>Defines a <code>styleActiveLine</code> option that, when enabled,
       gives the wrapper of the active line the class <code>CodeMirror-activeline</code>,
-      and adds a background with the class <code>CodeMirror-activeline-background</code>.
-      is enabled. See the <a href="../demo/activeline.html">demo</a>.</dd>
+      adds a background with the class <code>CodeMirror-activeline-background</code>,
+      and adds the class <code>CodeMirror-activeline-gutter</code> to the
+      line's gutter space is enabled. See the
+      <a href="../demo/activeline.html">demo</a>.</dd>
 
       <dt id="addon_selection-pointer"><a href="../addon/selection/selection-pointer.js"><code>selection/selection-pointer.js</code></a></dt>
       <dd>Defines a <code>selectionPointer</code> option which you can


### PR DESCRIPTION
This patch enables styling of active line numbers by
adding a `CodeMirror-activeline-gutter` class to the
line's gutter space.