### PR TITLE
spreadsheet mode no error on back slash

### DIFF
--- a/mode/spreadsheet/spreadsheet.js
+++ b/mode/spreadsheet/spreadsheet.js
@@ -70,7 +70,10 @@
           return "operator";
         case "\\":
           if (stream.match(/\\[a-z]+/)) return "string-2";
-          else return null;
+          else {
+            stream.next();
+            return "atom";
+          }
         case ".":
         case ",":
         case ";":


### PR DESCRIPTION
In spreadsheet mode with CodeMirror on a forward slash without a following character it throws stream errors. Also, if the input string ends with a forward slash it won't update the input box and throws a lot of errors.
This is a small fix that makes a single slash with no following character an atom type rather than null, and once a following character is added it becomes the string-2 type.