### PR TITLE
Add Vim.unmap to public api to undo Vim.map

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -682,6 +682,9 @@
         // Add user defined key bindings.
         exCommandDispatcher.map(lhs, rhs, ctx);
       },
+      unmap: function(lhs, ctx) {
+        exCommandDispatcher.unmap(lhs, ctx);
+      },
       // TODO: Expose setOption and getOption as instance methods. Need to decide how to namespace
       // them, or somehow make them work with the existing CodeMirror setOption/getOption API.
       setOption: setOption,

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -3950,7 +3950,13 @@ testVim('ex_imap', function(cm, vim, helpers) {
   is(vim.insertMode);
   helpers.doKeys('j', 'k');
   is(!vim.insertMode);
-})
+});
+testVim('ex_unmap_api', function(cm, vim, helpers) {
+  CodeMirror.Vim.map('<Alt-X>', 'gg', 'normal');
+  is(CodeMirror.Vim.handleKey(cm, "<Alt-X>", "normal"), "Alt-X key is mapped");
+  CodeMirror.Vim.unmap("<Alt-X>", "normal");
+  is(!CodeMirror.Vim.handleKey(cm, "<Alt-X>", "normal"), "Alt-X key is unmapped");
+});
 
 // Testing registration of functions as ex-commands and mapping to <Key>-keys
 testVim('ex_api_test', function(cm, vim, helpers) {


### PR DESCRIPTION
Hi. In the LightTable Vim plugin, we'd like our keybinding changes to stay in sync with the vim keymap bindings. Currently we can only map keybindings but can't undo them - https://github.com/LightTable/Vim/issues/66 . This seemed like a reasonable function to make public. Happy to discuss further if need be. Cheers