### PR TITLE
Fix for #3818: Cursor Moves to Beginning of Dialog Lines

### DIFF
--- a/addon/dialog/dialog.js
+++ b/addon/dialog/dialog.js
@@ -56,6 +56,8 @@
 
     var inp = dialog.getElementsByTagName("input")[0], button;
     if (inp) {
+      inp.focus();
+
       if (options.value) {
         inp.value = options.value;
         if (options.selectValueOnOpen !== false) {
@@ -79,8 +81,6 @@
       });
 
       if (options.closeOnBlur !== false) CodeMirror.on(inp, "blur", close);
-
-      inp.focus();
     } else if (button = dialog.getElementsByTagName("button")[0]) {
       CodeMirror.on(button, "click", function() {
         close();


### PR DESCRIPTION
Firefox seems to handle the cursor placement differently when the input is focused. 