### PR TITLE
[twig mode] Add `base` option support for mixed mode

### DIFF
--- a/mode/twig/twig.js
+++ b/mode/twig/twig.js
@@ -133,7 +133,7 @@
     if (!parserConfig || !parserConfig.base) return twigInner;
     return CodeMirror.multiplexingMode(
       CodeMirror.getMode(config, parserConfig.base), {
-        open: "{", close: "}", mode: twigInner, parseDelimiters: true
+        open: /{[{#%]/, close: /[}#%]}/, mode: twigInner, parseDelimiters: true
       }
     );
   });

--- a/mode/twig/twig.js
+++ b/mode/twig/twig.js
@@ -3,15 +3,17 @@
 
 (function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
-    mod(require("../../lib/codemirror"));
+    mod(require("../../lib/codemirror"), require("../htmlmixed/htmlmixed"),
+        require("../../addon/mode/overlay"));
   else if (typeof define == "function" && define.amd) // AMD
-    define(["../../lib/codemirror"], mod);
+    define(["../../lib/codemirror", "../htmlmixed/htmlmixed",
+            "../../addon/mode/overlay"], mod);
   else // Plain browser env
     mod(CodeMirror);
 })(function(CodeMirror) {
   "use strict";
 
-  CodeMirror.defineMode("twig", function() {
+  CodeMirror.defineMode("twig:inner", function() {
     var keywords = ["and", "as", "autoescape", "endautoescape", "block", "do", "endblock", "else", "elseif", "extends", "for", "endfor", "embed", "endembed", "filter", "endfilter", "flush", "from", "if", "endif", "in", "is", "include", "import", "not", "or", "set", "spaceless", "endspaceless", "with", "endwith", "trans", "endtrans", "blocktrans", "endblocktrans", "macro", "endmacro", "use", "verbatim", "endverbatim"],
         operator = /^[+\-*&%=<>!?|~^]/,
         sign = /^[:\[\(\{]/,
@@ -128,5 +130,10 @@
     };
   });
 
+  CodeMirror.defineMode("twig", function(config) {
+    var htmlBase = CodeMirror.getMode(config, "text/html");
+    var twigInner = CodeMirror.getMode(config, "twig:inner");
+    return CodeMirror.overlayMode(htmlBase, twigInner);
+  });
   CodeMirror.defineMIME("text/x-twig", "twig");
 });

--- a/mode/twig/twig.js
+++ b/mode/twig/twig.js
@@ -3,11 +3,9 @@
 
 (function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
-    mod(require("../../lib/codemirror"), require("../htmlmixed/htmlmixed"),
-        require("../../addon/mode/overlay"));
+    mod(require("../../lib/codemirror"),  require("../../addon/mode/multiplex"));
   else if (typeof define == "function" && define.amd) // AMD
-    define(["../../lib/codemirror", "../htmlmixed/htmlmixed",
-            "../../addon/mode/overlay"], mod);
+    define(["../../lib/codemirror", "../../addon/mode/multiplex"], mod);
   else // Plain browser env
     mod(CodeMirror);
 })(function(CodeMirror) {
@@ -130,10 +128,14 @@
     };
   });
 
-  CodeMirror.defineMode("twig", function(config) {
-    var htmlBase = CodeMirror.getMode(config, "text/html");
+  CodeMirror.defineMode("twig", function(config, parserConfig) {
     var twigInner = CodeMirror.getMode(config, "twig:inner");
-    return CodeMirror.overlayMode(htmlBase, twigInner);
+    if (!parserConfig || !parserConfig.base) return twigInner;
+    return CodeMirror.multiplexingMode(
+      CodeMirror.getMode(config, parserConfig.base), {
+        open: "{", close: "}", mode: twigInner, parseDelimiters: true
+      }
+    );
   });
   CodeMirror.defineMIME("text/x-twig", "twig");
 });


### PR DESCRIPTION
Updated Twig mode to an multiplexingMode.
Twig mode now supports a base option and the base is properly highlighted.

#### Examples
##### html base
before:
![before](https://cloud.githubusercontent.com/assets/3427236/13455650/715e35c6-e067-11e5-9ba3-e911309a9e7b.PNG)
after:
![after](https://cloud.githubusercontent.com/assets/3427236/13455654/730f9c8e-e067-11e5-93c1-eee5a7e3f953.PNG)

##### xml base
before: 
![image](https://cloud.githubusercontent.com/assets/3427236/13461328/640db154-e089-11e5-8f47-4c950212738a.png)
after:
![beforexml](https://cloud.githubusercontent.com/assets/3427236/13461331/6a2819c6-e089-11e5-9721-9d6dd95b2075.PNG)

