### PR TITLE
Fix MIME type of troff

### DIFF
--- a/mode/troff/troff.js
+++ b/mode/troff/troff.js
@@ -77,6 +77,9 @@ CodeMirror.defineMode('troff', function() {
   };
 });
 
+CodeMirror.defineMIME('text/troff', 'troff');
+CodeMirror.defineMIME('text/x-troff', 'troff');
+CodeMirror.defineMIME('application/x-troff', 'troff');
 CodeMirror.defineMIME('troff', 'troff');
 
 });


### PR DESCRIPTION
`text/troff` is the standard approved by IANA. Also add some
non-standard MIME types.
https://bugs.freedesktop.org/show_bug.cgi?id=5072