### PR TITLE
Disable draggable in firefox desktop

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -53,6 +53,8 @@
   // Optimize some code when these features are not used.
   var sawReadOnlySpans = false, sawCollapsedSpans = false;
 
+  var enableDraggable = (!webkit && !gecko);
+
   // EDITOR CONSTRUCTOR
 
   // A CodeMirror instance represents an editor. This is the object
@@ -176,7 +178,7 @@
 
     // Work around IE7 z-index bug (not perfect, hence IE7 not really being supported)
     if (ie && ie_version < 8) { d.gutters.style.zIndex = -1; d.scroller.style.paddingRight = 0; }
-    if (!webkit && !(gecko && mobile)) d.scroller.draggable = true;
+    if (enableDraggable) d.scroller.draggable = true;
 
     if (place) {
       if (place.appendChild) place.appendChild(d.wrapper);
@@ -3573,7 +3575,7 @@
     display.shift = e.shiftKey;
 
     if (eventInWidget(display, e)) {
-      if (!webkit) {
+      if (enableDraggable) {
         // Briefly turn off draggability, to allow widgets to do
         // normal dragging things.
         display.scroller.draggable = false;


### PR DESCRIPTION
So: on Chrome, selecting text works fine. But on firefox, the `draggable="true"` attribute of `CodeMirror-scroll` (set by https://github.com/codemirror/CodeMirror/blob/24d60578042ae03ee471bf54f3e851de9684fe79/lib/codemirror.js#L179 for all but webkit and firefox mobile) prevents text from being selected by any click-and-drag operation that starts inside the draggable element, in some circumstances (which I haven't managed to pin down, but you can see an example where it's broken on any of the code snippets on https://www.ably.io/documentation/quick-start-guide). (*Edit:* that page now isn't an example as we did a hack to remove the `draggable` attribute after codemirror setup has run -- you can see the behaviour by re-adding `draggable="true"` to any of the `CodeMirror-scroll` divs)

This is probably [a firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=800050), but not one that looks likely to be fixed any time soon

This PR changes the `draggable` condition from `(!webkit && !(gecko && mobile))` to `(!webkit && !gecko)` (and puts it in a variable to stop the two uses getting out of sync).

I don't quite understand how the `dragDrop` functionality works or fits into this (since at the moment `draggable` is set whether or not `dragDrop` is true), so apologies if this is wrong.