### PR TITLE
Fix: Undefined upon Paste. (fireCallbacksForOps)

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3030,7 +3030,9 @@
         var op = group.ops[j];
         if (op.cursorActivityHandlers)
           while (op.cursorActivityCalled < op.cursorActivityHandlers.length)
-            op.cursorActivityHandlers[op.cursorActivityCalled++].call(null, op.cm);
+            if (op.cursorActivityHandlers[op.cursorActivityCalled]) {
+              op.cursorActivityHandlers[op.cursorActivityCalled++].call(null, op.cm);
+            } else op.cursorActivityCalled++;
       }
     } while (i < callbacks.length);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "codemirror",
-    "version":"5.12.1",
+    "version":"5.12.2",
     "main": "lib/codemirror.js",
     "description": "In-browser code editing made bearable",
     "license": "MIT",


### PR DESCRIPTION
Bug:
- Paste text content into editor in 'markdown' mode.
- Uncaught TypeError: Cannot read property 'call' of undefined
```
fireCallbacksForOps	@	codemirror.js:3030
endOperation	@	codemirror.js:3040
runInOp	@	codemirror.js:3179
handlePaste	@	codemirror.js:1153
(anonymous function)	@	codemirror.js:1255
```
Fix:
- Added a check for undefined.