### PR TITLE
[vim-mode] fix insert/command cursor move different behavior (vim-mode in jupyter)

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1696,8 +1696,8 @@
         var line = motionArgs.forward ? cur.line + repeat : cur.line - repeat;
         var first = cm.firstLine();
         var last = cm.lastLine();
-        // Vim cancels linewise motions that start on an edge and move beyond
-        // that edge. It does not cancel motions that do not start on an edge.
+        // Vim go to line begin or line end when cursor at first/last line and
+        // move to previous/next line is triggered.
         if (line < first && cur.line == first){
           return this.moveToStartOfLine(cm, head, motionArgs, vim);
         }else if (line > last && cur.line == last){

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1698,9 +1698,10 @@
         var last = cm.lastLine();
         // Vim cancels linewise motions that start on an edge and move beyond
         // that edge. It does not cancel motions that do not start on an edge.
-        if ((line < first && cur.line == first) ||
-            (line > last && cur.line == last)) {
-          return;
+        if (line < first && cur.line == first){
+          return this.moveToStartOfLine(cm, head, motionArgs, vim);
+        }else if (line > last && cur.line == last){
+            return this.moveToEol(cm, head, motionArgs, vim);
         }
         if (motionArgs.toFirstChar){
           endCh=findFirstNonWhiteSpaceCharacter(cm.getLine(line));

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -634,11 +634,11 @@ testVim('dj_end_of_document', function(cm, vim, helpers) {
   var curStart = makeCursor(0, 3);
   cm.setCursor(curStart);
   helpers.doKeys('d', 'j');
-  eq(' word1 ', cm.getValue());
+  eq('', cm.getValue());
   var register = helpers.getRegisterController().getRegister();
-  eq('', register.toString());
-  is(!register.linewise);
-  helpers.assertCursorAt(0, 3);
+  eq(' word1 \n', register.toString());
+  is(register.linewise);
+  helpers.assertCursorAt(0, 0);
 }, { value: ' word1 ' });
 testVim('dk', function(cm, vim, helpers) {
   var curStart = makeCursor(1, 3);
@@ -654,11 +654,11 @@ testVim('dk_start_of_document', function(cm, vim, helpers) {
   var curStart = makeCursor(0, 3);
   cm.setCursor(curStart);
   helpers.doKeys('d', 'k');
-  eq(' word1 ', cm.getValue());
+  eq('', cm.getValue());
   var register = helpers.getRegisterController().getRegister();
-  eq('', register.toString());
-  is(!register.linewise);
-  helpers.assertCursorAt(0, 3);
+  eq(' word1 \n', register.toString());
+  is(register.linewise);
+  helpers.assertCursorAt(0, 0);
 }, { value: ' word1 ' });
 testVim('dw_space', function(cm, vim, helpers) {
   var curStart = makeCursor(0, 0);


### PR DESCRIPTION
The cursor move using j/k or up/down is different in insert/command mode.

This fix is needed to have a decent vim mode in Jupyter notebook (developed [here](https://github.com/jupyter/notebook/pull/1109)).

### old behavior
- in insert mode: when cursor is at the last line of a document and 'down' pressed, go to end of line. When cursor at first line and 'up' pressed, go to begin of line
- in command mode: when cursor is at the last line of a document and 'down' or 'j' pressed, event is discarded. When cursor at first line and 'up' or 'k' pressed, event is discarded.

### new behavior
- no change in insert mode
- in command mode: when cursor is at the last line of a document and 'down' or 'j' pressed, go at the end of line. When cursor at first line and 'up' or 'k' pressed, go at begin of line.