### PR TITLE
Allow applications to listen for the dragleave event.

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -657,7 +657,8 @@
       <strong>"keydown"</strong>, <strong>"keypress"</strong>,
       <strong>"keyup"</strong>, <strong>"cut"</strong>, <strong>"copy"</strong>, <strong>"paste"</strong>,
       <strong>"dragstart"</strong>, <strong>"dragenter"</strong>,
-      <strong>"dragover"</strong>, <strong>"drop"</strong>
+      <strong>"dragover"</strong>, <strong>"dragleave"</strong>,
+      <strong>"drop"</strong>
       (instance: CodeMirror, event: Event)</code></dt>
       <dd>Fired when CodeMirror is handling a DOM event of this type.
       You can <code>preventDefault</code> the event, or give it a

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3495,7 +3495,7 @@
       over: function(e) {if (!signalDOMEvent(cm, e)) { onDragOver(cm, e); e_stop(e); }},
       start: function(e){onDragStart(cm, e);},
       drop: operation(cm, onDrop),
-      leave: function() {clearDragCursor(cm);}
+      leave: function(e) {if (!signalDOMEvent(cm, e)) { clearDragCursor(cm); }}
     };
 
     var inp = d.input.getField();


### PR DESCRIPTION
This is a small change to allow applications to intercept the ``dragleave`` event in the same way as the other drag'n'drop events.