### PR TITLE
Avoid horizontal alignment of the gutters when the scrollbar is not…

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3146,8 +3146,10 @@
     if (op.scrollLeft != null && (display.scroller.scrollLeft != op.scrollLeft || op.forceScroll)) {
       doc.scrollLeft = Math.max(0, Math.min(display.scroller.scrollWidth - display.scroller.clientWidth, op.scrollLeft));
       display.scrollbars.setScrollLeft(doc.scrollLeft);
-      display.scroller.scrollLeft = doc.scrollLeft;
-      alignHorizontally(cm);
+      if (display.scroller.scrollLeft != doc.scrollLeft) {
+        display.scroller.scrollLeft = doc.scrollLeft;
+        alignHorizontally(cm);
+      }
     }
     // If we need to scroll a specific position into view, do so.
     if (op.scrollToPos) {
@@ -3959,8 +3961,10 @@
   function setScrollLeft(cm, val, isScroller) {
     if (isScroller ? val == cm.doc.scrollLeft : Math.abs(cm.doc.scrollLeft - val) < 2) return;
     val = Math.min(val, cm.display.scroller.scrollWidth - cm.display.scroller.clientWidth);
-    cm.doc.scrollLeft = val;
-    alignHorizontally(cm);
+    if (cm.doc.scrollLeft != val) {
+      cm.doc.scrollLeft = val;
+      alignHorizontally(cm);
+    }
     if (cm.display.scroller.scrollLeft != val) cm.display.scroller.scrollLeft = val;
     cm.display.scrollbars.setScrollLeft(val);
   }


### PR DESCRIPTION
…moved

A reported bug in a project using codemirror for a diff view is the result
of the fact that currently the gutters may be horizontally aligned also if
the scrollbar of the affected codemirror-field is not moved (anymore).

This happend if a very long line was shortened a bit which results in a
diff view that has a left side that is a bit longer than the right
side. If now the left horizontal scroll bar is moved to the right, the
right horizontal scroll bar stops moving at the end of the line while
the gutter still moves a little bit (that looks like the left scroll bar
would push it a bit to the right).

With this pull request, it will be first verified that the scroll bar has
moved and only then the gutters will be horizontally aligned.