### PR TITLE
jspm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,10 @@
                     "email": "marijnh@gmail.com",
                     "web": "http://marijnhaverbeke.nl"}],
     "repository": {"type": "git",
-                   "url": "https://github.com/codemirror/CodeMirror.git"}
+                   "url": "https://github.com/codemirror/CodeMirror.git"},
+    "jspm": {
+      "directories": {},
+      "dependencies": {},
+      "devDependencies": {}
+    }
 }


### PR DESCRIPTION
Hi!

This makes sure that jspm will not install the nodejs schims for buffer and process when installing codemirror for the browser.

I also had to override the `"directories"` to make sure that jspm was going to install codemirror in its entirety. With the original `"directories"` value, it would only install the content of the "`lib`" folder at the root of the package.

I am currently using my fork with:
```
jspm --version
0.16.31
jspm install codemirror=github:sutoiku/CodeMirror@5.13.0.n
```

I hope this help.
Many thanks for your attention.