### PR TITLE
Check if cm.save() is available before saving in keymap/vim.js

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -4515,8 +4515,8 @@
         if (CodeMirror.commands.save) {
           // If a save command is defined, call it.
           CodeMirror.commands.save(cm);
-        } else {
-          // Saves to text area if no save command is defined.
+        } else if (cm.save) {
+          // Saves to text area if no save command is defined and cm.save() is available.
           cm.save();
         }
       },


### PR DESCRIPTION
cm.save() might not exist if CodeMirror is not created from a
textarea. This adds an additional check to prevent TypeErrors.