### PR TITLE
Fix the link to Gerrit Code Review in doc/realworld.html

### DIFF
--- a/doc/realworld.html
+++ b/doc/realworld.html
@@ -79,7 +79,7 @@
       <li><a href="https://github.com/simogeo/Filemanager">Filemanager</a></li>
       <li><a href="https://hacks.mozilla.org/2013/11/firefox-developer-tools-episode-27-edit-as-html-codemirror-more/">Firefox Developer Tools</a></li>
       <li><a href="http://www.firepad.io">Firepad</a> (collaborative text editor)</li>
-      <li><a href="https://code.google.com/p/gerrit/">Gerrit</a>'s diff view</li>
+      <li><a href="https://gerritcodereview.com/">Gerrit</a>'s diff view and inline editor</li>
       <li><a href="https://github.com/maks/git-crx">Git Crx</a> (Chrome App for browsing local git repos)</li>
       <li><a href="http://tour.golang.org">Go language tour</a></li>
       <li><a href="https://github.com/github/android">GitHub's Android app</a></li>


### PR DESCRIPTION
The code.google.com link is deprecated. Also add that CodeMirror
is being used as Gerrit's inline editor.