### PR TITLE
[vim bindings] Remove dead code and initialize a property

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1048,7 +1048,7 @@
     };
     function HistoryController() {
         this.historyBuffer = [];
-        this.iterator;
+        this.iterator = 0;
         this.initialPrefix = null;
     }
     HistoryController.prototype = {
@@ -3290,8 +3290,6 @@
         line = cm.getLine(lineNum);
         pos = (dir > 0) ? 0 : line.length;
       }
-      // Should never get here.
-      throw new Error('The impossible happened.');
     }
 
     /**


### PR DESCRIPTION
The Error after the while(true) loop is not reachable and should
be removed. The "this.iterator" property should be given an
initial value of 0. This fixes two warnings reported by Closure
Compiler.