### PR TITLE
[tiddlywiki mode] Fix bogus return statements

### DIFF
--- a/mode/tiddlywiki/tiddlywiki.js
+++ b/mode/tiddlywiki/tiddlywiki.js
@@ -324,12 +324,7 @@ CodeMirror.defineMode("tiddlywiki", function () {
     word = stream.current();
     known = keywords.propertyIsEnumerable(word) && keywords[word];
 
-    if (known) {
-      return known.style, word;
-    }
-    else {
-      return null, word;
-    }
+    return known ? known.style : null;
   }
 
   // Interface


### PR DESCRIPTION
8ba727a0310b2e87d6a2c310580d368b1e3cc791 caused two return
statements to return the wrong variable. In addition, they cause
warnings when compiled with Closure Compiler. Fixed them to
return what they should.