### PR TITLE
[properties mode] Use empty block instead of empty statement

### DIFF
--- a/mode/properties/properties.js
+++ b/mode/properties/properties.js
@@ -34,7 +34,7 @@ CodeMirror.defineMode("properties", function() {
       }
 
       if (sol) {
-        while(stream.eatSpace());
+        while(stream.eatSpace()) {}
       }
 
       var ch = stream.next();


### PR DESCRIPTION
This eliminates a warning from Closure Compiler.