### PR TITLE
[tiddlywiki mode] Fix a return statement

### DIFF
--- a/mode/tiddlywiki/tiddlywiki.js
+++ b/mode/tiddlywiki/tiddlywiki.js
@@ -324,7 +324,7 @@ CodeMirror.defineMode("tiddlywiki", function () {
     word = stream.current();
     known = keywords.propertyIsEnumerable(word) && keywords[word];
 
-    return word;
+    return known ? known.style : null;
   }
 
   // Interface


### PR DESCRIPTION
According to
https://github.com/codemirror/CodeMirror/commit/8ba727a0310b2e87d6a2c310580d368b1e3cc791#diff-502b01b98b1553a622969a4b62a90a3eR328,
the return value should be known.style or null, not word.