### PR TITLE
Upon replace, search from the start of selection

### DIFF
--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -196,7 +196,7 @@
           replaceAll(cm, query, text)
         } else {
           clearSearch(cm);
-          var cursor = getSearchCursor(cm, query, cm.getCursor());
+          var cursor = getSearchCursor(cm, query, cm.getCursor("from"));
           var advance = function() {
             var start = cursor.from(), match;
             if (!(match = cursor.findNext())) {


### PR DESCRIPTION
Upon replace, if there is a match in the selection, it would be better to replace the current match, instead of the next match after the selection.