### PR TITLE
Fix mathematica mode by advancing the stream on error token

### DIFF
--- a/mode/mathematica/mathematica.js
+++ b/mode/mathematica/mathematica.js
@@ -126,6 +126,7 @@ CodeMirror.defineMode('mathematica', function(_config, _parserConfig) {
     }
 
     // everything else is an error
+    stream.next(); // advance the stream.
     return 'error';
   }
 


### PR DESCRIPTION
The mathematica mode breaks when it gets to the "error" case. In my case I saw it run in to an unrecognised character which brings it to returning "error" in its tokenizer, however the stream was not advanced for error tokens, and hence CM throws a "Mode _x_ failed to advance stream".