### PR TITLE
cleanup methods to help prevent DOM (detached node) leaks

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5953,9 +5953,21 @@
     };
 
     textarea.style.display = "none";
+
     var cm = CodeMirror(function(node) {
       textarea.parentNode.insertBefore(node, textarea.nextSibling);
     }, options);
+
+    cm.cleanup = function() {
+      if (textarea.form) {
+        off(textarea.form, "submit", save);
+      }
+      cm.toTextArea();
+      textarea = null;
+      cm = null;
+      CodeMirror.cleanup.apply(this);
+    }
+
     return cm;
   };
 
@@ -8887,6 +8899,32 @@
       return order;
     };
   })();
+
+  CodeMirror.cleanup = function() {
+    // Preventing detached DOM leaks: loop over and null out view and display objects.
+    var item, i, j;
+    var d = this.display;
+    var view = this.display.view;
+
+    function nullObject(obj) {
+      if (!obj) return;
+      for (item in obj) {
+        if (obj.hasOwnProperty(item)) {
+          obj[item] = null;
+        }
+      }
+    }
+
+    for (i=0, j=view.length; i<j; i++) {
+      nullObject(view[i]);
+    }
+
+    measureText = null;
+
+    nullObject(d);
+
+    d = view = null;
+  }
 
   // THE END
 


### PR DESCRIPTION
Hi CodeMirror folk,

This is my first fork and PR of a public repo in an ice age, so please forgive any obvious oversights. :laughing:

We use CodeMirror in a number of places within the Slack web app, which runs in desktop browsers and our own installable desktop apps which use web views (Safari/Webkit WebView) and Chromium (Electron) at present.

Given the dynamic nature of our web app, we regularly create and destroy views that can include CodeMirror instances. I noticed a number of detached DOM nodes building up very quickly over time, and found that CodeMirror just needs to release some DOM references when the view is being torn down to prevent the DOM tree(s) it creates from being leaked.

In our case, we'll instantiate with `editor = CodeMirror.fromTextArea(...)`, and later, call `editor.cleanup()` when the view is being destroyed. This calls a `cm.cleanup()` method specific to the `fromTextArea` instance, and finally `CodeMirror.cleanup()` which handles the rest.

Before my patch, running the contents of codemirror.js itself through the above and subsequently clearing the DOM underneath (i.e., canceling our "edit snippet" dialog) would result in 185,961 entries (yow, that's a lot of formatting nodes!) being shown under a Detached DOM tree item in Chrome Dev Tools. Over time, this would contribute to the webapp becoming slower as the detached DOM grew in size.

![codemirror dom leaks 2](https://cloud.githubusercontent.com/assets/174437/14288619/54ff4432-fb0c-11e5-8910-cd82830f237d.png)

Whilst I'm pretty sure I'm preaching to the choir here, detached nodes can be found in Chrome Dev Tools under Profiles -> Heap Snapshots (then take a snapshot), and then changing the view to from Summary to Containment View, or, just looking for Detached DOM tree entries in the list.

Every so often I look over the Slack webapp for leaked DOM trees and such, and identified this pattern with CodeMirror. I made edits as best I could to isolate and prevent against dangling event, property and direct node references within the new `cleanup()` methods.

Per guidelines, before making this PR I ran tests locally, and did not see any new regressions or failures introduced with my change. `bin/lint` also did not throw any complaints.

We've been applying my patch for the last while as we update CodeMirror, and I realize that's rather silly to keep doing. Please modify this change as you see fit and if it's useful, I'd be happy to see it worked in upstream. Thanks! :bow: 