### PR TITLE
Tweaks to lint gutter and icecoder theme

### DIFF
--- a/addon/lint/lint.css
+++ b/addon/lint/lint.css
@@ -1,6 +1,6 @@
 /* The lint marker gutter */
 .CodeMirror-lint-markers {
-  width: 16px;
+  width: 12px; margin-left: 2px;
 }
 
 .CodeMirror-lint-tooltip {
@@ -43,7 +43,7 @@
 .CodeMirror-lint-marker-error, .CodeMirror-lint-marker-warning {
   background-position: center center;
   background-repeat: no-repeat;
-  cursor: pointer;
+  cursor: help;
   display: inline-block;
   height: 16px;
   width: 16px;

--- a/theme/icecoder.css
+++ b/theme/icecoder.css
@@ -2,7 +2,7 @@
 ICEcoder default theme by Matt Pass, used in code editor available at https://icecoder.net
 */
 
-.cm-s-icecoder { color: #666; background: #141612; }
+.cm-s-icecoder { color: #666; background: #1d1d1b; }
 
 .cm-s-icecoder span.cm-keyword { color: #eee; font-weight:bold; }  /* off-white 1 */
 .cm-s-icecoder span.cm-atom { color: #e1c76e; }                    /* yellow */
@@ -37,7 +37,7 @@ ICEcoder default theme by Matt Pass, used in code editor available at https://ic
 
 .cm-s-icecoder .CodeMirror-cursor { border-left: 1px solid white; }
 .cm-s-icecoder div.CodeMirror-selected { color: #fff; background: #037; }
-.cm-s-icecoder .CodeMirror-gutters { background: #141612; min-width: 41px; border-right: 0; }
+.cm-s-icecoder .CodeMirror-gutters { background: #1d1d1b; min-width: 41px; border-right: 0; }
 .cm-s-icecoder .CodeMirror-linenumber { color: #555; cursor: default; }
-.cm-s-icecoder .CodeMirror-matchingbracket { border: 1px solid grey; color: black !important; }
+.cm-s-icecoder .CodeMirror-matchingbracket { color: #fff !important; background: #555 !important; }
 .cm-s-icecoder .CodeMirror-activeline-background { background: #000; }


### PR DESCRIPTION
Slightly slimmer gutter, with a 2px margin to left, to give a little space when you have maybe a gutter to left. cursor changed to help icon which seems to make more sense.

Warmer background color added for icecoder theme, plus fixed matching bracket (was a bordered box, which caused jumping and char became invisible (black on almost black), now grey box with white char).