### PR TITLE
[git commit message mode] Add and integrate

### DIFF
--- a/mode/git-commit-message/git-commit-message.js
+++ b/mode/git-commit-message/git-commit-message.js
@@ -1,0 +1,44 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+// Originally written by Shawn Pearce <sop@google.com>,
+// tweaked by Michael Zhou <zhoumotongxue008@gmail.com>
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+"use strict";
+
+CodeMirror.defineMode("git-commit-message", function() {
+  var header = /^(Parent|Author|AuthorDate|Commit|CommitDate):/;
+  var id = /^Change-Id: I[0-9a-f]{40}/; // Gerrit specific
+  var footer = /^[A-Z][A-Za-z0-9-]+:/;
+  var sha1 = /\b[0-9a-f]{6,40}/;
+
+  return {
+    token: function(stream) {
+      stream.eatSpace();
+      if (stream.column() == 0) {
+        if (stream.match(header))
+          return "keyword";
+        if (stream.match(id) || stream.match(footer))
+          return "builtin";
+      }
+
+      if (stream.match(sha1))
+        return "variable-2";
+      if (stream.match(/".*"/))
+        return "string";
+      stream.next();
+      return null;
+    }
+  };
+});
+
+CodeMirror.defineMIME("text/x-git-commit-message", "git-commit-message");
+
+});

--- a/mode/git-commit-message/index.html
+++ b/mode/git-commit-message/index.html
@@ -1,0 +1,52 @@
+<!doctype html>
+
+<title>CodeMirror: Git Commit Message mode</title>
+<meta charset="utf-8"/>
+<link rel=stylesheet href="../../doc/docs.css">
+
+<link rel="stylesheet" href="../../lib/codemirror.css">
+<script src="../../lib/codemirror.js"></script>
+<script src="git-commit-message.js"></script>
+<style>
+      .CodeMirror {border-top: 1px solid #ddd; border-bottom: 1px solid #ddd;}
+      span.cm-meta {color: #a0b !important;}
+      span.cm-error { background-color: black; opacity: 0.4;}
+      span.cm-error.cm-string { background-color: red; }
+      span.cm-error.cm-tag { background-color: #2b2; }
+    </style>
+<div id=nav>
+  <a href="http://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+
+  <ul>
+    <li><a href="../../index.html">Home</a>
+    <li><a href="../../doc/manual.html">Manual</a>
+    <li><a href="https://github.com/codemirror/codemirror">Code</a>
+  </ul>
+  <ul>
+    <li><a href="../index.html">Language modes</a>
+    <li><a class=active href="#">Git Commit Message</a>
+  </ul>
+</div>
+
+<article>
+<h2>Git Commit Message mode</h2>
+<form><textarea id="code" name="code">
+commit 88b05f3a0e5f9219c5fe160411db66ce6133e936
+Author: Shawn Pearce <sop@google.com>
+Date:   Wed Apr 30 12:29:54 2014 -0700
+
+    SideBySide2: Simple CM3 mode to syntax color Commit Message
+
+    Color the Parent, Author, AuthorDate, Commit, CommitDate lines
+    as keywords and any footers like Change-Id as builtin style.
+    This gives the screen a bit more color than the flat black text.
+
+    Change-Id: Ib82e7cafb792b86c522cffb0095b4da95559fd23
+</textarea></form>
+    <script>
+      var editor = CodeMirror.fromTextArea(document.getElementById("code"), {});
+    </script>
+
+    <p><strong>MIME types defined:</strong> <code>text/x-git-commit</code>.</p>
+
+  </article>

--- a/mode/index.html
+++ b/mode/index.html
@@ -65,6 +65,7 @@ option.</p>
       <li><a href="mllike/index.html">F#</a></li>
       <li><a href="gas/index.html">Gas</a> (AT&amp;T-style assembly)</li>
       <li><a href="gherkin/index.html">Gherkin</a></li>
+      <li><a href="git-commit-message/index.html">Git commit message</a></li>
       <li><a href="go/index.html">Go</a></li>
       <li><a href="groovy/index.html">Groovy</a></li>
       <li><a href="haml/index.html">HAML</a></li>

--- a/mode/meta.js
+++ b/mode/meta.js
@@ -54,6 +54,7 @@
     {name: "F#", mime: "text/x-fsharp", mode: "mllike", ext: ["fs"], alias: ["fsharp"]},
     {name: "Gas", mime: "text/x-gas", mode: "gas", ext: ["s"]},
     {name: "Gherkin", mime: "text/x-feature", mode: "gherkin", ext: ["feature"]},
+    {name: "Git Commit Message", mime: "text/x-git-commit-message", mode: "git-commit-message", file: /^COMMIT_MSG$/},
     {name: "GitHub Flavored Markdown", mime: "text/x-gfm", mode: "gfm", file: /^(readme|contributing|history).md$/i},
     {name: "Go", mime: "text/x-go", mode: "go", ext: ["go"]},
     {name: "Groovy", mime: "text/x-groovy", mode: "groovy", ext: ["groovy", "gradle"]},


### PR DESCRIPTION
Add a simple mode to color the Parent, Author, AuthorDate, Commit,
CommitDate lines as keywords and any footers like Change-Id or
Signed-off-by as builtin style. This gives the screen a bit more color
than the flat black text.

Originally written by Shawn Pearce <sop@google.com>, tweaked a little
bit by Michael Zhou <zhoumotongxue008@gmail.com> to match the style of
other current modes. Also fixed matching of headers / footers when they
are indented.