### PR TITLE
Use goLineStartSmart for cmd-left in Sublime keybindings

### DIFF
--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -55,6 +55,8 @@
   cmds[map["Alt-Left"] = "goSubwordLeft"] = function(cm) { moveSubword(cm, -1); };
   cmds[map["Alt-Right"] = "goSubwordRight"] = function(cm) { moveSubword(cm, 1); };
 
+  if (mac) map["Cmd-Left"] = "goLineStartSmart";
+
   var scrollLineCombo = mac ? "Ctrl-Alt-" : "Ctrl-";
 
   cmds[map[scrollLineCombo + "Up"] = "scrollLineUp"] = function(cm) {


### PR DESCRIPTION
OSX users of Sublime will be used to this as the default behavior. Right now CodeMirror with Sublime bindings jumps all the way to pos 0 on cmd-left. In actual Sublime, it jumps to start of text before going to pos 0. Luckily there's already a handy command for that!