### PR TITLE
Fix fenced code block mode switching for objective-c code blocks in github flavored markdown.

### DIFF
--- a/mode/gfm/test.js
+++ b/mode/gfm/test.js
@@ -51,6 +51,12 @@
      "[comment ```]",
      "bar");
 
+  MT("fencedCodeBlockModeSwitchingObjc",
+     "[comment ```objective-c]",
+     "[keyword @property] [variable NSString] [operator *] [variable foo];",
+     "[comment ```]",
+     "bar");
+
   MT("fencedCodeBlocksNoTildes",
      "~~~",
      "foo",

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -88,7 +88,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   ,   setextHeaderRE = /^ *(?:\={1,}|-{1,})\s*$/
   ,   textRE = /^[^#!\[\]*_\\<>` "'(~]+/
   ,   fencedCodeRE = new RegExp("^(" + (modeCfg.fencedCodeBlocks === true ? "~~~+|```+" : modeCfg.fencedCodeBlocks) +
-                                ")[ \\t]*([\\w+#]*)");
+                                ")[ \\t]*([\\w+#\-]*)");
 
   function switchInline(stream, state, f) {
     state.f = state.inline = f;

--- a/mode/meta.js
+++ b/mode/meta.js
@@ -91,7 +91,7 @@
     {name: "Nginx", mime: "text/x-nginx-conf", mode: "nginx", file: /nginx.*\.conf$/i},
     {name: "NSIS", mime: "text/x-nsis", mode: "nsis", ext: ["nsh", "nsi"]},
     {name: "NTriples", mime: "text/n-triples", mode: "ntriples", ext: ["nt"]},
-    {name: "Objective C", mime: "text/x-objectivec", mode: "clike", ext: ["m", "mm"]},
+    {name: "Objective C", mime: "text/x-objectivec", mode: "clike", ext: ["m", "mm"], alias: ["objective-c", "objc"]},
     {name: "OCaml", mime: "text/x-ocaml", mode: "mllike", ext: ["ml", "mli", "mll", "mly"]},
     {name: "Octave", mime: "text/x-octave", mode: "octave", ext: ["m"]},
     {name: "Oz", mime: "text/x-oz", mode: "oz", ext: ["oz"]},

--- a/test/index.html
+++ b/test/index.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="mode_test.css">
 <script src="../doc/activebookmark.js"></script>
 <script src="../lib/codemirror.js"></script>
+<script src="../mode/meta.js"></script>
 <script src="../addon/mode/overlay.js"></script>
 <script src="../addon/mode/multiplex.js"></script>
 <script src="../addon/search/searchcursor.js"></script>


### PR DESCRIPTION
There were two issues:

1. Github flavored markdown calls Objective C `objective-c`
2. The gfm.js mode didn't include `-` in its fenced code block regex

Additionally, test/index.html did not import the mode/meta.js file, which prevented mode lookup by name from working in unit tests.