### PR TITLE
Return null checks for annotation

### DIFF
--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -204,7 +204,8 @@
 
     var annotations = [];
     for (var i = 0; i < spans.length; ++i) {
-      annotations.push(spans[i].__annotation);
+      var ann = spans[i].__annotation;
+      if (ann) annotations.push(ann);
     }
     if (annotations.length) popupTooltips(annotations, e);
   }


### PR DESCRIPTION
Fix "Uncaught TypeError: Cannot read property 'severity' of undefined."

Previous changes made by this [commit](https://github.com/codemirror/CodeMirror/commit/9e31c01e11af098b76e059cf85ea5c9f9527fc99) broke my code. 
Here is the fix.

BTW, thank you for  the awesome tool!