### PR TITLE
[yacas mode] fix multiline comments

### DIFF
--- a/mode/yacas/yacas.js
+++ b/mode/yacas/yacas.js
@@ -111,11 +111,12 @@ CodeMirror.defineMode('yacas', function(_config, _parserConfig) {
   function tokenComment(stream, state) {
     var prev, next;
     while((next = stream.next()) != null) {
-      if (prev === '*' && next === '/')
+      if (prev === '*' && next === '/') {
+        state.tokenize = tokenBase;
         break;
+      }
       prev = next;
     }
-    state.tokenize = tokenBase;
     return 'comment';
   }
 


### PR DESCRIPTION
Obvious fix for a silly error in yacas mode causing multiline comments to be at most one line long