### PR TITLE
[Python] distinguish decorator at beginning of line from __matmul__

### DIFF
--- a/mode/python/python.js
+++ b/mode/python/python.js
@@ -249,15 +249,21 @@
     }
 
     function tokenLexer(stream, state) {
+      if (stream.sol()){
+        state.whiteSpaceAtBeginningOfLine = true;
+      }
       var style = state.tokenize(stream, state);
       var current = stream.current();
 
       // Handle decorators
-      if (current == "@") {
+      if (state.whiteSpaceAtBeginningOfLine && current == "@"){
         if (parserConf.version && parseInt(parserConf.version, 10) == 3)
           return stream.match(identifiers, false) ? "meta" : "operator";
         else
           return stream.match(identifiers, false) ? "meta" : ERRORCLASS;
+      }
+      if(!current.match(/^ +$/, false)){
+        state.whiteSpaceAtBeginningOfLine = false;
       }
 
       if ((style == "variable" || style == "builtin")

--- a/mode/python/test.js
+++ b/mode/python/test.js
@@ -1,0 +1,31 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+(function() {
+  var mode = CodeMirror.getMode({indentUnit: 4},
+              {name: "python",
+               version: 3,
+               singleLineStringErrors: false});
+  function MT(name) { test.mode(name, mode, Array.prototype.slice.call(arguments, 1)); }
+
+  // Error, because "foobarhello" is neither a known type or property, but
+  // property was expected (after "and"), and it should be in parentheses.
+  MT("decoratorStartOfLine",
+     "[meta @dec]",
+     "[keyword def] [def function]():",
+     "    [keyword pass]");
+
+  MT("decoratorIndented",
+     "[keyword class] [def Foo]:",
+     "    [meta @dec]",
+     "    [keyword def] [def function]():",
+     "        [keyword pass]");
+
+  MT("matmulWithSpace:", "[variable a] [operator @] [variable b]");
+  MT("matmulWithoutSpace:", "[variable a][operator @][variable b]");
+  MT("matmulSpaceBefore:", "[variable a] [operator @][variable b]");
+
+  MT("fValidStringPrefix", "[string f'this is a {formatted} string']");
+  MT("uValidStringPrefix", "[string u'this is an unicode string']");
+
+})();

--- a/test/index.html
+++ b/test/index.html
@@ -27,6 +27,7 @@
 <script src="../mode/jsx/jsx.js"></script>
 <script src="../mode/markdown/markdown.js"></script>
 <script src="../mode/php/php.js"></script>
+<script src="../mode/python/python.js"></script>
 <script src="../mode/powershell/powershell.js"></script>
 <script src="../mode/ruby/ruby.js"></script>
 <script src="../mode/shell/shell.js"></script>
@@ -123,6 +124,7 @@
     <script src="../mode/verilog/test.js"></script>
     <script src="../mode/xml/test.js"></script>
     <script src="../mode/xquery/test.js"></script>
+    <script src="../mode/python/test.js"></script>
     <script src="../mode/rust/test.js"></script>
     <script src="../mode/mscgen/mscgen_test.js"></script>
     <script src="../mode/mscgen/xu_test.js"></script>


### PR DESCRIPTION
`@` as __matmul__ operator only on Python 3,

Add tests for Python mode for this use case.

Closes #3957