### PR TITLE
sublime.js: auto-indent after insertLine

### DIFF
--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -124,6 +124,7 @@
       }
       cm.setSelections(newSelection);
     });
+    cm.execCommand("indentAuto");
   }
 
   cmds[map[ctrl + "Enter"] = "insertLineAfter"] = function(cm) { return insertLine(cm, false); };


### PR DESCRIPTION
Auto-indent inserted line (Ctrl + Enter) like in Sublime Text.