### PR TITLE
Include all ASCII control codes in specialChars

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5392,7 +5392,7 @@
     for (var i = newBreaks.length - 1; i >= 0; i--)
       replaceRange(cm.doc, val, newBreaks[i], Pos(newBreaks[i].line, newBreaks[i].ch + val.length))
   });
-  option("specialChars", /[\t\u0000-\u0019\u00ad\u200b-\u200f\u2028\u2029\ufeff]/g, function(cm, val, old) {
+  option("specialChars", /[\u0000-\u001f\u007f\u00ad\u200b-\u200f\u2028\u2029\ufeff]/g, function(cm, val, old) {
     cm.state.specialChars = new RegExp(val.source + (val.test("\t") ? "" : "|\t"), "g");
     if (old != CodeMirror.Init) cm.refresh();
   });


### PR DESCRIPTION
* `\x1a`-`\x1f` were missing though it looks like the intention was to cover all below `\x20` (space)
* added `\x7f` which is usually considered non-printable
* removed `\t` which was already covered in `\x00-\x19` as `\x09`