### PR TITLE
Disables wrapping on whitespace in CodeMirror-dialog by default

### DIFF
--- a/addon/dialog/dialog.css
+++ b/addon/dialog/dialog.css
@@ -6,6 +6,7 @@
   padding: .1em .8em;
   overflow: hidden;
   color: inherit;
+  white-space: nowrap;
 }
 
 .CodeMirror-dialog-top {


### PR DESCRIPTION
Fixes #3391.