### PR TITLE
[fix] `state.localMode.startState` should check `undefined`

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -218,7 +218,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       state.fencedChars = match[1]
       // try switching mode
       state.localMode = getMode(match[2]);
-      if (state.localMode) state.localState = state.localMode.startState();
+      if (state.localMode && state.localMode.startState) state.localState = state.localMode.startState();
       state.f = state.block = local;
       if (modeCfg.highlightFormatting) state.formatting = "code-block";
       state.code = -1


### PR DESCRIPTION
when I want to highlight ***```diff*** in section of markdown, it makes an error like

> markdown.js:221 Uncaught TypeError: state.localMode.startState is not a function

I think [markdown mode](https://github.com/codemirror/CodeMirror/blob/master/mode/markdown/markdown.js#L221) should check undefined or null for some case like [diff mode](https://github.com/codemirror/CodeMirror/blob/master/mode/diff/diff.js#L22)

![image](https://cloud.githubusercontent.com/assets/5318333/14814488/1417da0a-0bd9-11e6-8636-d9a236478817.png)