### PR TITLE
Fix typo in Fortran demo

### DIFF
--- a/mode/fortran/index.html
+++ b/mode/fortran/index.html
@@ -77,5 +77,5 @@
       });
     </script>
 
-    <p><strong>MIME types defined:</strong> <code>text/x-Fortran</code>.</p>
+    <p><strong>MIME types defined:</strong> <code>text/x-fortran</code>.</p>
   </article>


### PR DESCRIPTION
In Fortran demo page, it is stated that `text/x-Fortran` MIME type is defined, while the correct MIME type is with lowercase `f`