### PR TITLE
[vim mode] Fix fat-cursor border

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -52,7 +52,7 @@
 }
 .cm-fat-cursor .CodeMirror-cursor {
   width: auto;
-  border: 0;
+  border: 0 !important;
   background: #7e7;
 }
 .cm-fat-cursor div.CodeMirror-cursors {


### PR DESCRIPTION
Any theme with css rules about the cursor results to the normal cursor being displayed along with the fat cursor in vim mode, as seen below:
![image](https://cloud.githubusercontent.com/assets/3427236/15176939/359a2f68-1776-11e6-8531-f07599e7b35d.png)

This patch makes the `border: 0;` of the fat cursor `important` to avoid this issue.