### PR TITLE
Optimizing BranchChunk.insertInner for large files

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -7315,13 +7315,20 @@
         var child = this.children[i], sz = child.chunkSize();
         if (at <= sz) {
           child.insertInner(at, lines, height);
-          if (child.lines && child.lines.length > 50) {
-            while (child.lines.length > 50) {
-              var spilled = child.lines.splice(child.lines.length - 25, 25);
-              var newleaf = new LeafChunk(spilled);
-              child.height -= newleaf.height;
-              this.children.splice(i + 1, 0, newleaf);
-              newleaf.parent = this;
+          var childLines = child.lines;
+          var childLinesLen = childLines && childLines.length;
+          if (childLinesLen > 50) {
+            // To avoid memory thrashing when childLines is huge (e.g. first view of a large file), it's never spliced.
+            // Instead, small slices are taken. They're taken in order because sequential memory accesses are fastest.
+            var numNewLeafs = Math.ceil((childLinesLen - 50) / 25);
+            var newChildLinesLen = childLinesLen - numNewLeafs * 25;
+            child.lines = childLines.slice(0, newChildLinesLen);
+            for (var j = 0; j < numNewLeafs; j++) {
+              var leafStart = newChildLinesLen + j * 25;
+              var leaf = new LeafChunk(childLines.slice(leafStart, leafStart + 25));
+              child.height -= leaf.height;
+              this.children.push(leaf);
+              leaf.parent = this;
             }
             this.maybeSpill();
           }
@@ -7332,25 +7339,31 @@
     },
     // When a node has grown, check whether it should be split.
     maybeSpill: function() {
-      if (this.children.length <= 10) return;
       var me = this;
-      do {
-        var spilled = me.children.splice(me.children.length - 5, 5);
-        var sibling = new BranchChunk(spilled);
-        if (!me.parent) { // Become the parent node
-          var copy = new BranchChunk(me.children);
-          copy.parent = me;
-          me.children = [copy, sibling];
-          me = copy;
-        } else {
-          me.size -= sibling.size;
-          me.height -= sibling.height;
-          var myIndex = indexOf(me.parent.children, me);
-          me.parent.children.splice(myIndex + 1, 0, sibling);
-        }
-        sibling.parent = me.parent;
-      } while (me.children.length > 10);
-      me.parent.maybeSpill();
+      var children = me.children;
+      var numChildren = children.length;
+      if (numChildren <= 10) return;
+      // To avoid memory thrashing when the children array is huge (e.g. first view of a large file), it's never spliced.
+      // Instead, small slices are taken. They're taken in order because sequential memory accesses are fastest.
+      var parent = me.parent || me;
+      var numMoreBranches = Math.ceil((numChildren - 10) / 5);
+      var firstBranchNumChildren = numChildren - numMoreBranches * 5;
+      var firstBranch = new BranchChunk(children.slice(0, firstBranchNumChildren));
+      var branches = [firstBranch];
+      firstBranch.parent = parent;
+      for (var i = 0; i < numMoreBranches; i++) {
+        var branchStart = firstBranchNumChildren + i * 5;
+        var branch = new BranchChunk(children.slice(branchStart, branchStart + 5));
+        branches.push(branch);
+        branch.parent = parent;
+      }
+      if (parent === me) {
+        parent.children = branches;
+      } else {
+        var myIndex = indexOf(parent.children, me);
+        parent.children.splice(myIndex, 1, branches);
+      }
+      parent.maybeSpill();
     },
     iterN: function(at, n, op) {
       for (var i = 0; i < this.children.length; ++i) {


### PR DESCRIPTION
Fixes issue #4021 by avoiding repeated splicing of large arrays.