### PR TITLE
LineWiseCopyCut: Make this function usefully

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1102,7 +1102,7 @@
   var lastCopied = null;
   // This will be true when the last copy/cut occurred with no selection
   // and lineWiseCopyCut was enabled.  This allows us to alter the paste
-  // behavior to be more convenient when lineWiseCopyCut is enabled. 
+  // behavior to be more convenient when lineWiseCopyCut is enabled.
   var lastCopiedLinewise = false;
 
   function applyTextInput(cm, inserted, deleted, sel, origin) {
@@ -1134,7 +1134,7 @@
           from = Pos(from.line, from.ch - deleted);
         else if (cm.state.overwrite && !paste) // Handle overwrite
           to = Pos(to.line, Math.min(getLine(doc, to.line).text.length, to.ch + lst(textLines).length));
-        else if (paste && lastCopiedLinewise && cm.options.lineWiseCopyCut) // Handle paste after lineWiseCopyCut  
+        else if (paste && lastCopiedLinewise && cm.options.lineWiseCopyCut) // Handle paste after lineWiseCopyCut
           from = to = Pos(from.line, 0)
       }
       var updateInput = cm.curOp.updateInput;

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1100,6 +1100,10 @@
   // when pasting, we know what kind of selections the copied text
   // was made out of.
   var lastCopied = null;
+  // This will be true when the last copy/cut occurred with no selection
+  // and lineWiseCopyCut was enabled.  This allows us to alter the paste
+  // behavior to be more convenient when lineWiseCopyCut is enabled. 
+  var lastCopiedLinewise = false;
 
   function applyTextInput(cm, inserted, deleted, sel, origin) {
     var doc = cm.doc;
@@ -1130,6 +1134,8 @@
           from = Pos(from.line, from.ch - deleted);
         else if (cm.state.overwrite && !paste) // Handle overwrite
           to = Pos(to.line, Math.min(getLine(doc, to.line).text.length, to.ch + lst(textLines).length));
+        else if (paste && lastCopiedLinewise && cm.options.lineWiseCopyCut) // Handle paste after lineWiseCopyCut  
+          from = to = Pos(from.line, 0)
       }
       var updateInput = cm.curOp.updateInput;
       var changeEvent = {from: from, to: to, text: multiPaste ? multiPaste[i % multiPaste.length] : textLines,
@@ -1261,6 +1267,7 @@
 
       function prepareCopyCut(e) {
         if (signalDOMEvent(cm, e)) return
+        lastCopiedLinewise = false;
         if (cm.somethingSelected()) {
           lastCopied = cm.getSelections();
           if (input.inaccurateSelection) {
@@ -1274,6 +1281,7 @@
         } else {
           var ranges = copyableRanges(cm);
           lastCopied = ranges.text;
+          lastCopiedLinewise = true;
           if (e.type == "cut") {
             cm.setSelections(ranges.ranges, null, sel_dontScroll);
           } else {
@@ -1620,6 +1628,7 @@
 
       function onCopyCut(e) {
         if (signalDOMEvent(cm, e)) return
+        lastCopiedLinewise = false;
         if (cm.somethingSelected()) {
           lastCopied = cm.getSelections();
           if (e.type == "cut") cm.replaceSelection("", null, "cut");
@@ -1628,6 +1637,7 @@
         } else {
           var ranges = copyableRanges(cm);
           lastCopied = ranges.text;
+          lastCopiedLinewise = true;
           if (e.type == "cut") {
             cm.operation(function() {
               cm.setSelections(ranges.ranges, 0, sel_dontScroll);


### PR DESCRIPTION
See https://github.com/codemirror/CodeMirror/issues/3983 for complaints, 
this change makes it so that if the user only has empty selections and does a paste after a line-wise copy or cut, the line will be pasted at the beginning of current line instead of at the actual cursor position.  This makes the line-wise copy/cut feature way more convenient and useful.  E.g. user can simply do ctrl+C and then ctrl+V to duplicate a line quickly and keep the cursor in the same position.  