### PR TITLE
added support for codefolding with mobile (touchscreen) devices

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -3443,6 +3443,7 @@
       return dx * dx + dy * dy > 20 * 20;
     }
     on(d.scroller, "touchstart", function(e) {
+      if (clickInGutter(cm, e)) return;
       if (!signalDOMEvent(cm, e) && !isMouseLikeTouchEvent(e)) {
         clearTimeout(touchFinished);
         var now = +new Date;
@@ -3814,7 +3815,11 @@
   // Determines whether an event happened in the gutter, and fires the
   // handlers for the corresponding event.
   function gutterEvent(cm, e, type, prevent) {
-    try { var mX = e.clientX, mY = e.clientY; }
+    try {
+      // tries for mouse events first, then tries for touch events
+      var mX = e.clientX ? e.clientX : e.touches[0].pageX;
+      var mY = e.clientY ? e.clientY : e.touches[0].pageY;
+    }
     catch(e) { return false; }
     if (mX >= Math.floor(cm.display.gutters.getBoundingClientRect().right)) return false;
     if (prevent) e_preventDefault(e);


### PR DESCRIPTION
This is my first Pull-Request, so bear with me.

I've just made a small modification so that CodeMirror recognises touch events inside the gutter (for use with `foldcode.js` addon).

Please let me know if I've done this wrong in any way. 
I read the `contributing.md` and it's passed all the tests.
Open to constructive feedback 😄 