### PR TITLE
NEW MODES: WordPress Post Editor - Shortcode + HTML

### DIFF
--- a/mode/index.html
+++ b/mode/index.html
@@ -152,6 +152,7 @@ option.</p>
       <li><a href="vhdl/index.html">VHDL</a></li>
       <li><a href="vue/index.html">Vue.js app</a></li>
       <li><a href="webidl/index.html">Web IDL</a></li>
+      <li><a href="wordpresspost/index.html">WordPress Post</a> (HTMLmixed + shortcodes)</li>
       <li><a href="xml/index.html">XML/HTML</a></li>
       <li><a href="xquery/index.html">XQuery</a></li>
       <li><a href="yacas/index.html">Yacas</a></li>

--- a/mode/wordpresspost/index.html
+++ b/mode/wordpresspost/index.html
@@ -82,9 +82,9 @@
     </p>
 
     <p>
-      For use in the WordPress tinyMCE post/page editor in the admin
-      backend. Highlights the <a href="https://codex.wordpress.org/Shortcode_API">
-      WordPress Shorcode Syntax</a> as if were HTML. Also looks for special
+      For use in the WordPress admin tinyMCE post/page editor. Highlights
+      the <a href="https://codex.wordpress.org/Shortcode_API">
+      WordPress Shorcode Syntax</a> as if were XML. Also looks for special
       <a href="https://en.support.wordpress.com/more-tag/">WordPress
       &lt;--more--&gt; tags</a> and colors them accordingly.
     </p>

--- a/mode/wordpresspost/index.html
+++ b/mode/wordpresspost/index.html
@@ -1,0 +1,92 @@
+<!doctype html>
+
+<title>CodeMirror: HTML mixed mode</title>
+<meta charset="utf-8"/>
+<link rel=stylesheet href="../../doc/docs.css">
+
+<link rel="stylesheet" href="../../lib/codemirror.css">
+<link rel="stylesheet" href="../../theme/material.css">
+<script src="../../lib/codemirror.js"></script>
+<script src="../xml/xml.js"></script>
+<script src="../javascript/javascript.js"></script>
+<script src="../css/css.js"></script>
+<script src="../htmlmixed/htmlmixed.js"></script>
+<script src="shortcode.js"></script>
+<script src="wordpresspost.js"></script>
+<style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
+<div id=nav>
+  <a href="http://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+
+  <ul>
+    <li><a href="../../index.html">Home</a>
+    <li><a href="../../doc/manual.html">Manual</a>
+    <li><a href="https://github.com/codemirror/codemirror">Code</a>
+  </ul>
+  <ul>
+    <li><a href="../index.html">Language modes</a>
+    <li><a class=active href="#">WordPress Post</a>
+  </ul>
+</div>
+
+<article>
+<h2>WordPress Post Editor mode</h2>
+<form><textarea id="code" name="code">
+  <div>
+    [shortcode attribute="value" standaloneAttribute bool=true int=42 ]
+      [oneliner noquotes=stringvaluewithnospaces]
+      [self-closing-syntax html='<label class="name">Label</label>' /]
+      shortcode content
+      <a href="#">nested html</a>
+      [[escapedshortcode]]
+      [ [brackets that-dont-count]]
+    [/shortcode]
+  </div>
+
+  <!--more WordPress More Tag Text --><!--noteaser-->
+  <!--HTML comment--><!--[shortcode]-->
+
+  ERRORS!
+  [/noMatchlessEndTags]
+  [shortcode no_square_brackets_in_attribute_values='text[shortcode]']
+  [no/special|characters\in*shortcode^names or.attribute`names=error]
+
+  <?php
+  // shorcode in a meta block
+  [shortcode]
+  ?>
+
+  <style>
+    /* square brackets in css block */
+    element[attribute="value"]{ color:red; }
+  </style>
+
+  <script>
+      // square brackets in javascript block
+      array = ['valueone', 'valuetwo'];
+  </script>
+
+</textarea></form>
+    <script>
+      var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
+        mode: 'wordpresspost',
+        theme: 'material',
+        lineNumbers: true
+      });
+    </script>
+    <br/>
+
+    <p>
+      The WordPress Post mode depends on the XML, JavaScript, CSS,
+      HTMLmixed, and Shortcode modes. The Shortcode mode is included
+      in the wordpresspost directory.
+    </p>
+
+    <p>
+      For use in the WordPress tinyMCE post/page editor in the admin
+      backend. Highlights the <a href="https://codex.wordpress.org/Shortcode_API">
+      WordPress Shorcode Syntax</a> as if were HTML. Also looks for special
+      <a href="https://en.support.wordpress.com/more-tag/">WordPress
+      &lt;--more--&gt; tags</a> and colors them accordingly.
+    </p>
+
+  </article>

--- a/mode/wordpresspost/shortcode.js
+++ b/mode/wordpresspost/shortcode.js
@@ -1,0 +1,297 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+/**
+ * @name         CodeMirror Shortcode Mode
+ * @description  WordPress shortcode syntax highlighting for CodeMirror
+ * @author       James Bradford
+ * @link         http://arniebradfo.com
+ * @link         https://codex.wordpress.org/Shortcode_API
+ * @license      MIT
+ *
+ * derived from the CodeMirror xml mode
+**/
+
+(function (mod) {
+  if (typeof exports == 'object' && typeof module == 'object') { // CommonJS
+    mod(require('../../lib/codemirror'));
+  } else if (typeof define == 'function' && define.amd) { // AMD
+    define(['../../lib/codemirror'], mod);
+  } else { // Plain browser env
+    mod(CodeMirror);
+  }
+}(function (CodeMirror) {
+  'use strict';
+
+  var shortcodeConfig = {
+    allowUnquoted: true,
+    allowMissing: true,
+    caseFold: true
+  };
+
+  CodeMirror.defineMode('shortcode', function (editorConf, config_) {
+    var indentUnit = editorConf.indentUnit;
+    var config = {};
+    var defaults = shortcodeConfig;
+    for (var propDefault in defaults) config[propDefault] = defaults[propDefault];
+    for (var propConfig in config_) config[propConfig] = config_[propConfig];
+
+    // Return variables for tokenizers
+    var type, setStyle;
+
+    function inText (stream, state) {
+      var ch = stream.next();
+      if (ch === '[') {
+        if (stream.peek() === '[') {
+          state.tokenize = inEscape;
+          return 'comment';
+        }
+        if (/\s/.test(stream.peek())) return null;
+        type = stream.eat('/') ? 'closeTag' : 'openTag';
+        state.tokenize = inTag;
+        return 'tag bracket';
+      } else {
+        stream.eatWhile(/[^\[]/);
+        return null;
+      }
+    }
+    inText.isInText = true;
+
+    function inEscape (stream, state) {
+      var inEscapeFinal = function (stream, state) {
+        stream.next();
+        state.tokenize = inText;
+        return 'comment';
+      };
+      inEscapeFinal.isInEscape = true;
+      var ch = stream.next();
+      if (ch === ']' && stream.peek() === ']') state.tokenize = inEscapeFinal;
+      stream.eatWhile(/[^\]]/);
+      return null;
+    }
+    inEscape.isInEscape = true;
+
+    function inTag (stream, state) {
+      var ch = stream.next();
+      if (ch === ']' || (ch === '/' && stream.eat(']'))) {
+        state.tokenize = inText;
+        type = 'endTag';
+        return 'tag bracket';
+      } else if (ch === '=') {
+        type = 'equals';
+        return null;
+      } else if (ch === '[') {
+        state.tokenize = inText;
+        state.state = baseState;
+        state.tagName = state.tagStart = null;
+        var next = state.tokenize(stream, state);
+        return next ? next + ' tag error' : 'tag error';
+      } else if (/[\'\"]/.test(ch)) {
+        state.tokenize = inAttribute(ch);
+        state.stringStartCol = stream.column();
+        return state.tokenize(stream, state);
+      } else {
+        stream.match(/^[^\s\u00a0=\[\]\"\']*[^\s\u00a0=\[\]\"\'\/]/);
+        return 'word';
+      }
+    }
+
+    function inAttribute (quote) {
+      var closure = function (stream, state) {
+        var ch = stream.next();
+        if (ch === quote) {
+          state.tokenize = inTag;
+          return 'string';
+        } else if (/[\[\]]/.test(ch)) {
+          return 'string error';
+        } else {
+          stream.eatWhile(/[^\[\]\'\"]/);
+          return 'string';
+        }
+      };
+      closure.isInAttribute = true;
+      return closure;
+    }
+
+    function Context (state, tagName, startOfLine) {
+      this.tagHistory = [tagName];
+      if (state.context) this.tagHistory = this.tagHistory.concat(state.context.tagHistory);
+      this.prev = state.context;
+      this.tagName = tagName;
+      this.indent = state.indented;
+      this.startOfLine = startOfLine;
+    }
+
+    function popContext (state) {
+      if (state.context) state.context = state.context.prev;
+    }
+
+    function baseState (type, stream, state) {
+      if (type === 'openTag') {
+        state.tagStart = stream.column();
+        return tagNameState;
+      } else if (type === 'closeTag') {
+        return closeTagNameState;
+      } else {
+        return baseState;
+      }
+    }
+
+    function tagNameState (type, stream, state) {
+      if (type === 'word') {
+        var cur = stream.current();
+        if (/[\[\]\/\'\"<>&]/.test(cur)) {
+          setStyle = 'error';
+        } else {
+          state.tagName = stream.current();
+          setStyle = 'tag';
+        }
+        return attrState;
+      } else {
+        setStyle = 'error';
+        return tagNameState;
+      }
+    }
+
+    function closeTagNameState (type, stream, state) {
+      if (type === 'word') {
+        var tagName = stream.current();
+        if ((state.context && state.context.tagName === tagName) || config.matchClosing === false) {
+          setStyle = 'tag';
+          return closeState;
+        } else if (state.context && state.context.tagHistory.indexOf(tagName) > 0) {
+          var level = state.context.tagHistory.indexOf(tagName);
+          for (var i = 0; i < level; i++) popContext(state);
+          setStyle = 'tag';
+          return closeState;
+        } else {
+          setStyle = 'tag error';
+          return closeStateErr;
+        }
+      } else {
+        setStyle = 'error';
+        return closeStateErr;
+      }
+    }
+
+    function closeState (type, _stream, state) {
+      if (type !== 'endTag') {
+        setStyle = 'error';
+        return closeState;
+      }
+      popContext(state);
+      return baseState;
+    }
+    function closeStateErr (type, stream, state) {
+      setStyle = 'error';
+      return closeState(type, stream, state);
+    }
+
+    function attrState (type, _stream, state) {
+      if (type === 'word') {
+        if (!/^[a-z0-9_\-]+$/i.test(_stream.current())) setStyle = 'error';
+        else setStyle = 'attribute';
+        return attrEqState;
+      } else if (type === 'endTag') {
+        var tagName = state.tagName;
+        var tagStart = state.tagStart;
+        state.tagName = state.tagStart = null;
+        state.context = new Context(state, tagName, tagStart === state.indented);
+        return baseState;
+      }
+      setStyle = 'error';
+      return attrState;
+    }
+    function attrEqState (type, stream, state) {
+      if (type === 'equals') return attrValueState;
+      if (!config.allowMissing) setStyle = 'error';
+      return attrState(type, stream, state);
+    }
+    function attrValueState (type, stream, state) {
+      if (type === 'string') return attrContinuedState;
+      if (type === 'word' && config.allowUnquoted) {
+        setStyle = 'string';
+        return attrState;
+      }
+      setStyle = 'error';
+      return attrState(type, stream, state);
+    }
+    function attrContinuedState (type, stream, state) {
+      if (type === 'string') return attrContinuedState;
+      return attrState(type, stream, state);
+    }
+
+    return {
+      startState: function (baseIndent) {
+        var state = {
+          tokenize: inText,
+          state: baseState,
+          indented: baseIndent || 0,
+          tagName: null,
+          tagStart: null,
+          context: null
+        };
+        if (baseIndent != null) state.baseIndent = baseIndent;
+        return state;
+      },
+
+      token: function (stream, state) {
+        if (!state.tagName && stream.sol()) state.indented = stream.indentation();
+        if (stream.eatSpace()) return null;
+        type = null;
+        var style = state.tokenize(stream, state);
+        if ((style || type) && style !== 'comment') {
+          setStyle = null;
+          state.state = state.state(type || style, stream, state);
+          if (setStyle) style = setStyle === 'error' ? style + ' error' : setStyle;
+        }
+        return style;
+      },
+
+      indent: function (state, textAfter, fullLine) {
+        var context = state.context;
+        // Indent multi-line strings (e.g. css).
+        if (state.tokenize.isInAttribute) {
+          if (state.tagStart === state.indented) {
+            return state.stringStartCol + 1;
+          } else {
+            return state.indented + indentUnit;
+          }
+        }
+        if (state.tokenize !== inTag && state.tokenize !== inText) {
+          return fullLine ? fullLine.match(/^(\s*)/)[0].length : 0;
+        }
+        // Indent the starts of attribute names.
+        if (state.tagName) {
+          if (config.multilineTagIndentPastTag !== false) {
+            return state.tagStart + state.tagName.length + 2;
+          } else {
+            return state.tagStart + indentUnit * (config.multilineTagIndentFactor || 1);
+          }
+        }
+        var tagAfter = textAfter && /^\[(\/)?([\w_:\.-]*)/.exec(textAfter);
+        if (tagAfter && tagAfter[1]) { // Closing tag spotted
+          while (context) {
+            if (context.tagName === tagAfter[2]) {
+              context = context.prev;
+              break;
+            } else {
+              break;
+            }
+          }
+        }
+        while (context && context.prev && !context.startOfLine) {
+          context = context.prev;
+        }
+        if (context) {
+          return context.indent + indentUnit;
+        } else {
+          return state.baseIndent || 0;
+        }
+      },
+
+      skipAttribute: function (state) {
+        if (state.state === attrValueState) state.state = attrState;
+      }
+    };
+  });
+}));

--- a/mode/wordpresspost/shortcode.js
+++ b/mode/wordpresspost/shortcode.js
@@ -1,5 +1,6 @@
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: http://codemirror.net/LICENSE
+
 /**
  * @name         CodeMirror Shortcode Mode
  * @description  WordPress shortcode syntax highlighting for CodeMirror

--- a/mode/wordpresspost/wordpresspost.js
+++ b/mode/wordpresspost/wordpresspost.js
@@ -1,0 +1,132 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+/**
+ * @name         CodeMirror WordPress Post Editor Mode
+ * @description  Combines htmlmixed with the WordPress' shortcode syntax for use in the WordPress post text editor
+ * @author       James Bradford
+ * @link         http://arniebradfo.com
+ * @license      MIT
+ *
+ * derived from the CodeMirror htmlmixed mode
+**/
+
+(function (mod) {
+  if (typeof exports == 'object' && typeof module == 'object') { // CommonJS
+    mod(require('../../lib/codemirror'), require('../htmlmixed/htmlmixed'), require('shortcode'));
+  } else if (typeof define == 'function' && define.amd) { // AMD
+    define(['../../lib/codemirror', '../htmlmixed/htmlmixed', 'shortcode'], mod);
+  } else { // Plain browser env
+    mod(CodeMirror);
+  }
+}(function (CodeMirror) {
+  'use strict';
+
+  CodeMirror.defineMode('wordpresspost', function (config, parserConfig) {
+    var htmlmixedMode = CodeMirror.getMode(config, {
+      name: 'htmlmixed',
+      multilineTagIndentFactor: parserConfig.multilineTagIndentFactor,
+      multilineTagIndentPastTag: parserConfig.multilineTagIndentPastTag
+    });
+
+    var shortcodeMode = CodeMirror.getMode(config, {
+      name: 'shortcode',
+      multilineTagIndentFactor: parserConfig.multilineTagIndentFactor,
+      multilineTagIndentPastTag: parserConfig.multilineTagIndentPastTag
+    });
+
+    function shortcodeToken (stream, state) {
+      state.isInShortcode = true;
+      var style = shortcodeMode.token(stream, state.shortcodeState);
+      var inText = state.shortcodeState.tokenize.isInText;
+      var inEscape = state.shortcodeState.tokenize.isInEscape;
+      if (inText) {
+        state.token = htmlmixedToken;
+      } else if (inEscape && /\]/.test(stream.current())) {
+        var cur = stream.current();
+        var open = cur.search(/\]/);
+        stream.backUp(cur.length - open - 1);
+        if (stream.peek() !== ']') state.token = htmlmixedToken;
+      }
+      return style;
+    }
+
+    function htmlmixedToken (stream, state) {
+      state.isInShortcode = false;
+      var style = htmlmixedMode.token(stream, state.htmlmixedState);
+      var inText = state.htmlmixedState.htmlState.tokenize.isInText;
+      if (inText && /\[/.test(stream.current()) && !state.htmlmixedState.localState && style === null) {
+        var cur = stream.current();
+        var open = cur.search(/\[/);
+        stream.backUp(cur.length - open);
+        if (state.shortcodeState == null) { // ===null or ===undefined
+          state.shortcodeState = CodeMirror.startState(shortcodeMode, htmlmixedMode.indent(state.htmlmixedState, ''));
+        }
+        state.token = shortcodeToken;
+      } else if (inText && /<!\-\-more|<!\-\-noteaser\-\->/.test(stream.current()) && !state.htmlmixedState.localState && style === 'comment') {
+        stream.backUp(stream.current().length);
+        state.token = moreToken;
+      }
+      return style;
+    }
+
+    function moreToken (stream, state) {
+      if (stream.match('<!--more')) {
+        return 'meta';
+      } else if (stream.match('-->') || stream.match('<!--noteaser-->')) {
+        state.token = htmlmixedToken;
+        return 'meta';
+      } else {
+        stream.eatWhile(/[^\-/]/);
+        return 'string';
+      }
+    }
+
+    return {
+      startState: function () {
+        var state = htmlmixedMode.startState();
+        return {
+          token: htmlmixedToken,
+          isInShortcode: false,
+          shortcodeState: null,
+          htmlmixedState: state
+        };
+      },
+
+      copyState: function (state) {
+        var shortcodeStateProx;
+        if (state.shortcodeState) {
+          shortcodeStateProx = CodeMirror.copyState(shortcodeMode, state.shortcodeState);
+        }
+        return {
+          token: state.token,
+          shortcodeState: shortcodeStateProx,
+          htmlmixedState: CodeMirror.copyState(htmlmixedMode, state.htmlmixedState)
+        };
+      },
+
+      token: function (stream, state) {
+        return state.token(stream, state);
+      },
+
+      indent: function (state, textAfter) {
+        if (state.isInShortcode) return htmlmixedMode.indent(state.htmlmixedState, textAfter);
+        else if (!state.isInShortcode) return shortcodeMode.indent(state.shortcodeState, textAfter);
+        else return CodeMirror.Pass;
+      },
+
+      innerMode: function (state) {
+        if (state.isInShortcode) {
+          return {
+            state: state.shortcodeState,
+            mode: shortcodeMode
+          };
+        } else {
+          return {
+            state: state.htmlmixedState,
+            mode: htmlmixedMode
+          };
+        }
+      }
+    };
+  }, 'htmlmixed', 'shortcode');
+}));

--- a/mode/wordpresspost/wordpresspost.js
+++ b/mode/wordpresspost/wordpresspost.js
@@ -1,5 +1,6 @@
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: http://codemirror.net/LICENSE
+
 /**
  * @name         CodeMirror WordPress Post Editor Mode
  * @description  Combines htmlmixed with the WordPress' shortcode syntax for use in the WordPress post text editor


### PR DESCRIPTION
I created a set of modes for helping code in the WordPress TinyMCE post/page editor. Its part of a plugin I'm developing. I thought I might as well add it to the source. 

There are two new modes:
- **The shortcode mode:** Kinda like a WordPress version of xml with square brackets instead of angle brackets.
- **The WordPress post editor mode:** Combines the shortcode mode with HTMLmixed and some other WordPress specific stuff.

I put both of them in the same folder because I couldn't think of an situation where the shortcode mode would be used outside of a WordPress post editor.

Let me know what you think.

Thanks!
-James