### PR TITLE
Add clearOnEnter as foldOption

### DIFF
--- a/addon/fold/foldcode.js
+++ b/addon/fold/foldcode.js
@@ -49,7 +49,7 @@
     });
     var myRange = cm.markText(range.from, range.to, {
       replacedWith: myWidget,
-      clearOnEnter: true,
+      clearOnEnter: getOption(cm, options, "clearOnEnter"),
       __isFold: true
     });
     myRange.on("clear", function(from, to) {
@@ -129,7 +129,8 @@
     rangeFinder: CodeMirror.fold.auto,
     widget: "\u2194",
     minFoldSize: 0,
-    scanUp: false
+    scanUp: false,
+    clearOnEnter: true
   };
 
   CodeMirror.defineOption("foldOptions", null);


### PR DESCRIPTION
Add option 'clearOnEnter' to foldcode.js and default it to true. This option determines whether the marker added when folding a line clears when the cursor enters it.