### PR TITLE
Add a dataset option to markText

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -1630,6 +1630,10 @@ editor.setOption("extraKeys", {
         documents, you can set <code>shared</code> to true to make the
         marker appear in all documents. By default, a marker appears
         only in its target document.</dd>
+        <dt id="mark_dataset"><code><strong>dataset</strong>:
+        object</code></dt><dd>When given, will copy the key/value pairs
+        in the object into the <code>dataset</code> attribute of the
+        created nodes.
       </dl>
       The method will return an object that represents the marker
       (with constructor <code>CodeMirror.TextMarker</code>), which

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -6236,7 +6236,7 @@
       if (updateMaxLine) cm.curOp.updateMaxLine = true;
       if (marker.collapsed)
         regChange(cm, from.line, to.line + 1);
-      else if (marker.className || marker.title || marker.startStyle || marker.endStyle || marker.css)
+      else if (marker.className || marker.title || marker.startStyle || marker.endStyle || marker.css || marker.dataset)
         for (var i = from.line; i <= to.line; i++) regLineChange(cm, i, "text");
       if (marker.atomic) reCheckSelection(cm.doc);
       signalLater(cm, "markerAdded", cm, marker);
@@ -6989,7 +6989,7 @@
 
   // Build up the DOM representation for a single token, and add it to
   // the line map. Takes care to render special characters separately.
-  function buildToken(builder, text, style, startStyle, endStyle, title, css) {
+  function buildToken(builder, text, style, startStyle, endStyle, title, css, dataset) {
     if (!text) return;
     var displayText = builder.splitSpaces ? text.replace(/ {3,}/g, splitSpaces) : text;
     var special = builder.cm.state.specialChars, mustWrap = false;
@@ -7042,6 +7042,7 @@
       if (endStyle) fullStyle += endStyle;
       var token = elt("span", [content], fullStyle, css);
       if (title) token.title = title;
+      if (dataset) copyObj(dataset, token.dataset);
       return builder.content.appendChild(token);
     }
     builder.content.appendChild(content);
@@ -7057,7 +7058,7 @@
   // Work around nonsense dimensions being reported for stretches of
   // right-to-left text.
   function buildTokenBadBidi(inner, order) {
-    return function(builder, text, style, startStyle, endStyle, title, css) {
+    return function(builder, text, style, startStyle, endStyle, title, css, dataset) {
       style = style ? style + " cm-force-border" : "cm-force-border";
       var start = builder.pos, end = start + text.length;
       for (;;) {
@@ -7066,8 +7067,8 @@
           var part = order[i];
           if (part.to > start && part.from <= start) break;
         }
-        if (part.to >= end) return inner(builder, text, style, startStyle, endStyle, title, css);
-        inner(builder, text.slice(0, part.to - start), style, startStyle, null, title, css);
+        if (part.to >= end) return inner(builder, text, style, startStyle, endStyle, title, css, dataset);
+        inner(builder, text.slice(0, part.to - start), style, startStyle, null, title, css, dataset);
         startStyle = null;
         text = text.slice(part.to - start);
         start = part.to;
@@ -7101,12 +7102,12 @@
     }
 
     var len = allText.length, pos = 0, i = 1, text = "", style, css;
-    var nextChange = 0, spanStyle, spanEndStyle, spanStartStyle, title, collapsed;
+    var nextChange = 0, spanStyle, spanEndStyle, spanStartStyle, title, collapsed, dataset;
     for (;;) {
       if (nextChange == pos) { // Update current marker set
         spanStyle = spanEndStyle = spanStartStyle = title = css = "";
-        collapsed = null; nextChange = Infinity;
-        var foundBookmarks = [], endStyles
+        collapsed = null; nextChange = Infinity; dataset = null;
+        var foundBookmarks = [], endStyles;
         for (var j = 0; j < spans.length; ++j) {
           var sp = spans[j], m = sp.marker;
           if (m.type == "bookmark" && sp.from == pos && m.widgetNode) {
@@ -7119,8 +7120,9 @@
             if (m.className) spanStyle += " " + m.className;
             if (m.css) css = (css ? css + ";" : "") + m.css;
             if (m.startStyle && sp.from == pos) spanStartStyle += " " + m.startStyle;
-            if (m.endStyle && sp.to == nextChange) (endStyles || (endStyles = [])).push(m.endStyle, sp.to)
+            if (m.endStyle && sp.to == nextChange) (endStyles || (endStyles = [])).push(m.endStyle, sp.to);
             if (m.title && !title) title = m.title;
+            if (m.dataset && !dataset) dataset = m.dataset;
             if (m.collapsed && (!collapsed || compareCollapsedMarkers(collapsed.marker, m) < 0))
               collapsed = sp;
           } else if (sp.from > pos && nextChange > sp.from) {
@@ -7128,7 +7130,7 @@
           }
         }
         if (endStyles) for (var j = 0; j < endStyles.length; j += 2)
-          if (endStyles[j + 1] == nextChange) spanEndStyle += " " + endStyles[j]
+          if (endStyles[j + 1] == nextChange) spanEndStyle += " " + endStyles[j];
 
         if (!collapsed || collapsed.from == pos) for (var j = 0; j < foundBookmarks.length; ++j)
           buildCollapsedSpan(builder, 0, foundBookmarks[j]);
@@ -7148,7 +7150,8 @@
           if (!collapsed) {
             var tokenText = end > upto ? text.slice(0, upto - pos) : text;
             builder.addToken(builder, tokenText, style ? style + spanStyle : spanStyle,
-                             spanStartStyle, pos + tokenText.length == nextChange ? spanEndStyle : "", title, css);
+                             spanStartStyle, pos + tokenText.length == nextChange ? spanEndStyle : "",
+                             title, css, dataset);
           }
           if (end >= upto) {text = text.slice(upto - pos); pos = upto; break;}
           pos = end;


### PR DESCRIPTION
Lets you attach something like an id to a piece of code; without having to worry about it showing up on hover, like it would if you used title.