### PR TITLE
Prevent native search dialog from opening when persistent search dialog is open

### DIFF
--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -68,10 +68,7 @@
         var overriddenCommands = ['find', 'findPersistent', 'findNext', 'findPrev'];
 
         if (keyCommand && overriddenCommands.indexOf(keyCommand) !== -1) {
-          startSearch(cm, getSearchState(cm), val);
-          doSearch(cm, ev.shiftKey, true);
-          CodeMirror.e_stop(ev);
-          return false;
+          f(val, ev);
         }
       }
     });

--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -63,12 +63,18 @@
       selectValueOnOpen: true,
       closeOnEnter: false,
       onClose: function() { clearSearch(cm); },
-      onKeyDown: function(ev, val) {
-        var keyCommand = CodeMirror.keyMap['default'][CodeMirror.keyName(ev)];
-        var overriddenCommands = ['find', 'findPersistent', 'findNext', 'findPrev'];
-
-        if (keyCommand && overriddenCommands.indexOf(keyCommand) !== -1) {
-          f(val, ev);
+      onKeyDown: function(ev, query) {
+        var cmd = CodeMirror.keyMap['default'][CodeMirror.keyName(ev)];
+        if (cmd) {
+          var nextSearchCmds = ['findNext', 'findPrev'];
+          var searchCmds = ['find', 'findPersistent'];
+          if (nextSearchCmds.indexOf(cmd) !== -1) {
+            startSearch(cm, getSearchState(cm), query);
+            CodeMirror.commands[cmd](cm);
+            CodeMirror.e_stop(ev);
+          } else if (searchCmds.indexOf(cmd) !== -1) {
+            f(query, ev);
+          }
         }
       }
     });

--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -62,7 +62,18 @@
       value: deflt,
       selectValueOnOpen: true,
       closeOnEnter: false,
-      onClose: function() { clearSearch(cm); }
+      onClose: function() { clearSearch(cm); },
+      onKeyDown: function(ev, val) {
+        var keyCommand = CodeMirror.keyMap['default'][CodeMirror.keyName(ev)];
+        var overriddenCommands = ['find', 'findPersistent', 'findNext', 'findPrev'];
+
+        if (keyCommand && overriddenCommands.indexOf(keyCommand) !== -1) {
+          startSearch(cm, getSearchState(cm), val);
+          doSearch(cm, ev.shiftKey, true);
+          CodeMirror.e_stop(ev);
+          return false;
+        }
+      }
     });
   }
 


### PR DESCRIPTION
Prevents events for find commands when the persistent search dialog is open. This helps with accidental extra key presses.