### PR TITLE
Persistent search - find next

### DIFF
--- a/addon/dialog/dialog.js
+++ b/addon/dialog/dialog.js
@@ -65,6 +65,8 @@
         }
       }
 
+      if (options.onOpen)
+        options.onOpen(inp.value, close);
       if (options.onInput)
         CodeMirror.on(inp, "input", function(e) { options.onInput(e, inp.value, close);});
       if (options.onKeyUp)

--- a/addon/dialog/dialog.js
+++ b/addon/dialog/dialog.js
@@ -65,8 +65,6 @@
         }
       }
 
-      if (options.onOpen)
-        options.onOpen(inp.value, close);
       if (options.onInput)
         CodeMirror.on(inp, "input", function(e) { options.onInput(e, inp.value, close);});
       if (options.onKeyUp)

--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -57,13 +57,12 @@
     return cm.getSearchCursor(query, pos, queryCaseInsensitive(query));
   }
 
-  function persistentDialog(cm, text, deflt, onEnter, onOpen) {
-    cm.openDialog(text, onEnter, {
+  function persistentDialog(cm, text, deflt, f) {
+    cm.openDialog(text, f, {
       value: deflt,
       selectValueOnOpen: true,
       closeOnEnter: false,
       onClose: function() { clearSearch(cm); },
-      onOpen: onOpen,
       onKeyDown: function(ev, val) {
         var keyCommand = CodeMirror.keyMap['default'][CodeMirror.keyName(ev)];
         var overriddenCommands = ['find', 'findPersistent', 'findPersistentNext', 'findPersistentPrev', 'findNext', 'findPrev'];
@@ -130,8 +129,7 @@
     var q = cm.getSelection() || state.lastQuery;
     if (persistent && cm.openDialog) {
       var hiding = null
-
-      var onEnter = function(query, event) {
+      persistentDialog(cm, queryDialog, q, function(query, event) {
         CodeMirror.e_stop(event);
         if (!query) return;
         if (query != state.queryText) {
@@ -146,17 +144,11 @@
               dialog.getBoundingClientRect().bottom - 4 > cm.cursorCoords(to, "window").top)
             (hiding = dialog).style.opacity = .4
         })
-      }
-
-      var onOpen = null;
+      });
       if (immediate) {
-        onOpen = function(q) {
-          startSearch(cm, getSearchState(cm), q);
-          findNext(cm, rev);
-        }
+        startSearch(cm, state, q);
+        findNext(cm, rev);
       }
-
-      persistentDialog(cm, queryDialog, q, onEnter, onOpen);
     } else {
       dialog(cm, queryDialog, "Search for:", q, function(query) {
         if (query && !state.query) cm.operation(function() {

--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -62,7 +62,18 @@
       value: deflt,
       selectValueOnOpen: true,
       closeOnEnter: false,
-      onClose: function() { clearSearch(cm); }
+      onClose: function() { clearSearch(cm); },
+      onKeyDown: function(ev, val) {
+        var keyCommand = CodeMirror.keyMap['default'][CodeMirror.keyName(ev)];
+        var overriddenCommands = ['find', 'findPersistent', 'findNext', 'findPrev'];
+
+        if (keyCommand && overriddenCommands.indexOf(keyCommand) !== -1) {
+          startSearch(cm, getSearchState(cm), val);
+          doSearch(cm, ev.shiftKey, true);
+          CodeMirror.e_stop(ev);
+          return false;
+        }
+      }
     });
   }
 


### PR DESCRIPTION
We're switching over from the `find` to `findPersistent` functionality (which we prefer) I've found that it can be a little confusing for users who are used to the "old" find method - e.g. there is no way to open the persistent search and jump to the next or previous match (which is our the current find next/previous behaviour).

This PR adds two new search commands `findPersistentNext` and `findPersistentPrev` which do this. I would have liked to do this just using the existing search functions but I could't find a hook to be able to trigger a search immediately after the persistent dialog opens. I therefore added an `onOpen` hook.

Note: I've also included the changes from #4050 because this PR is a bit more destructive and so I wanted to split them up. However I've included it here as I realised that the extra commands would also need to be [caught](https://github.com/codemirror/CodeMirror/compare/master...40thieves:persistent-next?expand=1#diff-b39f347c31c96f6bba9d7d2aef74c267R69). Let me know if this is a problem and I'll pull it out.

Happy to make adjustments with your feedback 😄 