### PR TITLE
[go mode] Add `error` as highlighted type

### DIFF
--- a/mode/go/go.js
+++ b/mode/go/go.js
@@ -23,7 +23,7 @@ CodeMirror.defineMode("go", function(config) {
     "bool":true, "byte":true, "complex64":true, "complex128":true,
     "float32":true, "float64":true, "int8":true, "int16":true, "int32":true,
     "int64":true, "string":true, "uint8":true, "uint16":true, "uint32":true,
-    "uint64":true, "int":true, "uint":true, "uintptr":true
+    "uint64":true, "int":true, "uint":true, "uintptr":true, "error": true
   };
 
   var atoms = {


### PR DESCRIPTION
It is, per https://golang.org/ref/spec#Predeclared_identifiers