### PR TITLE
Use key definition from keyMap before calling call

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5871,7 +5871,7 @@
 
   var lookupKey = CodeMirror.lookupKey = function(key, map, handle, context) {
     map = getKeyMap(map);
-    var found = map.call ? map.call(key, context) : map[key];
+    var found = map[key] || (map.call ? map.call(key, context) : null);
     if (found === false) return "nothing";
     if (found === "...") return "multi";
     if (found != null && handle(found)) return "handled";


### PR DESCRIPTION
This fixes behaviour that is broken in the vim keymap. Specifically keys explicitly defined in vim-insert and vim-replace modes do not work.
