### PR TITLE
Use Sublime Text word/subword movement with alt/ctrl

### DIFF
--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -43,6 +43,15 @@
     return Pos(start.line, pos);
   }
 
+  function moveWord(cm, dir) {
+    cm.extendSelectionsBy(function(range) {
+      if (cm.display.shift || cm.doc.extend || range.empty())
+        return cm.findPosH(range.head, dir, "word");
+      else
+        return dir < 0 ? range.from() : range.to();
+    });
+  }
+
   function moveSubword(cm, dir) {
     cm.extendSelectionsBy(function(range) {
       if (cm.display.shift || cm.doc.extend || range.empty())
@@ -52,8 +61,10 @@
     });
   }
 
-  cmds[map["Alt-Left"] = "goSubwordLeft"] = function(cm) { moveSubword(cm, -1); };
-  cmds[map["Alt-Right"] = "goSubwordRight"] = function(cm) { moveSubword(cm, 1); };
+  cmds[map["Ctrl-Left"] = "goSubwordLeft"] = function(cm) { moveSubword(cm, -1); };
+  cmds[map["Ctrl-Right"] = "goSubwordRight"] = function(cm) { moveSubword(cm, 1); };
+  cmds[map["Alt-Left"] = "goWordLeft"] = function(cm) { moveWord(cm, -1); };
+  cmds[map["Alt-Right"] = "goWordRight"] = function(cm) { moveWord(cm, 1); };
 
   if (mac) map["Cmd-Left"] = "goLineStartSmart";
 


### PR DESCRIPTION
The only per-word movement in the existing sublime controls is sub-word, but it uses the full word keyboard shortcuts. This PR switches the alt shortcut to be full word and adds ctrl as subword to sync up with Sublime's defaults