### PR TITLE
[vim mode] Fix Backspace in replace mode and remove autocomplete bindings

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -53,6 +53,7 @@
     { keys: '<Down>', type: 'keyToKey', toKeys: 'j' },
     { keys: '<Space>', type: 'keyToKey', toKeys: 'l' },
     { keys: '<BS>', type: 'keyToKey', toKeys: 'h', context: 'normal'},
+    { keys: '<BS>', type: 'motion', motion: 'moveByCharacters', motionArgs: { forward: false }, context: 'insert'},
     { keys: '<C-Space>', type: 'keyToKey', toKeys: 'W' },
     { keys: '<C-BS>', type: 'keyToKey', toKeys: 'B', context: 'normal' },
     { keys: '<S-Space>', type: 'keyToKey', toKeys: 'w' },
@@ -4771,13 +4772,6 @@
     CodeMirror.keyMap['vim-insert'] = {
       // TODO: override navigation keys so that Esc will cancel automatic
       // indentation from o, O, i_<CR>
-      'Ctrl-N': 'autocomplete',
-      'Ctrl-P': 'autocomplete',
-      'Enter': function(cm) {
-        var fn = CodeMirror.commands.newlineAndIndentContinueComment ||
-            CodeMirror.commands.newlineAndIndent;
-        fn(cm);
-      },
       fallthrough: ['default'],
       attach: attachVimMap,
       detach: detachVimMap,
@@ -4785,7 +4779,6 @@
     };
 
     CodeMirror.keyMap['vim-replace'] = {
-      'Backspace': 'goCharLeft',
       fallthrough: ['vim-insert'],
       attach: attachVimMap,
       detach: detachVimMap,


### PR DESCRIPTION
See https://github.com/codemirror/CodeMirror/pull/4073