### PR TITLE
Refine image highlighting in markdown mode

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -444,7 +444,6 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     }
 
     if (ch === '[' && state.imageMarker) {
-      console.debug('imageAltText')
       state.imageMarker = false;
       state.imageAltText = true
       if (modeCfg.highlightFormatting) state.formatting = "image";
@@ -452,10 +451,10 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     }
 
     if (ch === ']' && state.imageAltText) {
-      console.debug('End alt text')
       if (modeCfg.highlightFormatting) state.formatting = "image";
       var type = getType(state);
       state.imageAltText = false;
+      state.image = false;
       state.inline = state.f = linkHref;
       return type;
     }

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -63,7 +63,9 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     list2: "variable-3",
     list3: "keyword",
     hr: "hr",
-    image: "tag",
+    image: "image",
+    imageAltText: "image-alt-text",
+    imageMarker: "image-marker",
     formatting: "formatting",
     linkInline: "link",
     linkEmail: "link",
@@ -313,6 +315,9 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       if (state.strikethrough) { styles.push(tokenTypes.strikethrough); }
       if (state.linkText) { styles.push(tokenTypes.linkText); }
       if (state.code) { styles.push(tokenTypes.code); }
+      if (state.image) { styles.push(tokenTypes.image); }
+      if (state.imageAltText) { styles.push(tokenTypes.imageAltText); }
+      if (state.imageMarker) { styles.push(tokenTypes.imageMarker); }
     }
 
     if (state.header) { styles.push(tokenTypes.header, tokenTypes.header + "-" + state.header); }
@@ -432,12 +437,30 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     }
 
     if (ch === '!' && stream.match(/\[[^\]]*\] ?(?:\(|\[)/, false)) {
-      stream.match(/\[[^\]]*\]/);
-      state.inline = state.f = linkHref;
-      return tokenTypes.image;
+      state.imageMarker = true;
+      state.image = true;
+      if (modeCfg.highlightFormatting) state.formatting = "image";
+      return getType(state);
     }
 
-    if (ch === '[' && stream.match(/[^\]]*\](\(.*\)| ?\[.*?\])/, false)) {
+    if (ch === '[' && state.imageMarker) {
+      console.debug('imageAltText')
+      state.imageMarker = false;
+      state.imageAltText = true
+      if (modeCfg.highlightFormatting) state.formatting = "image";
+      return getType(state);
+    }
+
+    if (ch === ']' && state.imageAltText) {
+      console.debug('End alt text')
+      if (modeCfg.highlightFormatting) state.formatting = "image";
+      var type = getType(state);
+      state.imageAltText = false;
+      state.inline = state.f = linkHref;
+      return type;
+    }
+
+    if (ch === '[' && stream.match(/[^\]]*\](\(.*\)| ?\[.*?\])/, false) && !state.image) {
       state.linkText = true;
       if (modeCfg.highlightFormatting) state.formatting = "link";
       return getType(state);

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -316,7 +316,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       if (state.linkText) { styles.push(tokenTypes.linkText); }
       if (state.code) { styles.push(tokenTypes.code); }
       if (state.image) { styles.push(tokenTypes.image); }
-      if (state.imageAltText) { styles.push(tokenTypes.imageAltText); }
+      if (state.imageAltText) { styles.push(tokenTypes.imageAltText, "link"); }
       if (state.imageMarker) { styles.push(tokenTypes.imageMarker); }
     }
 

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -22,6 +22,8 @@
       "list3" : "override-list3",
       "hr" : "override-hr",
       "image" : "override-image",
+      "imageAltText": "override-image-alt-text",
+      "imageMarker": "override-image-marker",
       "linkInline" : "override-link-inline",
       "linkEmail" : "override-link-email",
       "linkText" : "override-link-text",
@@ -88,6 +90,9 @@
 
   FT("formatting_escape",
      "[formatting-escape \\*]");
+
+  FT("formatting_image",
+     "[formatting&formatting-image&image&image-marker !][formatting&formatting-image&image&image-alt-text [[][image&image-alt-text alt text][formatting&formatting-image&image&image-alt-text ]]][formatting&formatting-link-string&string&url (][url&string http://link.to/image.jpg][formatting&formatting-link-string&string&url )]");
 
   MT("plainText",
      "foo");
@@ -589,6 +594,20 @@
   MT("hrDashLong",
      "[hr ---------------------------------------]");
 
+  //Images
+  MT("Images",
+     "[image&image-marker !][image&image-alt-text [[alt text]]][string&url (http://link.to/image.jpg)]")
+
+  //Images with highlight alt text
+  MT("imageEm",
+     "[image&image-marker !][image&image-alt-text [[][image-alt-text&em&image *alt text*][image&image-alt-text ]]][string&url (http://link.to/image.jpg)]");
+
+  MT("imageStrong",
+     "[image&image-marker !][image&image-alt-text [[][image-alt-text&strong&image **alt text**][image&image-alt-text ]]][string&url (http://link.to/image.jpg)]");
+
+  MT("imageEmStrong",
+     "[image&image-marker !][image&image-alt-text [[][image-alt-text&image&strong **][image&image-alt-text&em&strong *alt text**][image&image-alt-text&em *][image&image-alt-text ]]][string&url (http://link.to/image.jpg)]");
+
   // Inline link with title
   MT("linkTitle",
      "[link [[foo]]][string&url (http://example.com/ \"bar\")] hello");
@@ -599,7 +618,7 @@
 
   // Inline link with image
   MT("linkImage",
-     "[link [[][tag ![[foo]]][string&url (http://example.com/)][link ]]][string&url (http://example.com/)] bar");
+     "[link [[][link&image&image-marker !][link&image&image-alt-text [[alt text]]][string&url (http://link.to/image.jpg)][link ]]][string&url (http://example.com/)] bar");
 
   // Inline link with Em
   MT("linkEm",
@@ -615,15 +634,15 @@
 
   // Image with title
   MT("imageTitle",
-     "[tag ![[foo]]][string&url (http://example.com/ \"bar\")] hello");
+     "[image&image-marker !][image&image-alt-text [[alt text]]][string&url (http://example.com/ \"bar\")] hello");
 
   // Image without title
   MT("imageNoTitle",
-     "[tag ![[foo]]][string&url (http://example.com/)] bar");
+     "[image&image-marker !][image&image-alt-text [[alt text]]][string&url (http://example.com/)] bar");
 
   // Image with asterisks
   MT("imageAsterisks",
-     "[tag ![[*foo*]]][string&url (http://example.com/)] bar");
+     "[image&image-marker !][image&image-alt-text [[ ][image&image-alt-text&em *alt text*][image&image-alt-text ]]][string&url (http://link.to/image.jpg)] bar");
 
   // Not a link. Should be normal text due to square brackets being used
   // regularly in text, especially in quoted material, and no space is allowed
@@ -878,7 +897,7 @@
     "[override-hr * * *]");
 
   TokenTypeOverrideTest("overrideImage",
-    "[override-image ![[foo]]][override-link-href&url (http://example.com/)]")
+    "[override-image&override-image-marker !][override-image&override-image-alt-text [[alt text]]][override-link-href&url (http://link.to/image.jpg)]");
 
   TokenTypeOverrideTest("overrideLinkText",
     "[override-link-text [[foo]]][override-link-href&url (http://example.com)]");

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -92,7 +92,7 @@
      "[formatting-escape \\*]");
 
   FT("formatting_image",
-     "[formatting&formatting-image&image&image-marker !][formatting&formatting-image&image&image-alt-text [[][image&image-alt-text alt text][formatting&formatting-image&image&image-alt-text ]]][formatting&formatting-link-string&string&url (][url&string http://link.to/image.jpg][formatting&formatting-link-string&string&url )]");
+     "[formatting&formatting-image&image&image-marker !][formatting&formatting-image&image&image-alt-text&link [[][image&image-alt-text&link alt text][formatting&formatting-image&image&image-alt-text&link ]]][formatting&formatting-link-string&string&url (][url&string http://link.to/image.jpg][formatting&formatting-link-string&string&url )]");
 
   MT("plainText",
      "foo");
@@ -596,17 +596,17 @@
 
   //Images
   MT("Images",
-     "[image&image-marker !][image&image-alt-text [[alt text]]][string&url (http://link.to/image.jpg)]")
+     "[image&image-marker !][image&image-alt-text&link [[alt text]]][string&url (http://link.to/image.jpg)]")
 
   //Images with highlight alt text
   MT("imageEm",
-     "[image&image-marker !][image&image-alt-text [[][image-alt-text&em&image *alt text*][image&image-alt-text ]]][string&url (http://link.to/image.jpg)]");
+     "[image&image-marker !][image&image-alt-text&link [[][image-alt-text&em&image&link *alt text*][image&image-alt-text&link ]]][string&url (http://link.to/image.jpg)]");
 
   MT("imageStrong",
-     "[image&image-marker !][image&image-alt-text [[][image-alt-text&strong&image **alt text**][image&image-alt-text ]]][string&url (http://link.to/image.jpg)]");
+     "[image&image-marker !][image&image-alt-text&link [[][image-alt-text&strong&image&link **alt text**][image&image-alt-text&link ]]][string&url (http://link.to/image.jpg)]");
 
   MT("imageEmStrong",
-     "[image&image-marker !][image&image-alt-text [[][image-alt-text&image&strong **][image&image-alt-text&em&strong *alt text**][image&image-alt-text&em *][image&image-alt-text ]]][string&url (http://link.to/image.jpg)]");
+     "[image&image-marker !][image&image-alt-text&link [[][image-alt-text&image&strong&link **][image&image-alt-text&em&strong&link *alt text**][image&image-alt-text&em&link *][image&image-alt-text&link ]]][string&url (http://link.to/image.jpg)]");
 
   // Inline link with title
   MT("linkTitle",
@@ -618,7 +618,7 @@
 
   // Inline link with image
   MT("linkImage",
-     "[link [[][link&image&image-marker !][link&image&image-alt-text [[alt text]]][string&url (http://link.to/image.jpg)][link ]]][string&url (http://example.com/)] bar");
+     "[link [[][link&image&image-marker !][link&image&image-alt-text&link [[alt text]]][string&url (http://link.to/image.jpg)][link ]]][string&url (http://example.com/)] bar");
 
   // Inline link with Em
   MT("linkEm",
@@ -634,15 +634,15 @@
 
   // Image with title
   MT("imageTitle",
-     "[image&image-marker !][image&image-alt-text [[alt text]]][string&url (http://example.com/ \"bar\")] hello");
+     "[image&image-marker !][image&image-alt-text&link [[alt text]]][string&url (http://example.com/ \"bar\")] hello");
 
   // Image without title
   MT("imageNoTitle",
-     "[image&image-marker !][image&image-alt-text [[alt text]]][string&url (http://example.com/)] bar");
+     "[image&image-marker !][image&image-alt-text&link [[alt text]]][string&url (http://example.com/)] bar");
 
   // Image with asterisks
   MT("imageAsterisks",
-     "[image&image-marker !][image&image-alt-text [[ ][image&image-alt-text&em *alt text*][image&image-alt-text ]]][string&url (http://link.to/image.jpg)] bar");
+     "[image&image-marker !][image&image-alt-text&link [[ ][image&image-alt-text&em&link *alt text*][image&image-alt-text&link ]]][string&url (http://link.to/image.jpg)] bar");
 
   // Not a link. Should be normal text due to square brackets being used
   // regularly in text, especially in quoted material, and no space is allowed
@@ -897,7 +897,7 @@
     "[override-hr * * *]");
 
   TokenTypeOverrideTest("overrideImage",
-    "[override-image&override-image-marker !][override-image&override-image-alt-text [[alt text]]][override-link-href&url (http://link.to/image.jpg)]");
+    "[override-image&override-image-marker !][override-image&override-image-alt-text&link [[alt text]]][override-link-href&url (http://link.to/image.jpg)]");
 
   TokenTypeOverrideTest("overrideLinkText",
     "[override-link-text [[foo]]][override-link-href&url (http://example.com)]");


### PR DESCRIPTION
According to the format suggested in #4082 add more information to images.

This implements formatting as suggested in the issue and adds tests for the implemented tokens. Also updates some tests with the new format.

With highlighting mode an image will now look like this:

```html
<span style="padding-right: 0.1px;">
    <span class="cm-formatting cm-formatting-image cm-image cm-image-marker">!</span>
    <span class="cm-formatting cm-formatting-image cm-image cm-image-alt-text">[</span>
    <span class="cm-image cm-image-alt-text">alt text</span>
    <span class="cm-formatting cm-formatting-image cm-image cm-image-alt-text">]</span>
    <span class="cm-formatting cm-formatting-link-string cm-string cm-url">(</span>
    <span class="cm-string cm-url">http://link.to/image.jpg</span>
    <span class="cm-formatting cm-formatting-link-string cm-string cm-url">)</span>
</span>
```

Giving a great deal of freedom to styling it however you like.