### PR TITLE
Force editor layer for faster paint.

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -5,6 +5,7 @@
   font-family: monospace;
   height: 300px;
   color: black;
+  transform: translate3d(0, 0, 0);
 }
 
 /* PADDING */


### PR DESCRIPTION
Implement the layer separation suggested in [1] to reduce the print area when scrolling. The editor will get its own GPU accelerated layer [2]. It applies to Chrome/WebKit.

Before
![before](https://cloud.githubusercontent.com/assets/284743/16778483/7f2fe2d4-486e-11e6-839a-323c8072704c.PNG)

After
![after](https://cloud.githubusercontent.com/assets/284743/16778503/920c3394-486e-11e6-84e9-73e368b2440b.PNG)

[1] [Tricks for high performance scrolling](https://groups.google.com/forum/#!searchin/codemirror/translate3d/codemirror/kQirncJtBjI/rdzEf1zOeRwJ)
[2] [Accelerated Rendering in Chrome](http://www.html5rocks.com/en/tutorials/speed/layers/)
