### PR TITLE
Make match-highlight scrollbar annotations case-sensitive

### DIFF
--- a/addon/search/match-highlighter.js
+++ b/addon/search/match-highlighter.js
@@ -72,7 +72,7 @@
     cm.addOverlay(state.overlay = makeOverlay(query, hasBoundary, style));
     if (state.options.annotateScrollbar && cm.showMatchesOnScrollbar) {
       var searchFor = hasBoundary ? new RegExp("\\b" + query + "\\b") : query;
-      state.matchesonscroll = cm.showMatchesOnScrollbar(searchFor, true,
+      state.matchesonscroll = cm.showMatchesOnScrollbar(searchFor, false,
         {className: "CodeMirror-selection-highlight-scrollbar"});
     }
   }


### PR DESCRIPTION
To match the actual match-highlights in the editor.