### PR TITLE
Minor modification to clean up after hasBadBidiRects test

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -8558,8 +8558,9 @@
     if (badBidiRects != null) return badBidiRects;
     var txt = removeChildrenAndAdd(measure, document.createTextNode("A\u062eA"));
     var r0 = range(txt, 0, 1).getBoundingClientRect();
-    if (!r0 || r0.left == r0.right) return false; // Safari returns null in some cases (#2780)
     var r1 = range(txt, 1, 2).getBoundingClientRect();
+    removeChildren(measure);
+    if (!r0 || r0.left == r0.right) return false; // Safari returns null in some cases (#2780)
     return badBidiRects = (r1.right - r0.right < 3);
   }
 


### PR DESCRIPTION
In going through Google webmaster tools for one of my websites, I was surprised to see "AخA" listed as a keyword in my pages. I finally traced it back to your repository, since I use embedded SageMathCells and that uses CodeMirror. I've noticed that every website using CodeMirror comes up in a Google search for that three-character combination, so perhaps you left it in intentionally.

If it was not intentional, this small modification to the test function removes the leftover textnode.