### PR TITLE
Added support for "text/babel" script type

### DIFF
--- a/mode/htmlmixed/htmlmixed.js
+++ b/mode/htmlmixed/htmlmixed.js
@@ -15,6 +15,7 @@
     script: [
       ["lang", /(javascript|babel)/i, "javascript"],
       ["type", /^(?:text|application)\/(?:x-)?(?:java|ecma)script$|^$/i, "javascript"],
+      ["type", /^text\/babel$/i, "javascript"],
       ["type", /./, "text/plain"],
       [null, null, "javascript"]
     ],


### PR DESCRIPTION
In many places (react tutorial, babel-standalone usage page, etc) babel scripts can be defined using script type "text/babel" without setting any script lang.