### PR TITLE
Variable width tabs via tabStops option

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -8318,7 +8318,7 @@
   };
 
   function tabStopAt(column, tabSize, tabStops) {
-    if (tabStops) {
+    if (tabStops.length > 0) {
       var stop = tabStops.find(function (d) { return d > column; });
       if (stop) {
         return stop

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -4780,8 +4780,9 @@
         pos = tabStops[i];
         indentString += "\t";
       }
-      if ( i === tabStops.length )
+      if ( i === tabStops.length ) {
         for (i = Math.floor((indentation - pos) / tabSize); i; --i) {pos += tabSize; indentString += "\t";}
+      }
     }
     if (pos < indentation) indentString += spaceStr(indentation - pos);
 

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -4759,7 +4759,7 @@
       }
     }
     if (how == "prev") {
-      if (n > doc.first) indentation = countColumn(getLine(doc, n-1).text, null, tabSize);
+      if (n > doc.first) indentation = countColumn(getLine(doc, n-1).text, null, tabSize, tabStops);
       else indentation = 0;
     } else if (how == "add") {
       indentation = curSpace + cm.options.indentUnit;
@@ -4771,8 +4771,18 @@
     indentation = Math.max(0, indentation);
 
     var indentString = "", pos = 0;
-    if (cm.options.indentWithTabs)
-      for (var i = Math.floor(indentation / tabSize); i; --i) {pos += tabSize; indentString += "\t";}
+    if (cm.options.indentWithTabs) {
+      var i;
+      for (i = 0; i < tabStops.length; ++i) {
+        if (tabStops[i] > indentation) {
+          break;
+        }
+        pos = tabStops[i];
+        indentString += "\t";
+      }
+      if ( i === tabStops.length )
+        for (i = Math.floor((indentation - pos) / tabSize); i; --i) {pos += tabSize; indentString += "\t";}
+    }
     if (pos < indentation) indentString += spaceStr(indentation - pos);
 
     if (indentString != curSpaceString) {

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -6002,10 +6002,11 @@
   // Fed to the mode parsers, provides helper functions to make
   // parsers more succinct.
 
-  var StringStream = CodeMirror.StringStream = function(string, tabSize) {
+  var StringStream = CodeMirror.StringStream = function(string, tabSize, tabStops) {
     this.pos = this.start = 0;
     this.string = string;
     this.tabSize = tabSize || 8;
+    this.tabStops = tabStops;
     this.lastColumnPos = this.lastColumnValue = 0;
     this.lineStart = 0;
   };
@@ -6042,14 +6043,14 @@
     backUp: function(n) {this.pos -= n;},
     column: function() {
       if (this.lastColumnPos < this.start) {
-        this.lastColumnValue = countColumn(this.string, this.start, this.tabSize, this.lastColumnPos, this.lastColumnValue);
+        this.lastColumnValue = countColumn(this.string, this.start, this.tabSize, this.tabStops, this.lastColumnPos, this.lastColumnValue);
         this.lastColumnPos = this.start;
       }
-      return this.lastColumnValue - (this.lineStart ? countColumn(this.string, this.lineStart, this.tabSize) : 0);
+      return this.lastColumnValue - (this.lineStart ? countColumn(this.string, this.lineStart, this.tabSize, this.tabStops) : 0);
     },
     indentation: function() {
-      return countColumn(this.string, null, this.tabSize) -
-        (this.lineStart ? countColumn(this.string, this.lineStart, this.tabSize) : 0);
+      return countColumn(this.string, null, this.tabSize, this.tabStops) -
+        (this.lineStart ? countColumn(this.string, this.lineStart, this.tabSize, this.tabStops) : 0);
     },
     match: function(pattern, consume, caseInsensitive) {
       if (typeof pattern == "string") {
@@ -6822,7 +6823,7 @@
     var doc = cm.doc, mode = doc.mode, style;
     pos = clipPos(doc, pos);
     var line = getLine(doc, pos.line), state = getStateBefore(cm, pos.line, precise);
-    var stream = new StringStream(line.text, cm.options.tabSize), tokens;
+    var stream = new StringStream(line.text, cm.options.tabSize, cm.options.tabStops), tokens;
     if (asArray) tokens = [];
     while ((asArray || stream.pos < pos.ch) && !stream.eol()) {
       stream.start = stream.pos;
@@ -6837,7 +6838,7 @@
     var flattenSpans = mode.flattenSpans;
     if (flattenSpans == null) flattenSpans = cm.options.flattenSpans;
     var curStart = 0, curStyle = null;
-    var stream = new StringStream(text, cm.options.tabSize), style;
+    var stream = new StringStream(text, cm.options.tabSize, cm.options.tabStops), style;
     var inner = cm.options.addModeClass && [null];
     if (text == "") extractLineClasses(callBlankLine(mode, state), lineClasses);
     while (!stream.eol()) {
@@ -6930,7 +6931,7 @@
   // aren't currently visible.
   function processLine(cm, text, state, startAt) {
     var mode = cm.doc.mode;
-    var stream = new StringStream(text, cm.options.tabSize);
+    var stream = new StringStream(text, cm.options.tabSize, cm.options.tabStops);
     stream.start = stream.pos = startAt || 0;
     if (text == "") callBlankLine(mode, state);
     while (!stream.eol()) {
@@ -7049,7 +7050,7 @@
         if (!m) break;
         pos += skipped + 1;
         if (m[0] == "\t") {
-          var tabSize = builder.cm.options.tabSize, tabWidth = tabSize - builder.col % tabSize;
+          var tabSize = builder.cm.options.tabSize, tabStops = builder.cm.options.tabStops, tabWidth = tabStopAt(builder.col, tabSize, tabStops) - builder.col;
           var txt = content.appendChild(elt("span", spaceStr(tabWidth), "cm-tab"));
           txt.setAttribute("role", "presentation");
           txt.setAttribute("cm-text", "\t");

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -8327,7 +8327,7 @@
         }
       }
       var stop = tabStops[tabStops.length - 1]
-      return stop + (tabSize - ((column - stop) % tabSize))
+      return column + (tabSize - ((column - stop) % tabSize))
     } else {
       return column + (tabSize - (column % tabSize))
     }

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -8321,13 +8321,13 @@
 
   function tabStopAt(column, tabSize, tabStops) {
     if (tabStops.length > 0) {
-      var stop = tabStops.find(function (d) { return d > column; });
-      if (stop) {
-        return stop
-      } else {
-        stop = tabStops[tabStops.length - 1]
-        return stop + (tabSize - ((column - stop) % tabSize))
+      for (var i = 0; i < tabStops.length; ++i) {
+        if (tabStops[i] > column) {
+          return tabStops[i]
+        }
       }
+      var stop = tabStops[tabStops.length - 1]
+      return stop + (tabSize - ((column - stop) % tabSize))
     } else {
       return column + (tabSize - (column % tabSize))
     }

--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2492,7 +2492,7 @@
       if (search <= doc.first) return doc.first;
       var line = getLine(doc, search - 1);
       if (line.stateAfter && (!precise || search <= doc.frontier)) return search;
-      var indented = countColumn(line.text, null, cm.options.tabSize);
+      var indented = countColumn(line.text, null, cm.options.tabSize, cm.options.tabStops);
       if (minline == null || minindent > indented) {
         minline = search - 1;
         minindent = indented;
@@ -3575,7 +3575,7 @@
     catch (e) { return null; }
     var coords = coordsChar(cm, x, y), line;
     if (forRect && coords.xRel == 1 && (line = getLine(cm.doc, coords.line).text).length == coords.ch) {
-      var colDiff = countColumn(line, line.length, cm.options.tabSize) - line.length;
+      var colDiff = countColumn(line, line.length, cm.options.tabSize, cm.options.tabStop) - line.length;
       coords = Pos(coords.line, Math.max(0, Math.round((x - paddingH(cm.display).left) / charWidth(cm.display)) - colDiff));
     }
     return coords;
@@ -3743,17 +3743,17 @@
       lastPos = pos;
 
       if (type == "rect") {
-        var ranges = [], tabSize = cm.options.tabSize;
-        var startCol = countColumn(getLine(doc, start.line).text, start.ch, tabSize);
-        var posCol = countColumn(getLine(doc, pos.line).text, pos.ch, tabSize);
+        var ranges = [], tabSize = cm.options.tabSize, tabStops = cm.options.tabStops;
+        var startCol = countColumn(getLine(doc, start.line).text, start.ch, tabSize, tabStops);
+        var posCol = countColumn(getLine(doc, pos.line).text, pos.ch, tabSize, tabStops);
         var left = Math.min(startCol, posCol), right = Math.max(startCol, posCol);
         for (var line = Math.min(start.line, pos.line), end = Math.min(cm.lastLine(), Math.max(start.line, pos.line));
              line <= end; line++) {
-          var text = getLine(doc, line).text, leftPos = findColumn(text, left, tabSize);
+          var text = getLine(doc, line).text, leftPos = findColumn(text, left, tabSize, tabStops);
           if (left == right)
             ranges.push(new Range(Pos(line, leftPos), Pos(line, leftPos)));
           else if (text.length > leftPos)
-            ranges.push(new Range(Pos(line, leftPos), Pos(line, findColumn(text, right, tabSize))));
+            ranges.push(new Range(Pos(line, leftPos), Pos(line, findColumn(text, right, tabSize, tabStops))));
         }
         if (!ranges.length) ranges.push(new Range(start, start));
         setSelection(doc, normalizeSelection(startSel.ranges.slice(0, ourIndex).concat(ranges), ourIndex),
@@ -4744,8 +4744,8 @@
       else state = getStateBefore(cm, n);
     }
 
-    var tabSize = cm.options.tabSize;
-    var line = getLine(doc, n), curSpace = countColumn(line.text, null, tabSize);
+    var tabSize = cm.options.tabSize, tabStops = cm.options.tabStops;
+    var line = getLine(doc, n), curSpace = countColumn(line.text, null, tabSize, tabStops);
     if (line.stateAfter) line.stateAfter = null;
     var curSpaceString = line.text.match(/^\s*/)[0], indentation;
     if (!aggressive && !/\S/.test(line.text)) {
@@ -5395,6 +5395,11 @@
     clearCaches(cm);
     regChange(cm);
   }, true);
+  option("tabStops", [], function(cm) {
+    resetModeState(cm);
+    clearCaches(cm);
+    regChange(cm);
+  }, true);
   option("lineSeparator", null, function(cm, val) {
     cm.doc.lineSep = val;
     if (!val) return;
@@ -5736,11 +5741,11 @@
     indentLess: function(cm) {cm.indentSelection("subtract");},
     insertTab: function(cm) {cm.replaceSelection("\t");},
     insertSoftTab: function(cm) {
-      var spaces = [], ranges = cm.listSelections(), tabSize = cm.options.tabSize;
+      var spaces = [], ranges = cm.listSelections(), tabSize = cm.options.tabSize, tabStops = cm.options.tabStops;
       for (var i = 0; i < ranges.length; i++) {
         var pos = ranges[i].from();
-        var col = countColumn(cm.getLine(pos.line), pos.ch, tabSize);
-        spaces.push(spaceStr(tabSize - col % tabSize));
+        var col = countColumn(cm.getLine(pos.line), pos.ch, tabSize, tabStops);
+        spaces.push(tabStopAt(col, tabSize, tabStops));
       }
       cm.replaceSelections(spaces);
     },
@@ -8302,9 +8307,23 @@
     this.id = setTimeout(f, ms);
   };
 
+  function tabStopAt(column, tabSize, tabStops) {
+    if (tabStops) {
+      var stop = tabStops.find(function (d) { return d > column; });
+      if (stop) {
+        return stop
+      } else {
+        stop = tabStops[tabStops.length - 1]
+        return stop + (tabSize - ((column - stop) % tabSize))
+      }
+    } else {
+      return column + (tabSize - (column % tabSize))
+    }
+  }
+
   // Counts the column offset in a string, taking tabs into account.
   // Used mostly to find indentation.
-  var countColumn = CodeMirror.countColumn = function(string, end, tabSize, startIndex, startValue) {
+  var countColumn = CodeMirror.countColumn = function(string, end, tabSize, tabStops, startIndex, startValue) {
     if (end == null) {
       end = string.search(/[^\s\u00a0]/);
       if (end == -1) end = string.length;
@@ -8314,14 +8333,14 @@
       if (nextTab < 0 || nextTab >= end)
         return n + (end - i);
       n += nextTab - i;
-      n += tabSize - (n % tabSize);
+      n = tabStopAt(n, tabSize, tabStops)
       i = nextTab + 1;
     }
   };
 
   // The inverse of countColumn -- find the offset that corresponds to
   // a particular column.
-  var findColumn = CodeMirror.findColumn = function(string, goal, tabSize) {
+  var findColumn = CodeMirror.findColumn = function(string, goal, tabSize, tabStops) {
     for (var pos = 0, col = 0;;) {
       var nextTab = string.indexOf("\t", pos);
       if (nextTab == -1) nextTab = string.length;
@@ -8329,7 +8348,7 @@
       if (nextTab == string.length || col + skipped >= goal)
         return pos + Math.min(skipped, goal - col);
       col += nextTab - pos;
-      col += tabSize - (col % tabSize);
+      col = tabStopAt(col, tabSize, tabStops);
       pos = nextTab + 1;
       if (col >= goal) return pos;
     }

--- a/test/test.js
+++ b/test/test.js
@@ -158,6 +158,17 @@ testCM("indent", function(cm) {
   eq(cm.getLine(1), "\t\t  blah();");
 }, {value: "if (x) {\nblah();\n}", indentUnit: 3, indentWithTabs: true, tabSize: 8});
 
+testCM("indentWithTabStops", function(cm) {
+  cm.indentLine(1);
+  eq(cm.getLine(1), "   blah();");
+  cm.setOption("indentUnit", 4);
+  cm.indentLine(1);
+  eq(cm.getLine(1), "\tblah();");
+  cm.setOption("indentUnit", 8);
+  cm.indentLine(1);
+  eq(cm.getLine(1), "\t\t  blah();");
+}, {value: "if (x) {\nblah();\n}", indentUnit: 3, indentWithTabs: true, tabStops: [4,6], tabSize: 8});
+
 testCM("indentByNumber", function(cm) {
   cm.indentLine(0, 2);
   eq(cm.getLine(0), "  foo");


### PR DESCRIPTION
Added support for variable width tabs via a `tabStops` option.
`tabStops` defaults to `[]` which doesn't change the current behavior at all. When it is defined, tab characters will shift to the lowest tab stop that is greater than the current column. If the current column is greater than the largest `tabStop` we fall back to using the `tabSize`. At that point new tabs are offset _from the last tab stop_ rather than from the beginning of the line.

For example if we have `tabStops = [2]` and `tabSize = 4` then a sequence of tab characters will look like:
```
--|----|----|----|
```
Where - is one character width and | is a tab stop. This behavior can be changed easily enough if something else is preferred, but this seemed like the most logical to me.
