### PR TITLE
Re run mode and overlays on refresh

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -5336,6 +5336,7 @@
 
     refresh: methodOp(function() {
       var oldHeight = this.display.cachedTextHeight;
+      this.state.modeGen++;
       regChange(this);
       this.curOp.forceUpdate = true;
       clearCaches(this);


### PR DESCRIPTION
this fix extends refresh to also re run all modes and overlays on all lines affected with refresh

This allows updating all (visible) text with any changes made to the modes or overlays which is the expected behavior for a refresh. 

Case in point, having a spellcheck overlay with an 'ignore all' option which adds a word to a list of words ignored by the spellchecker. Calling refresh will update the display so that the word will not be marked as a typo in any line.