### PR TITLE
Color fix for solarized light vim mode

### DIFF
--- a/theme/solarized.css
+++ b/theme/solarized.css
@@ -155,8 +155,8 @@ http://ethanschoonover.com/solarized/img/solarized-palette.png
 .cm-s-solarized .CodeMirror-cursor { border-left: 1px solid #819090; }
 
 /* Fat cursor */
-.cm-s-solarized.cm-s-light.cm-fat-cursor .CodeMirror-cursor { background: #fdf6e3; }
-.cm-s-solarized.cm-s-light .cm-animate-fat-cursor { background-color: #fdf6e3; }
+.cm-s-solarized.cm-s-light.cm-fat-cursor .CodeMirror-cursor { background: #77ee77; }
+.cm-s-solarized.cm-s-light .cm-animate-fat-cursor { background-color: #77ee77; }
 .cm-s-solarized.cm-s-dark.cm-fat-cursor .CodeMirror-cursor { background: #586e75; }
 .cm-s-solarized.cm-s-dark .cm-animate-fat-cursor { background-color: #586e75; }
 


### PR DESCRIPTION
There is a colour issue with the solarized light theme. In vim mode, the cursor is not visible because it has the same colour as the background. This screenshot has the upper brackets selected, and you can see only the brackets get highlighted, but not the cursor.

<img width="628" alt="screen shot 2016-08-08 at 11 41 04" src="https://cloud.githubusercontent.com/assets/10077885/17482458/c120510e-5d79-11e6-96db-4e8aa60b4b3f.png">

This is the fixed one with colour taken from the previous version in code mirror.

<img width="631" alt="screen shot 2016-08-08 at 15 01 45" src="https://cloud.githubusercontent.com/assets/10077885/17482495/ea3b67ae-5d79-11e6-8120-8937c98fdff2.png">

After a small research, this was most probably introduced in #4036 . The fat cursor colour is also from that issue.