### PR TITLE
Fix bug where immediate search would throw error if no previous query

### DIFF
--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -146,7 +146,7 @@
           searchNext(query, event);
         }
       });
-      if (immediate) {
+      if (immediate && q) {
         startSearch(cm, state, q);
         findNext(cm, rev);
       }


### PR DESCRIPTION
Searching with `findPersistentNext` or `findPersistentPrev` will immediately run a search with the previous query. However it will throw and error if no previous query exists.

This PR fixes this bug by preventing immediate execution if no previous query is set.