### PR TITLE
Look up key command in extra keys when in persistent search

### DIFF
--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -136,7 +136,9 @@
         })
       };
       persistentDialog(cm, queryDialog, q, searchNext, function(event, query) {
-        var cmd = CodeMirror.keyMap[cm.getOption("keyMap")][CodeMirror.keyName(event)];
+        var keyName = CodeMirror.keyName(event)
+        var cmd = CodeMirror.keyMap[cm.getOption("keyMap")][keyName]
+        if (!cmd) cmd = cm.getOption('extraKeys')[keyName]
         if (cmd == "findNext" || cmd == "findPrev") {
           CodeMirror.e_stop(event);
           startSearch(cm, getSearchState(cm), query);

--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -139,7 +139,8 @@
         var keyName = CodeMirror.keyName(event)
         var cmd = CodeMirror.keyMap[cm.getOption("keyMap")][keyName]
         if (!cmd) cmd = cm.getOption('extraKeys')[keyName]
-        if (cmd == "findNext" || cmd == "findPrev") {
+        if (cmd == "findNext" || cmd == "findPrev" ||
+          cmd == "findPersistentNext" || cmd == "findPersistentPrev") {
           CodeMirror.e_stop(event);
           startSearch(cm, getSearchState(cm), query);
           cm.execCommand(cmd);


### PR DESCRIPTION
When the persistent search is open, the `find`, `findNext` and `findPrev` commands can be executed to jump between matches. If a keymap has been changed to add additional bindings for these commands or if bindings for `findPersistentNext` or `findPersistentPrev` have been added, then the search will not behave in the same way.

This PR adds a look up in `extraKeys` for the key bind, and adds `findPersistentNext`/`findPersistentPrev` as valid commands to be executed.