### PR TITLE
Add f to delimiter stripping for Python mode

### DIFF
--- a/mode/python/python.js
+++ b/mode/python/python.js
@@ -185,7 +185,7 @@
     }
 
     function tokenStringFactory(delimiter) {
-      while ("rub".indexOf(delimiter.charAt(0).toLowerCase()) >= 0)
+      while ("rubf".indexOf(delimiter.charAt(0).toLowerCase()) >= 0)
         delimiter = delimiter.substr(1);
 
       var singleline = delimiter.length == 1;


### PR DESCRIPTION
So f-strings get terminated correctly.

This illustrates the problem I'm trying to fix.

![screenshot from 2016-08-19 11-27-02](https://cloud.githubusercontent.com/assets/327925/17807034/1854322c-6600-11e6-84cd-b8ab46ca3a9c.png)
