### PR TITLE
Introduce getBidiPartAtWithOther

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2873,7 +2873,9 @@
     }
     var order = getOrder(lineObj), ch = pos.ch;
     if (!order) return get(ch);
-    var partPos = getBidiPartAt(order, ch);
+    var res = getBidiPartAtWithOther(order, ch);
+    var partPos = res[0];
+    var bidiOther = res[1];
     var val = getBidi(ch, partPos);
     if (bidiOther != null) val.other = getBidi(ch, bidiOther);
     return val;
@@ -8721,25 +8723,28 @@
     if (b == linedir) return false;
     return a < b;
   }
-  var bidiOther;
-  function getBidiPartAt(order, pos) {
-    bidiOther = null;
+  function getBidiPartAtWithOther(order, pos) {
+    var bidiOther = null;
     for (var i = 0, found; i < order.length; ++i) {
       var cur = order[i];
-      if (cur.from < pos && cur.to > pos) return i;
+      if (cur.from < pos && cur.to > pos) return [i, bidiOther];
       if ((cur.from == pos || cur.to == pos)) {
         if (found == null) {
           found = i;
         } else if (compareBidiLevel(order, cur.level, order[found].level)) {
           if (cur.from != cur.to) bidiOther = found;
-          return i;
+          return [i, bidiOther];
         } else {
           if (cur.from != cur.to) bidiOther = i;
-          return found;
+          return [found, bidiOther];
         }
       }
     }
-    return found;
+    return [found, bidiOther];
+  }
+
+  function getBidiPartAt(order, pos) {
+    return getBidiPartAtWithOther(order, pos)[0];
   }
 
   function moveInLine(line, pos, dir, byUnit) {


### PR DESCRIPTION
… instead of leaking internal information into a global and using it 6000 lines earlier. Helps me with introducing ES6 modules.