### PR TITLE
Fix 'vue' mode after 'jade' was renamed to 'pug'

### DIFF
--- a/mode/vue/index.html
+++ b/mode/vue/index.html
@@ -14,7 +14,7 @@
 <script src="../css/css.js"></script>
 <script src="../coffeescript/coffeescript.js"></script>
 <script src="../sass/sass.js"></script>
-<script src="../jade/jade.js"></script>
+<script src="../pug/pug.js"></script>
 
 <script src="../handlebars/handlebars.js"></script>
 <script src="../htmlmixed/htmlmixed.js"></script>

--- a/mode/vue/vue.js
+++ b/mode/vue/vue.js
@@ -12,7 +12,7 @@
         require("../css/css"),
         require("../sass/sass"),
         require("../stylus/stylus"),
-        require("../jade/jade"),
+        require("../pug/pug"),
         require("../handlebars/handlebars"));
   } else if (typeof define === "function" && define.amd) { // AMD
     define(["../../lib/codemirror",
@@ -23,7 +23,7 @@
             "../css/css",
             "../sass/sass",
             "../stylus/stylus",
-            "../jade/jade",
+            "../pug/pug",
             "../handlebars/handlebars"], mod);
   } else { // Plain browser env
     mod(CodeMirror);
@@ -42,9 +42,9 @@
     ],
     template: [
       ["lang", /^vue-template$/i, "vue"],
-      ["lang", /^jade$/i, "jade"],
+      ["lang", /^pug$/i, "pug"],
       ["lang", /^handlebars$/i, "handlebars"],
-      ["type", /^(text\/)?(x-)?jade$/i, "jade"],
+      ["type", /^(text\/)?(x-)?pug/i, "pug"],
       ["type", /^text\/x-handlebars-template$/i, "handlebars"],
       [null, null, "vue-template"]
     ]
@@ -63,7 +63,7 @@
 
   CodeMirror.defineMode("vue", function (config) {
     return CodeMirror.getMode(config, {name: "htmlmixed", tags: tagLanguages});
-  }, "htmlmixed", "xml", "javascript", "coffeescript", "css", "sass", "stylus", "jade", "handlebars");
+  }, "htmlmixed", "xml", "javascript", "coffeescript", "css", "sass", "stylus", "pug", "handlebars");
 
   CodeMirror.defineMIME("script/x-vue", "vue");
 });


### PR DESCRIPTION
I'm getting the following error from Webpack when trying to update to 5.18:

```
ModuleNotFoundError: Module not found: Error: Cannot resolve 'file' or 'directory' ../jade/jade in /Users/leonya/code/upsource/frontend/bootstrap/node_modules/codemirror/mode/vue
    at /Users/leonya/code/upsource/frontend/bootstrap/node_modules/webpack/lib/Compilation.js:229:38
    at onDoneResolving (/Users/leonya/code/upsource/frontend/bootstrap/node_modules/webpack/lib/NormalModuleFactory.js:29:20)
    at /Users/leonya/code/upsource/frontend/bootstrap/node_modules/webpack/lib/NormalModuleFactory.js:85:20
    at /Users/leonya/code/upsource/frontend/bootstrap/node_modules/webpack/node_modules/async/lib/async.js:726:13
    at /Users/leonya/code/upsource/frontend/bootstrap/node_modules/webpack/node_modules/async/lib/async.js:52:16
    at done (/Users/leonya/code/upsource/frontend/bootstrap/node_modules/webpack/node_modules/async/lib/async.js:241:17)
    at /Users/leonya/code/upsource/frontend/bootstrap/node_modules/webpack/node_modules/async/lib/async.js:44:16
    at /Users/leonya/code/upsource/frontend/bootstrap/node_modules/webpack/node_modules/async/lib/async.js:723:17
    at /Users/leonya/code/upsource/frontend/bootstrap/node_modules/webpack/node_modules/async/lib/async.js:167:37
    at /Users/leonya/code/upsource/frontend/bootstrap/node_modules/enhanced-resolve/lib/UnsafeCachePlugin.js:24:19
    at onResolved (/Users/leonya/code/upsource/frontend/bootstrap/node_modules/enhanced-resolve/lib/Resolver.js:38:18)
    at /Users/leonya/code/upsource/frontend/bootstrap/node_modules/enhanced-resolve/lib/Resolver.js:127:10
    at /Users/leonya/code/upsource/frontend/bootstrap/node_modules/enhanced-resolve/lib/Resolver.js:191:15
    at applyPluginsParallelBailResult.createInnerCallback.log (/Users/leonya/code/upsource/frontend/bootstrap/node_modules/enhanced-resolve/lib/Resolver.js:110:4)
    at loggingCallbackWrapper (/Users/leonya/code/upsource/frontend/bootstrap/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
    at /Users/leonya/code/upsource/frontend/bootstrap/node_modules/tapable/lib/Tapable.js:134:6
    at Tapable.<anonymous> (/Users/leonya/code/upsource/frontend/bootstrap/node_modules/enhanced-resolve/lib/DirectoryDescriptionFilePlugin.js:24:12)
    at Storage.finished (/Users/leonya/code/upsource/frontend/bootstrap/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:38:16)
    at ReadFileContext.callback (/Users/leonya/code/upsource/frontend/bootstrap/node_modules/graceful-fs/graceful-fs.js:78:16)
    at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:359:13)
resolve file
  /Users/leonya/code/upsource/frontend/bootstrap/node_modules/codemirror/mode/jade/jade doesn't exist
  /Users/leonya/code/upsource/frontend/bootstrap/node_modules/codemirror/mode/jade/jade.webpack.js doesn't exist
  /Users/leonya/code/upsource/frontend/bootstrap/node_modules/codemirror/mode/jade/jade.web.js doesn't exist
  /Users/leonya/code/upsource/frontend/bootstrap/node_modules/codemirror/mode/jade/jade.js doesn't exist
  /Users/leonya/code/upsource/frontend/bootstrap/node_modules/codemirror/mode/jade/jade.json doesn't exist
resolve directory
  /Users/leonya/code/upsource/frontend/bootstrap/node_modules/codemirror/mode/jade/jade doesn't exist (directory default file)
  /Users/leonya/code/upsource/frontend/bootstrap/node_modules/codemirror/mode/jade/jade/package.json doesn't exist (directory description file)
```