### PR TITLE
Fix space regression

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -30,6 +30,7 @@
   var ie = ie_upto10 || ie_11up;
   var ie_version = ie && (ie_upto10 ? document.documentMode || 6 : ie_11up[1]);
   var webkit = /WebKit\//.test(userAgent);
+  var webkit_version = webkit ? parseInt(userAgent.match(/WebKit\/([0-9]+)\./)[1], 10) : null;
   var qtwebkit = webkit && /Qt\/\d+\.\d+/.test(userAgent);
   var chrome = /Chrome\//.test(userAgent);
   var presto = /Opera\//.test(userAgent);
@@ -2721,6 +2722,8 @@
         while (place.coverStart + end < place.coverEnd && isExtendingChar(prepared.line.text.charAt(place.coverStart + end))) ++end;
         if (ie && ie_version < 9 && start == 0 && end == place.coverEnd - place.coverStart)
           rect = node.parentNode.getBoundingClientRect();
+        else if (webkit && webkit_version < 600)
+          rect = range(node, start, end).getBoundingClientRect() || nullRect;
         else
           rect = getUsefulRect(range(node, start, end).getClientRects(), bias)
         if (rect.left || rect.right || start == 0) break;


### PR DESCRIPTION
In old versions of WebKit, with CodeMirror's wrap mode enabled, an odd behavior happens. That is, the first whitespace keypress in a sequence is not displayed until another space is added.

This is the commit that introduced the issue: https://github.com/codemirror/CodeMirror/commit/e60f4b7dd88b71e227f79200932c028ca047d78e

I have added a special case to the code to fallback to the old method in case an old version of WebKit is used.
