### PR TITLE
Fix for modifiers on class members

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -617,6 +617,12 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   }
   function classBody(type, value) {
     if (type == "variable" || cx.style == "keyword") {
+      if (isTS) {
+        // Technically any of these modifiers could be standalone property names, but this is rare.
+        if (value == "public" || value == "private" || value == "protected" || value == "abstract") {
+          return cont(classBody);
+        }
+      }
       if (value == "static") {
         cx.marked = "keyword";
         return cont(classBody);

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -173,10 +173,27 @@
   }
 
   TS("extend_type",
-     "[keyword class] [def Foo] [keyword extends] [variable-3 Some][operator <][variable-3 Type][operator >] {}")
+     "[keyword class] [def Foo] [keyword extends] [variable-3 Some][operator <][variable-3 Type][operator >] {}");
 
   TS("arrow_type",
-     "[keyword let] [def x]: ([variable arg]: [variable-3 Type]) [operator =>] [variable-3 ReturnType]")
+     "[keyword let] [def x]: ([variable arg]: [variable-3 Type]) [operator =>] [variable-3 ReturnType]");
+  
+  TS("class_element_modifier_public_static",
+     "[keyword class] [def C] {",
+     "  [keyword public] [keyword static] [property method](): [variable-3 number] {",
+     "    [keyword return] [number 100];",
+     "  }",
+     "}");
+
+  TS("class_element_modifier_private",
+     "[keyword class] [def C] {",
+     "  [keyword private] [property count]: [variable-3 number];",
+     "}");
+
+  TS("class_element_modifier_protected_abstract",
+     "[keyword class] [def C] {",
+     "  [keyword protected] [keyword abstract] [property mustImplement]([def config]: [variable-3 string]): [variable-3 void];",
+     "}");
 
   var jsonld_mode = CodeMirror.getMode(
     {indentUnit: 2},


### PR DESCRIPTION
Fixes #4188.

Basically given that `static` doesn't use any lookahead to determine whether it should be treated as a modifier, I took the same approach here. Let me know if there's anything you'd prefer I fix up.