### PR TITLE
Update highlight.js

### DIFF
--- a/src/line/highlight.js
+++ b/src/line/highlight.js
@@ -37,7 +37,7 @@ export function highlightLine(cm, line, state, forceToEnd) {
       } else {
         for (; start < i; start += 2) {
           let cur = st[start+1]
-          st[start+1] = (cur ? cur + " " : "") + "cm-overlay " + style
+          st[start+1] = (cur ? cur + " " : "") + "overlay " + style
         }
       }
     }, lineClasses)


### PR DESCRIPTION
Ensure that when an overlay is added that the class `cm-overlay` is used to denote a `span` instead of `cm-cm-overlay` (with the `cm-` prefix repeated twice).

* E.g. before fix:
```
<span class="cm-cm-overlay cm-spell-error">zpelling</span>
```

* And after fix:
```
<span class="cm-overlay cm-spell-error">zpelling</span>
```