### PR TITLE
Document transposeChars, fix some inconsistencies

### DIFF
--- a/test/emacs_test.js
+++ b/test/emacs_test.js
@@ -111,7 +111,7 @@
   sim("transposeChar", "abcd\ne",
       "Ctrl-F", "Ctrl-T", "Ctrl-T", txt("bcad\ne"), at(0, 3),
       "Ctrl-F", "Ctrl-T", "Ctrl-T", "Ctrl-T", txt("bcda\ne"), at(0, 4),
-      "Ctrl-F", "Ctrl-T", txt("bcde\na"), at(1, 0));
+      "Ctrl-F", "Ctrl-T", txt("bcde\na"), at(1, 1));
 
   sim("manipWordCase", "foo BAR bAZ",
       "Alt-C", "Alt-L", "Alt-U", txt("Foo bar BAZ"),


### PR DESCRIPTION
Since it used `head`, the direction a selection was made would change which
chars get transposed. Also, a cursor at line start was not moved on successful
swapping.