### PR TITLE
[dracula theme] consistent selection styling regardless of focus

### DIFF
--- a/theme/dracula.css
+++ b/theme/dracula.css
@@ -16,7 +16,7 @@
 .cm-s-dracula .CodeMirror-gutters { color: #282a36; }
 .cm-s-dracula .CodeMirror-cursor { border-left: solid thin #f8f8f0; }
 .cm-s-dracula .CodeMirror-linenumber { color: #6D8A88; }
-.cm-s-dracula.CodeMirror-focused div.CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
+.cm-s-dracula .CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
 .cm-s-dracula .CodeMirror-line::selection, .cm-s-dracula .CodeMirror-line > span::selection, .cm-s-dracula .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
 .cm-s-dracula .CodeMirror-line::-moz-selection, .cm-s-dracula .CodeMirror-line > span::-moz-selection, .cm-s-dracula .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
 .cm-s-dracula span.cm-comment { color: #6272a4; }


### PR DESCRIPTION
This prevents selections from inheriting the default `#d9d9d9` background when editor is defocused.

reproducible @ https://codemirror.net/demo/theme.html#dracula