### PR TITLE
[javascript mode] add function & function-2 styles

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -498,9 +498,14 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
       cx.marked = "property";
       return cont(objprop);
     } else if (type == "variable" || cx.style == "keyword") {
-      cx.marked = "property";
-      if (value == "get" || value == "set") return cont(getterSetter);
-      return cont(afterprop);
+      if (value == "get" || value == "set") {
+        cx.marked = "property";
+        return cont(getterSetter);
+      }
+      else {
+        cx.marked = isTokenFunc(cx.stream) ? "function-2" : "property";
+        return cont(afterprop);
+      }
     } else if (type == "number" || type == "string") {
       cx.marked = jsonldMode ? "property" : (cx.style + " property");
       return cont(afterprop);
@@ -654,9 +659,19 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
            (isTS && (value == "public" || value == "private" || value == "protected" || value == "readonly" || value == "abstract"))) &&
           cx.stream.match(/^\s+[\w$\xa1-\uffff]/, false)) {
         cx.marked = "keyword";
+
+        if (value == "get" || value == "set")
+          cx.isGetterSetter = true;
+
         return cont(classBody);
       }
-      cx.marked = "property";
+      if (cx.isGetterSetter) {
+        cx.marked = "property";
+        cx.isGetterSetter = false;
+      }
+      else
+        cx.marked = isTokenFunc(cx.stream) ? "function-2" : "property";
+
       return cont(isTS ? classfield : functiondef, classBody);
     }
     if (value == "*") {


### PR DESCRIPTION
This implementation accounts for both, variables & properties:

```js
foo()
foo.call()
foo.apply()
foo.bar()
foo.bar.call()
```

etc..

This is not quite ready for merging, since it would require that all themes add

`.cm-function`
`.cm-function-2`

which *replace* (when needed)

`cm-variable`
`cm-variable-2`

While languages *are* different [1], functions exist in a great number of them (with similar calling conventions), and it seems appropriate that each CM mode is not required to overload an unpredictable `cm-variable-*` or other unused class [2] to tag them.

If this change is too breaking perhaps for modes that rely on the old parser classifications, what would be a good way to add *additional* `cm-function` (maybe even more specific `cm-method`) classes to these tokens? 

[1] https://github.com/codemirror/CodeMirror/issues/4284#issuecomment-251505455
[2] https://github.com/codemirror/CodeMirror/blob/master/lib/codemirror.css#L113-L133