### PR TITLE
R fixes

### DIFF
--- a/mode/r/index.html
+++ b/mode/r/index.html
@@ -68,6 +68,13 @@ print(df$`#letter`)
 m1 <- matrix(1:6, 2, 3)
 m2 <- m1 %*% t(m1)
 cat("Matrix product: "); print(m2)
+
+# Assignments:
+a <- 1
+b <<- 2
+c = 3
+4 -> d
+5 ->> e
 </textarea></form>
     <script>
       var editor = CodeMirror.fromTextArea(document.getElementById("code"), {});

--- a/mode/r/index.html
+++ b/mode/r/index.html
@@ -31,47 +31,43 @@
 <article>
 <h2>R mode</h2>
 <form><textarea id="code" name="code">
-# Code from http://www.mayin.org/ajayshah/KB/R/
+X <- list(height = 5.4, weight = 54)
+cat("Printing objects: "); print(X)
+print("Accessing individual elements:")
+cat(sprintf("Your height is %s and your weight is %s\n", X$height, X$weight))
 
-# FIRST LEARN ABOUT LISTS --
-X = list(height=5.4, weight=54)
-print("Use default printing --")
-print(X)
-print("Accessing individual elements --")
-cat("Your height is ", X$height, " and your weight is ", X$weight, "\n")
-
-# FUNCTIONS --
+# Functions:
 square <- function(x) {
-  return(x*x)
+  return(x * x)
 }
-cat("The square of 3 is ", square(3), "\n")
-
-                 # default value of the arg is set to 5.
-cube <- function(x=5) {
-  return(x*x*x);
-}
-cat("Calling cube with 2 : ", cube(2), "\n")    # will give 2^3
-cat("Calling cube        : ", cube(), "\n")     # will default to 5^3.
-
-# LEARN ABOUT FUNCTIONS THAT RETURN MULTIPLE OBJECTS --
-powers <- function(x) {
-  parcel = list(x2=x*x, x3=x*x*x, x4=x*x*x*x);
-  return(parcel);
-}
-
-X = powers(3);
-print("Showing powers of 3 --"); print(X);
-
-# WRITING THIS COMPACTLY (4 lines instead of 7)
-
-powerful <- function(x) {
-  return(list(x2=x*x, x3=x*x*x, x4=x*x*x*x));
-}
-print("Showing powers of 3 --"); print(powerful(3));
+cat(sprintf("The square of 3 is %s\n", square(3)))
 
 # In R, the last expression in a function is, by default, what is
-# returned. So you could equally just say:
-powerful <- function(x) {list(x2=x*x, x3=x*x*x, x4=x*x*x*x)}
+# returned. The idiomatic way to write the function is:
+square <- function(x) {
+  x * x
+}
+# or, for functions with short content:
+square <- function(x) x * x
+
+# Function arguments with default values:
+cube <- function(x = 5) x * x * x
+cat(sprintf("Calling cube with 2 : %s\n", cube(2))  # will give 2^3
+cat(sprintf("Calling cube        : %s\n", cube())   # will default to 5^3.
+
+powers <- function(x) list(x2 = x*x, x3 = x*x*x, x4 = x*x*x*x)
+
+cat("Powers of 3: "); print(powers(3))
+
+# Data frames
+df <- data.frame(letters = letters[1:5], '#letter' = 1:5)
+print(df$letters)
+print(df$`#letter`)
+
+# Operators:
+m1 <- matrix(1:6, 2, 3)
+m2 <- m1 %*% t(m1)
+cat("Matrix product: "); print(m2)
 </textarea></form>
     <script>
       var editor = CodeMirror.fromTextArea(document.getElementById("code"), {});

--- a/mode/r/r.js
+++ b/mode/r/r.js
@@ -66,7 +66,11 @@ CodeMirror.defineMode("r", function(config) {
     } else if (ch == "%") {
       if (stream.skipTo("%")) stream.next();
       return "operator variable-2";
-    } else if (ch == "<" && stream.eat("-")) {
+    } else if (
+        (ch == "<" && stream.eat("-")) ||
+        (ch == "<" && stream.match("<-")) ||
+        (ch == "-" && stream.match(/>>?/))
+      ) {
       return "operator arrow";
     } else if (ch == "=" && state.ctx.argList) {
       return "arg-is";

--- a/mode/r/r.js
+++ b/mode/r/r.js
@@ -44,6 +44,9 @@ CodeMirror.defineMode("r", function(config) {
     } else if (ch == "'" || ch == '"') {
       state.tokenize = tokenString(ch);
       return "string";
+    } else if (ch == "`") {
+      stream.match(/[^`]+`/);
+      return "variable-3";
     } else if (ch == "." && stream.match(/.[.\d]+/)) {
       return "keyword";
     } else if (/[\w\.]/.test(ch) && ch != "_") {

--- a/mode/r/r.js
+++ b/mode/r/r.js
@@ -62,13 +62,13 @@ CodeMirror.defineMode("r", function(config) {
       return "variable";
     } else if (ch == "%") {
       if (stream.skipTo("%")) stream.next();
-      return "variable-2";
+      return "operator variable-2";
     } else if (ch == "<" && stream.eat("-")) {
-      return "arrow";
+      return "operator arrow";
     } else if (ch == "=" && state.ctx.argList) {
       return "arg-is";
     } else if (opChars.test(ch)) {
-      if (ch == "$") return "dollar";
+      if (ch == "$") return "operator dollar";
       stream.eatWhile(opChars);
       return "operator";
     } else if (/[\(\){}\[\];]/.test(ch)) {


### PR DESCRIPTION
This PR fixes a few R issues:

* The code example was very unidiomatic (semicolons, unnecessary `return`s). I improved that.
* `%...%` operators, `$` operators, and `<-` operators didn’t have the “operator” token type. i added it.
* R knows more arrows than `<-`, namely `<<-`, `->` , and `->>`
* Fixes #4297: Now `` df$`#foo` `` is properly highlighted