### PR TITLE
[javascript mode] Fix tokenization for class expressions

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -395,6 +395,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     var maybeop = noComma ? maybeoperatorNoComma : maybeoperatorComma;
     if (atomicTypes.hasOwnProperty(type)) return cont(maybeop);
     if (type == "function") return cont(functiondef, maybeop);
+    if (type == "class") return cont(pushlex("form"), classExpression, poplex);
     if (type == "keyword c" || type == "async") return cont(noComma ? maybeexpressionNoComma : maybeexpression);
     if (type == "(") return cont(pushlex(")"), maybeexpression, expect(")"), poplex, maybeop);
     if (type == "operator" || type == "spread") return cont(noComma ? expressionNoComma : expression);
@@ -618,6 +619,11 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   function funarg(type) {
     if (type == "spread") return cont(funarg);
     return pass(pattern, maybetype, maybeAssign);
+  }
+  function classExpression(type, value) {
+    // Class expressions may have an optional name.
+    if (type == "variable") return className(type, value);
+    return classNameAfter(type, value);
   }
   function className(type, value) {
     if (type == "variable") {register(value); return cont(classNameAfter);}

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -38,6 +38,16 @@
      "  }",
      "}");
 
+  MT("anonymous_class_expression",
+     "[keyword const] [def Adder] [operator =] [keyword class] [keyword extends] [variable Arithmetic] {",
+     "  [property add]([def a], [def b]) {}",
+     "};");
+
+  MT("named_class_expression",
+     "[keyword const] [def Subber] [operator =] [keyword class] [def Subtract] {",
+     "  [property sub]([def a], [def b]) {}",
+     "};");
+
   MT("import",
      "[keyword function] [def foo]() {",
      "  [keyword import] [def $] [keyword from] [string 'jquery'];",


### PR DESCRIPTION
I noticed that syntax highlighting of method declarations in class expressions doesn't work. Class declarations work just fine though.

![class-expression-bug](https://cloud.githubusercontent.com/assets/703602/19277981/f07bf478-8fdb-11e6-87cb-856f26cc0066.png)

It's even more prevalent when using another theme, like Monokai:
![class-expression-bug-2](https://cloud.githubusercontent.com/assets/703602/19278116/73400976-8fdc-11e6-8bb4-0eb369531486.png)

This PR includes both tests and a fix.
