### PR TITLE
Fix select from beginning of line behavior in contenteditable mode

### DIFF
--- a/src/input/ContentEditableInput.js
+++ b/src/input/ContentEditableInput.js
@@ -157,7 +157,10 @@ ContentEditableInput.prototype = copyObj({
     if (rng) {
       if (!gecko && this.cm.state.focused) {
         sel.collapse(start.node, start.offset)
-        if (!rng.collapsed) sel.addRange(rng)
+        if (!rng.collapsed) {
+          sel.removeAllRanges()
+          sel.addRange(rng)
+        }
       } else {
         sel.removeAllRanges()
         sel.addRange(rng)


### PR DESCRIPTION
Here's a GIF demonstrating the issue, as seen in Safari with `inputStyle: "contenteditable"`: 
https://cl.ly/1f2W13231j0W (works fine in Chrome and Firefox.)

Steps:
1. Go to beginning of any line
2. Press <kbd>shift</kbd> and <kbd>down arrow key</kbd>
3. Expect to select full line, but nothing was highlighted ⚠️ 
4. Press deleted, see that lines were deleted even though they weren't highlighted

Simply calling `removeAllRanges()` prior to `addRange()` fixes  this issue.

Manually tested :ok_hand: in Chrome Version 53.0.2785.143, Firefox 48.0, Safari Version 9.1.