### PR TITLE
[lint addon] 'tooltipsEditor' option - disableable tooltips over text.

### DIFF
--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -226,7 +226,7 @@
       var state = cm.state.lint = new LintState(cm, parseOptions(cm, val), hasLintGutter);
       if (state.options.lintOnChange !== false)
         cm.on("change", onChange);
-      if (state.options.tooltips != false)
+      if (state.options.tooltips != false && state.options.tooltipsEditor != false)
         CodeMirror.on(cm.getWrapperElement(), "mouseover", state.onMouseOver);
 
       startLinting(cm);


### PR DESCRIPTION
Tooltips over text can now be disabled without disabling tooltips
shown when mouse cursor is hovered over the gutter.