### PR TITLE
Insert soft tab when `indentWithTabs` is false

### DIFF
--- a/src/edit/commands.js
+++ b/src/edit/commands.js
@@ -104,7 +104,13 @@ export let commands = {
   },
   defaultTab: cm => {
     if (cm.somethingSelected()) cm.indentSelection("add")
-    else cm.execCommand("insertTab")
+    else {
+      if (cm.getOption("indentWithTabs")) {
+        cm.execCommand("insertTab")
+      } else {
+        cm.execCommand("insertSoftTab")
+      }
+    }
   },
   // Swap the two chars left and right of each selection's head.
   // Move cursor behind the two swapped characters afterwards.


### PR DESCRIPTION
https://github.com/codemirror/CodeMirror/issues/1725

The default behavior is quite wield comparing modern editor.
I think inserting `Tab` character when using spaces as an indent is quite rare case.

![Tab vs Spaces](https://camo.githubusercontent.com/96d51190854058fe8f6953dd4f1a50047ef47bd9/687474703a2f2f6576616465666c6f772e636f6d2f77702d636f6e74656e742f75706c6f6164732f323031312f30332f54616273537061636573426f74682e706e67)