### PR TITLE
No transposing char on OS X

### DIFF
--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -294,7 +294,7 @@
     });
   };
 
-  map[ctrl + "T"] = "transposeChars";
+  if (!mac) map[ctrl + "T"] = "transposeChars";
 
   function sortLines(cm, caseSensitive) {
     if (cm.isReadOnly()) return CodeMirror.Pass


### PR DESCRIPTION
Sublime Editor on OS X doesn't support transpose by itself because the OS supports it by default.
Beside, It is provided `Ctrl + T` not `Cmd + T`.

> `Cmd + T` executes `Go to anywhere` on OS X
http://docs.sublimetext.info/en/latest/reference/keyboard_shortcuts_osx.html#navigation-goto-anywhere