### PR TITLE
Coordinate DOM updates across multiple CodeMirror instances.

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2000,6 +2000,22 @@ editor.setOption("extraKeys", {
       lot faster. The return value from this method will be the return
       value of your function.</dd>
 
+      <dt id="coordinatedOperation"><code><strong>cm.coordinatedOperation</strong>(func: () → any)  → () → boolean</code><dt>
+      <dd>This is a variant of <a href="#operation"><code>operation</code></a>
+      which allows for the coordinated update of the DOM accross multiple
+      CodeMirror instances. This can be a significant speed up when many
+      instances are involved. It is intended to used as follows:
+        <ol>
+          <li>Call <code>coordinatedOperation</code> on each CodeMirror
+            instance and collect the function it returns into a list.</li>
+          <li>Execute each function in the list one at a time.</li>
+          <li>Execute each function in the list again.</li>
+          <li>Repeatedly execute each function in the list until all of
+            them return <code>true</code> to indicate that they are have
+            completed.</li>
+        </ol> 
+      </dd>  
+
       <dt id="indentLine"><code><strong>cm.indentLine</strong>(line: integer, ?dir: string|integer)</code></dt>
       <dd>Adjust the indentation of the given line. The second
       argument (which defaults to <code>"smart"</code>) may be one of:

--- a/src/edit/methods.js
+++ b/src/edit/methods.js
@@ -9,7 +9,7 @@ import { indentLine } from "../input/indent"
 import { triggerElectric } from "../input/input"
 import { onKeyDown, onKeyPress, onKeyUp } from "./key_events"
 import { getKeyMap } from "../input/keymap"
-import { methodOp, operation, runInOp } from "../display/operations"
+import { methodOp, operation, runInOp, coordinatedRunInOp } from "../display/operations"
 import { clipLine, clipPos, cmp, Pos } from "../line/pos"
 import { charCoords, charWidth, clearCaches, clearLineMeasurementCache, coordsChar, cursorCoords, displayHeight, displayWidth, estimateLineHeights, fromCoordSystem, intoCoordSystem, scrollGap, textHeight } from "../measurement/position_measurement"
 import { Range } from "../model/selection"
@@ -449,6 +449,8 @@ export default function(CodeMirror) {
     }),
 
     operation: function(f){return runInOp(this, f)},
+
+    coordinatedOperation: function(f){return coordinatedRunInOp(this, f)},
 
     refresh: methodOp(function() {
       let oldHeight = this.display.cachedTextHeight

--- a/src/util/operation_group.js
+++ b/src/util/operation_group.js
@@ -36,7 +36,7 @@ export function finishOperation(op, endCb) {
   try { fireCallbacksForOps(group) }
   finally {
     operationGroup = null
-    endCb(group)
+    return endCb(group)
   }
 }
 

--- a/src/util/operation_group.js
+++ b/src/util/operation_group.js
@@ -31,7 +31,7 @@ function fireCallbacksForOps(group) {
 
 export function finishOperation(op, endCb) {
   let group = op.ownsGroup
-  if (!group) return
+  if (!group) return function() { return true }
 
   try { fireCallbacksForOps(group) }
   finally {


### PR DESCRIPTION
My application Extraterm https://github.com/sedwards2009/extraterm uses CodeMirror a lot. "A lot" meaning that typical terminal tab may contain 10s to 100s of CM instances interleaved with other content. This works quite well except for things which affect the whole terminal tab and scrollback. For example, resizing and refreshing CSS styles. I'm looking for ways to speed up these kinds of bulk operations across multiple CM instances.

This pull request adds a `cm.coordinatedOperation()` method which allows for the coordinated update of the DOM across multiple CodeMirror instances. When CM finishes an operation updates the DOM, it will try to group DOM reads and writes into batches so as to avoid DOM thrashing. (I'm referring to the `endOperation_R1`, `endOperation_W1`, `endOperation_R2`, `endOperation_W2` functions.) `coordinatedOperation()` lets the caller operate on multiple CM instances and then execute all of the instances' `endOperation_R1` functions, then all of the `endOperation_W1` functions etc etc. This groups the update operations.

This chrome time line below shows the performance differences when using 100 CM instances. Normal `cm.refresh()` vs `cm.refresh()` with `coordinatedOperation()`, and also `cm.setSize(null,null)` vs the same using `coordinatedOperation()`.

![codemirror_coordinated_operation_stats](https://cloud.githubusercontent.com/assets/6926644/19597867/8a96c28c-9797-11e6-9d33-52cc18c66ab3.png)
