### PR TITLE
TL-Verilog mode cleanup/rewrite.

### DIFF
--- a/mode/verilog/verilog.js
+++ b/mode/verilog/verilog.js
@@ -302,7 +302,13 @@ CodeMirror.defineMode("verilog", function(config, parserConfig) {
         state.indented = stream.indentation();
         state.startOfLine = true;
       }
-      if (hooks.token) hooks.token(stream, state);
+      if (hooks.token) {
+        // Call hook, with an optional return value of a style to override verilog styling.
+        var style = hooks.token(stream, state);
+        if (style !== undefined) {
+          return style;
+        }
+      }
       if (stream.eatSpace()) return null;
       curPunc = null;
       curKeyword = null;
@@ -375,163 +381,285 @@ CodeMirror.defineMode("verilog", function(config, parserConfig) {
     name: "verilog"
   });
 
-  // TLVVerilog mode
 
-  var tlvchScopePrefixes = {
-    ">": "property", "->": "property", "-": "hr", "|": "link", "?$": "qualifier", "?*": "qualifier",
-    "@-": "variable-3", "@": "variable-3", "?": "qualifier"
+
+  // TL-Verilog mode.
+  // See tl-x.org for language spec.
+  // See the mode in action at makerchip.com.
+  // Contact: steve.hoover@redwoodeda.com
+
+  // TLV Identifier prefixes.
+  // Note that sign is not treated separately, so "+/-" versions of numeric identifiers
+  // are included.
+  var tlvIdentifierStyle = {
+    "|": "link",
+    ">": "property",  // Should condition this off for > TLV 1c.
+    "$": "variable",
+    "$$": "variable",
+    "?$": "qualifier",
+    "?*": "qualifier",
+    "-": "hr",
+    "/": "property",
+    "/-": "property",
+    "@": "variable-3",
+    "@-": "variable-3",
+    "@++": "variable-3",
+    "@+=": "variable-3",
+    "@+=-": "variable-3",
+    "@--": "variable-3",
+    "@-=": "variable-3",
+    "%+": "tag",
+    "%-": "tag",
+    "%": "tag",
+    ">>": "tag",
+    "<<": "tag",
+    "<>": "tag",
+    "#": "tag",  // Need to choose a style for this.
+    "^": "attribute",
+    "^^": "attribute",
+    "^!": "attribute",
+    "*": "variable-2",
+    "**": "variable-2",
+    "\\": "keyword",
+    "\"": "comment"
   };
 
-  function tlvGenIndent(stream, state) {
-    var tlvindentUnit = 2;
-    var rtnIndent = -1, indentUnitRq = 0, curIndent = stream.indentation();
-    switch (state.tlvCurCtlFlowChar) {
-    case "\\":
-      curIndent = 0;
-      break;
-    case "|":
-      if (state.tlvPrevPrevCtlFlowChar == "@") {
-        indentUnitRq = -2; //-2 new pipe rq after cur pipe
-        break;
-      }
-      if (tlvchScopePrefixes[state.tlvPrevCtlFlowChar])
-        indentUnitRq = 1; // +1 new scope
-      break;
-    case "M":  // m4
-      if (state.tlvPrevPrevCtlFlowChar == "@") {
-        indentUnitRq = -2; //-2 new inst rq after  pipe
-        break;
-      }
-      if (tlvchScopePrefixes[state.tlvPrevCtlFlowChar])
-        indentUnitRq = 1; // +1 new scope
-      break;
-    case "@":
-      if (state.tlvPrevCtlFlowChar == "S")
-        indentUnitRq = -1; // new pipe stage after stmts
-      if (state.tlvPrevCtlFlowChar == "|")
-        indentUnitRq = 1; // 1st pipe stage
-      break;
-    case "S":
-      if (state.tlvPrevCtlFlowChar == "@")
-        indentUnitRq = 1; // flow in pipe stage
-      if (tlvchScopePrefixes[state.tlvPrevCtlFlowChar])
-        indentUnitRq = 1; // +1 new scope
-      break;
-    }
-    var statementIndentUnit = tlvindentUnit;
-    rtnIndent = curIndent + (indentUnitRq*statementIndentUnit);
-    return rtnIndent >= 0 ? rtnIndent : curIndent;
+  // Lines starting with these characters define scope (result in indentation).
+  var tlvScopePrefixChars = {
+    "/": "beh-hier",
+    ">": "beh-hier",
+    "-": "phys-hier",
+    "|": "pipe",
+    "?": "when",
+    "@": "stage",
+    "\\": "keyword"
+  };
+  var tlvIndentUnit = 3;
+  var tlvTrackStatements = false;
+  var tlvIdentMatch = /^([~!@#\$%\^&\*-\+=\?\/\\\|'"<>]+)([\d\w_]*)/;  // Matches an identifiere.
+  // Note that ':' is excluded, because of it's use in [:].
+  var tlvLinePrefixMatch = /^[! ]  /;
+  var tlvCommentMatch = /^\/[\/\*]/;
+
+
+  // Returns a style specific to the scope at the given indentation column.
+  // Type is one of: "indent", "scope-ident", "before-scope-ident".
+  function tlvScopeStyle(state, indentation, type) {
+    // Begin scope.
+    var depth = indentation / tlvIndentUnit;  // TODO: Pass this in instead.
+    return "tlv-" + state.tlvIndentationStyle[depth] + "-" + type;
+  }
+
+  // Return true if the next thing in the stream is an identifier with a mnemonic.
+  function tlvIdentNext(stream) {
+    var match;
+    return (match = stream.match(tlvIdentMatch, false)) && match[2].length > 0;
   }
 
   CodeMirror.defineMIME("text/x-tlv", {
     name: "verilog",
+
     hooks: {
-      "\\": function(stream, state) {
-        var vxIndent = 0, style = false;
-        var curPunc  = stream.string;
-        if ((stream.sol()) && ((/\\SV/.test(stream.string)) || (/\\TLV/.test(stream.string)))) {
-          curPunc = (/\\TLV_version/.test(stream.string))
-            ? "\\TLV_version" : stream.string;
-          stream.skipToEnd();
-          if (curPunc == "\\SV" && state.vxCodeActive) {state.vxCodeActive = false;};
-          if ((/\\TLV/.test(curPunc) && !state.vxCodeActive)
-            || (curPunc=="\\TLV_version" && state.vxCodeActive)) {state.vxCodeActive = true;};
-          style = "keyword";
-          state.tlvCurCtlFlowChar  = state.tlvPrevPrevCtlFlowChar
-            = state.tlvPrevCtlFlowChar = "";
-          if (state.vxCodeActive == true) {
-            state.tlvCurCtlFlowChar  = "\\";
-            vxIndent = tlvGenIndent(stream, state);
-          }
-          state.vxIndentRq = vxIndent;
-        }
-        return style;
-      },
-      tokenBase: function(stream, state) {
-        var vxIndent = 0, style = false;
-        var tlvisOperatorChar = /[\[\]=:]/;
-        var tlvkpScopePrefixs = {
-          "**":"variable-2", "*":"variable-2", "$$":"variable", "$":"variable",
-          "^^":"attribute", "^":"attribute"};
-        var ch = stream.peek();
-        var vxCurCtlFlowCharValueAtStart = state.tlvCurCtlFlowChar;
-        if (state.vxCodeActive == true) {
-          if (/[\[\]{}\(\);\:]/.test(ch)) {
-            // bypass nesting and 1 char punc
-            style = "meta";
-            stream.next();
-          } else if (ch == "/") {
-            stream.next();
-            if (stream.eat("/")) {
-              stream.skipToEnd();
-              style = "comment";
-              state.tlvCurCtlFlowChar = "S";
-            } else {
-              stream.backUp(1);
-            }
-          } else if (ch == "@") {
-            // pipeline stage
-            style = tlvchScopePrefixes[ch];
-            state.tlvCurCtlFlowChar = "@";
-            stream.next();
-            stream.eatWhile(/[\w\$_]/);
-          } else if (stream.match(/\b[mM]4+/, true)) { // match: function(pattern, consume, caseInsensitive)
-            // m4 pre proc
-            stream.skipTo("(");
-            style = "def";
-            state.tlvCurCtlFlowChar = "M";
-          } else if (ch == "!" && stream.sol()) {
-            // v stmt in tlv region
-            // state.tlvCurCtlFlowChar  = "S";
-            style = "comment";
-            stream.next();
-          } else if (tlvisOperatorChar.test(ch)) {
-            // operators
-            stream.eatWhile(tlvisOperatorChar);
-            style = "operator";
-          } else if (ch == "#") {
-            // phy hier
-            state.tlvCurCtlFlowChar  = (state.tlvCurCtlFlowChar == "")
-              ? ch : state.tlvCurCtlFlowChar;
-            stream.next();
-            stream.eatWhile(/[+-]\d/);
-            style = "tag";
-          } else if (tlvkpScopePrefixs.propertyIsEnumerable(ch)) {
-            // special TLV operators
-            style = tlvkpScopePrefixs[ch];
-            state.tlvCurCtlFlowChar = state.tlvCurCtlFlowChar == "" ? "S" : state.tlvCurCtlFlowChar;  // stmt
-            stream.next();
-            stream.match(/[a-zA-Z_0-9]+/);
-          } else if (style = tlvchScopePrefixes[ch] || false) {
-            // special TLV operators
-            state.tlvCurCtlFlowChar = state.tlvCurCtlFlowChar == "" ? ch : state.tlvCurCtlFlowChar;
-            stream.next();
-            stream.match(/[a-zA-Z_0-9]+/);
-          }
-          if (state.tlvCurCtlFlowChar != vxCurCtlFlowCharValueAtStart) { // flow change
-            vxIndent = tlvGenIndent(stream, state);
-            state.vxIndentRq = vxIndent;
-          }
-        }
-        return style;
-      },
+
+      electricInput: false,
+
+
+      // Return undefined for verilog tokenizing, or style for TLV token (null not used).
+      // Standard CM styles are used for most formatting, but some TL-Verilog-specific highlighting
+      // can be enabled with the definition of cm-tlv-* styles, including highlighting for:
+      //   - M4 tokens
+      //   - TLV scope indentation
+      //   - Statement delimitation (enabled by tlvTrackStatements)
       token: function(stream, state) {
-        if (state.vxCodeActive == true && stream.sol() && state.tlvCurCtlFlowChar != "") {
-          state.tlvPrevPrevCtlFlowChar = state.tlvPrevCtlFlowChar;
-          state.tlvPrevCtlFlowChar = state.tlvCurCtlFlowChar;
-          state.tlvCurCtlFlowChar = "";
+        var style = undefined;
+
+        // Set highlighting mode based on code region (TLV or SV).
+        if (stream.sol() && ! state.tlvInBlockComment) {
+          // Process region.
+          if (stream.peek() == '\\') {
+            style = "def";
+            stream.skipToEnd();
+            if (stream.string.match(/\\SV/)) {
+              state.tlvCodeActive = false;
+            } else if (stream.string.match(/\\TLV/)){
+              state.tlvCodeActive = true;
+            }
+          }
+          // Process TLV line prefix -- correct indentation.
+          if (state.tlvCodeActive && (state.indented == 0) && stream.match(tlvLinePrefixMatch)) {
+            stream.match(/ */);
+            state.indented = stream.pos;
+            stream.pos = 0;
+          }
+
+          // Compute indentation state:
+          //   o Required indentation on next line
+          //   o Indentation scope styles
+          var indented = state.indented;
+          var depth = indented / tlvIndentUnit;
+          if (depth <= state.tlvIndentationStyle.length) {
+            // not deeper than current scope
+
+            var blankline = stream.string.length == indented;
+            var chPos = depth * tlvIndentUnit;
+            if (chPos < stream.string.length) {
+              var bodyString = stream.string.slice(chPos);
+              var ch = bodyString[0];
+              var match;
+              if (tlvScopePrefixChars[ch] && ((match = bodyString.match(tlvIdentMatch)) &&
+                  tlvIdentifierStyle[match[1]])) {
+                // this line begins scope (except non-region keyword identifiers, which are statements themselves)
+                if (!(ch == "\\" && chPos > 0)) {
+                  indented += tlvIndentUnit;
+                  state.tlvIndentationStyle[depth] = tlvScopePrefixChars[ch];
+                  if (tlvTrackStatements) {state.statementComment = false;}
+                  depth++;
+                }
+              }
+            }
+            // Clear out deeper indentation levels unless line is blank.
+            if (!blankline) {
+              while (state.tlvIndentationStyle.length > depth) {
+                state.tlvIndentationStyle.pop();
+              }
+            }
+          }
         }
+
+        if (state.tlvCodeActive) {
+          // Highlight as TLV.
+
+          var beginStatement = false;
+          if (tlvTrackStatements) {
+            // This starts a statement if the position is at the scope level
+            // and we're not within a statement leading comment.
+            beginStatement =
+                   (stream.peek() != " ") &&   // not a space
+                   (style === undefined) &&    // not a region identifier
+                   !state.tlvInBlockComment && // not in block comment
+                   //!stream.match(tlvCommentMatch, false) && // not comment start
+                   (stream.column() == state.tlvIndentationStyle.length * tlvIndentUnit);  // at scope level
+            if (beginStatement) {
+              if (state.statementComment) {
+                // statement already started by comment
+                beginStatement = false;
+              }
+              state.statementComment =
+                   stream.match(tlvCommentMatch, false); // comment start
+            }
+          }
+
+          var match;
+          if (style !== undefined) {
+            // Region line.
+            style += " " + tlvScopeStyle(state, 0, "scope-ident")
+          } else if (((stream.pos / tlvIndentUnit) < state.tlvIndentationStyle.length) &&
+                     (match = stream.match(stream.sol() ? tlvLinePrefixMatch : /^   /))) {
+            // Indentation
+            style = // make this style distinct from the previous one to prevent
+                    // codemirror from combining spans
+                    "tlv-indent-" + (((stream.pos % 2) == 0) ? "even" : "odd") +
+                    // and style it
+                    " " + tlvScopeStyle(state, stream.pos - tlvIndentUnit, "indent");
+            // Style the line prefix character.
+            if (match[0].charAt(0) == "!") {
+              style += " tlv-alert-line-prefix";
+            }
+            // Place a class before a scope identifier.
+            if (tlvIdentNext(stream)) {
+              style += " " + tlvScopeStyle(state, stream.pos, "before-scope-ident");
+            }
+          } else if (state.tlvInBlockComment) {
+            // In a block comment.
+            if (stream.match(/^.*?\*\//)) {
+              // Exit block comment.
+              state.tlvInBlockComment = false;
+              if (tlvTrackStatements && !stream.eol()) {
+                // Anything after comment is assumed to be real statement content.
+                state.statementComment = false;
+              }
+            } else {
+              stream.skipToEnd();
+            }
+            style = "comment";
+          } else if ((match = stream.match(tlvCommentMatch)) && !state.tlvInBlockComment) {
+            // Start comment.
+            if (match[0] == "//") {
+              // Line comment.
+              stream.skipToEnd();
+            } else {
+              // Block comment.
+              state.tlvInBlockComment = true;
+            }
+            style = "comment";
+          } else if (match = stream.match(tlvIdentMatch)) {
+            // looks like an identifier (or identifier prefix)
+            var prefix = match[1];
+            var mnemonic = match[2];
+            if (// is identifier prefix
+                (prefix in tlvIdentifierStyle) &&
+                // has mnemonic or we're at the end of the line (maybe it hasn't been typed yet)
+                (mnemonic.length > 0 || stream.eol())) {
+              style = tlvIdentifierStyle[prefix];
+              if (stream.column() == state.indented) {
+                // Begin scope.
+                style += " " + tlvScopeStyle(state, stream.column(), "scope-ident")
+              }
+            } else {
+              // Just swallow one character and try again.
+              // This enables subsequent identifier match with preceding symbol character, which
+              //   is legal within a statement.  (Eg, !$reset).  It also enables detection of
+              //   comment start with preceding symbols.
+              stream.backUp(stream.current().length - 1);
+              style = "tlv-default";
+            }
+          } else if (stream.match(/^\t+/)) {
+            // Highlight tabs, which are illegal.
+            style = "tlv-tab";
+          } else if (stream.match(/^[\[\]{}\(\);\:]+/)) {
+            // [:], (), {}, ;.
+            style = "meta";
+          } else if (match = stream.match(/^[mM]4([\+_])?[\w\d_]*/)) {
+            // m4 pre proc
+            style = (match[1] == "+") ? "tlv-m4-plus" : "tlv-m4";
+          } else if (stream.match(/^ +/)){
+            // Skip over spaces.
+            if (stream.eol()) {
+              // Trailing spaces.
+              style = "error";
+            } else {
+              // Non-trailing spaces.
+              style = "tlv-default";
+            }
+          } else if (stream.match(/^[\w\d_]+/)) {
+            // alpha-numeric token.
+            style = "number";
+          } else {
+            // Eat the next char w/ no formatting.
+            stream.next();
+            style = "tlv-default";
+          }
+          if (beginStatement) {
+            style += " tlv-statement";
+          }
+        } else {
+          if (stream.match(/^[mM]4([\w\d_]*)/)) {
+            // m4 pre proc
+            style = "tlv-m4";
+          }
+        }
+        return style;
       },
-      indent: function(state) {
-        return (state.vxCodeActive == true) ? state.vxIndentRq : -1;
-      },
+
       startState: function(state) {
-        state.tlvCurCtlFlowChar = "";
-        state.tlvPrevCtlFlowChar = "";
-        state.tlvPrevPrevCtlFlowChar = "";
-        state.vxCodeActive = true;
-        state.vxIndentRq = 0;
+        state.tlvIndentationStyle = [];  // Styles to use for each level of indentation.
+        state.tlvCodeActive = true;  // True when we're in a TLV region (and at beginning of file).
+        state.tlvInBlockComment = false;  // True inside /**/ comment.
+        if (tlvTrackStatements) {
+          state.statementComment = false;  // True inside a statement's header comment.
+        }
       }
+
     }
   });
 });


### PR DESCRIPTION
This push request is cleanup/rewrite of the Verilog mode support for Transaction-Level Verilog, currently with a limited user base (edaplayground.com and makerchip.com).  The only code change to the main Verilog mode is a check for the return value of the verilog token(..) hook, which now has an optional return value of 'style'.  TL-Verilog mode is largely rewritten to be cleaner and more maintainable with additional styling and a more comments.
