### PR TITLE
Adding text/yaml to the mime media types list

### DIFF
--- a/mode/meta.js
+++ b/mode/meta.js
@@ -157,7 +157,7 @@
     {name: "XML", mimes: ["application/xml", "text/xml"], mode: "xml", ext: ["xml", "xsl", "xsd"], alias: ["rss", "wsdl", "xsd"]},
     {name: "XQuery", mime: "application/xquery", mode: "xquery", ext: ["xy", "xquery"]},
     {name: "Yacas", mime: "text/x-yacas", mode: "yacas", ext: ["ys"]},
-    {name: "YAML", mime: "text/x-yaml", mode: "yaml", ext: ["yaml", "yml"], alias: ["yml"]},
+    {name: "YAML", mimes: ["text/x-yaml", "text/yaml"], mode: "yaml", ext: ["yaml", "yml"], alias: ["yml"]},
     {name: "Z80", mime: "text/x-z80", mode: "z80", ext: ["z80"]},
     {name: "mscgen", mime: "text/x-mscgen", mode: "mscgen", ext: ["mscgen", "mscin", "msc"]},
     {name: "xu", mime: "text/x-xu", mode: "mscgen", ext: ["xu"]},


### PR DESCRIPTION
Sadly, YAML doesn't (yet?) have a [registered media type](http://www.iana.org/assignments/media-types/media-types.xhtml).

Consequently, sometimes libraries (such as [mime-db](https://github.com/jshttp/mime-db/blob/9dd00b34556a8cdd6f3385f09d4989298c4b86e1/src/custom-types.json#L652-L654)) use `text/yaml` rather than `text/x-yaml`.

This solves for that.

Thanks!
🎩 