### PR TITLE
Fix Vue.js Single File Component Media Type

### DIFF
--- a/mode/meta.js
+++ b/mode/meta.js
@@ -154,6 +154,7 @@
     {name: "Velocity", mime: "text/velocity", mode: "velocity", ext: ["vtl"]},
     {name: "Verilog", mime: "text/x-verilog", mode: "verilog", ext: ["v"]},
     {name: "VHDL", mime: "text/x-vhdl", mode: "vhdl", ext: ["vhd", "vhdl"]},
+    {name: "Vue.js Component", mimes: ["script/x-vue", "text/x-vue"], mode: "vue", ext: ["vue"]},
     {name: "XML", mimes: ["application/xml", "text/xml"], mode: "xml", ext: ["xml", "xsl", "xsd"], alias: ["rss", "wsdl", "xsd"]},
     {name: "XQuery", mime: "application/xquery", mode: "xquery", ext: ["xy", "xquery"]},
     {name: "Yacas", mime: "text/x-yacas", mode: "yacas", ext: ["ys"]},

--- a/mode/vue/vue.js
+++ b/mode/vue/vue.js
@@ -66,4 +66,5 @@
   }, "htmlmixed", "xml", "javascript", "coffeescript", "css", "sass", "stylus", "pug", "handlebars");
 
   CodeMirror.defineMIME("script/x-vue", "vue");
+  CodeMirror.defineMIME("text/x-vue", "vue");
 });


### PR DESCRIPTION
Demo had the correct `text/x-vue`
defineMIME was using `script/x-vue`

There is, however, no `script/*` top-level media type:
http://www.iana.org/assignments/media-types/media-types.xhtml

Left, old `script/x-vue` for backwards compatibility.