### PR TITLE
Draw rulers all the way when scrollPastEnd is on.

### DIFF
--- a/addon/display/rulers.js
+++ b/addon/display/rulers.js
@@ -13,12 +13,12 @@
 
   CodeMirror.defineOption("rulers", false, function(cm, val) {
     if (cm.state.rulerDiv) {
-      cm.display.lineSpace.removeChild(cm.state.rulerDiv)
+      cm.state.rulerDiv.parentElement.removeChild(cm.state.rulerDiv)
       cm.state.rulerDiv = null
       cm.off("refresh", drawRulers)
     }
     if (val && val.length) {
-      cm.state.rulerDiv = cm.display.lineSpace.insertBefore(document.createElement("div"), cm.display.cursorDiv)
+      cm.state.rulerDiv = cm.display.lineSpace.parentElement.insertBefore(document.createElement("div"), cm.display.lineSpace)
       cm.state.rulerDiv.className = "CodeMirror-rulers"
       drawRulers(cm)
       cm.on("refresh", drawRulers)


### PR DESCRIPTION
Previously the "bottom: -20px" style placed the bottom of the rulers 20px into the bottom padding added by the scrollpastend addon, but the min-height on the CodeMirror-rulers div made them move around based on which lines were rendered.