### PR TITLE
Fix the `combine` option for overlay modes inside blankLines

### DIFF
--- a/addon/mode/overlay.js
+++ b/addon/mode/overlay.js
@@ -76,14 +76,14 @@ CodeMirror.overlayMode = function(base, overlay, combine) {
     innerMode: function(state) { return {state: state.base, mode: base}; },
 
     blankLine: function(state) {
-      var baseToken, overlayToken
+      var baseToken, overlayToken;
       if (base.blankLine) baseToken = base.blankLine(state.base);
       if (overlay.blankLine) overlayToken = overlay.blankLine(state.overlay);
 
       if (combine) {
         return baseToken + " " + overlayToken;
       } else {
-        return overlayToken == null ? baseToken : overlayToken
+        return overlayToken == null ? baseToken : overlayToken;
       }
     }
   };

--- a/addon/mode/overlay.js
+++ b/addon/mode/overlay.js
@@ -76,8 +76,15 @@ CodeMirror.overlayMode = function(base, overlay, combine) {
     innerMode: function(state) { return {state: state.base, mode: base}; },
 
     blankLine: function(state) {
-      if (base.blankLine) base.blankLine(state.base);
-      if (overlay.blankLine) overlay.blankLine(state.overlay);
+      var baseToken, overlayToken
+      if (base.blankLine) baseToken = base.blankLine(state.base);
+      if (overlay.blankLine) overlayToken = overlay.blankLine(state.overlay);
+
+      if (combine) {
+        return baseToken + " " + overlayToken;
+      } else {
+        return overlayToken == null ? baseToken : overlayToken
+      }
     }
   };
 };

--- a/addon/mode/overlay.js
+++ b/addon/mode/overlay.js
@@ -80,11 +80,9 @@ CodeMirror.overlayMode = function(base, overlay, combine) {
       if (base.blankLine) baseToken = base.blankLine(state.base);
       if (overlay.blankLine) overlayToken = overlay.blankLine(state.overlay);
 
-      if (combine) {
-        return baseToken + " " + overlayToken;
-      } else {
-        return overlayToken == null ? baseToken : overlayToken;
-      }
+      return overlayToken == null ?
+        baseToken :
+        (combine ? baseToken + " " + overlayToken : overlayToken);
     }
   };
 };


### PR DESCRIPTION
Before, the base methods were being called but nothing was being returned in either case. This should fix it both for normal and combine overlays.