### PR TITLE
[npmignore] add files that do nothing when installed with npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,5 @@
 /mode/*/*.html
 /mode/index.html
 .*
+bin
+rollup.config.js


### PR DESCRIPTION
Added files to `.gitignore`:
- **bin**
- **.rollup.config.js**