### PR TITLE
[Behavior change] Highlight active line even when text is selected

### DIFF
--- a/addon/selection/active-line.js
+++ b/addon/selection/active-line.js
@@ -3,14 +3,13 @@
 
 // Because sometimes you need to style the cursor's line.
 //
-// Adds two options:
 // 'styleActiveLine': when enabled, gives the active line's wrapping
 // <div> the CSS class "CodeMirror-activeline", and gives its background
 // <div> the class "CodeMirror-activeline-background".
 //
-// 'styleActiveSelected': When enabled and 'styleActiveLine' is
-// enabled, keeps the active line's styling active even when text is
-// selected within the line. Has no effect if 'styleActiveLine' is not enabled
+// 'styleActiveSelected': An optional parameter of 'styleActiveLine'.
+// When enabled, keeps the active line's styling active even when text is
+// selected within the line. Has no effect if 'styleActiveLine' is not enabled.
 
 (function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
@@ -38,15 +37,6 @@
     }
   });
 
-  CodeMirror.defineOption("styleActiveSelected", false, function(cm, val, old) {
-    var prev = old && old != CodeMirror.Init;
-    if (val && !prev) {
-      cm.state.maintainHighlight = true;
-    } else if (!val && prev) {
-      delete cm.state.maintainHighlight;
-    }
-  });
-
   function clearActiveLines(cm) {
     for (var i = 0; i < cm.state.activeLines.length; i++) {
       cm.removeLineClass(cm.state.activeLines[i], "wrap", WRAP_CLASS);
@@ -66,7 +56,7 @@
     var active = [];
     for (var i = 0; i < ranges.length; i++) {
       var range = ranges[i];
-      if (cm.state.maintainHighlight) {
+      if (cm.getOption('styleActiveLine').styleActiveSelected == true) {
         if (range.anchor.line != range.head.line) continue;
       } else {
         if (!range.empty()) continue;

--- a/addon/selection/active-line.js
+++ b/addon/selection/active-line.js
@@ -3,9 +3,14 @@
 
 // Because sometimes you need to style the cursor's line.
 //
-// Adds an option 'styleActiveLine' which, when enabled, gives the
-// active line's wrapping <div> the CSS class "CodeMirror-activeline",
-// and gives its background <div> the class "CodeMirror-activeline-background".
+// Adds two options:
+// 'styleActiveLine': when enabled, gives the active line's wrapping
+// <div> the CSS class "CodeMirror-activeline", and gives its background
+// <div> the class "CodeMirror-activeline-background".
+//
+// 'styleActiveSelected': When enabled and 'styleActiveLine' is
+// enabled, keeps the active line's styling active even when text is
+// selected within the line. Has no effect if 'styleActiveLine' is not enabled
 
 (function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
@@ -33,6 +38,15 @@
     }
   });
 
+  CodeMirror.defineOption("styleActiveSelected", false, function(cm, val, old) {
+    var prev = old && old != CodeMirror.Init;
+    if (val && !prev) {
+      cm.state.maintainHighlight = true;
+    } else if (!val && prev) {
+      delete cm.state.maintainHighlight;
+    }
+  });
+
   function clearActiveLines(cm) {
     for (var i = 0; i < cm.state.activeLines.length; i++) {
       cm.removeLineClass(cm.state.activeLines[i], "wrap", WRAP_CLASS);
@@ -52,7 +66,11 @@
     var active = [];
     for (var i = 0; i < ranges.length; i++) {
       var range = ranges[i];
-      if (!range.empty()) continue;
+      if (cm.state.maintainHighlight) {
+        if (range.anchor.line != range.head.line) continue;
+      } else {
+        if (!range.empty()) continue;
+      }
       var line = cm.getLineHandleVisualStart(range.head.line);
       if (active[active.length - 1] != line) active.push(line);
     }

--- a/demo/activeline.html
+++ b/demo/activeline.html
@@ -65,14 +65,24 @@
 </rss></textarea></form>
 
     <script>
+var styleActiveSelected = false;
 var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
   mode: "application/xml",
   styleActiveLine: true,
   lineNumbers: true,
   lineWrapping: true
 });
+
+function toggleSelProp() {
+  styleActiveSelected = !styleActiveSelected;
+  editor.setOption('styleActiveSelected', styleActiveSelected);
+  var label = styleActiveSelected ? 'Disable styleActiveSelected option' : 'Enable styleActiveSelected option';
+  document.getElementById('toggleButton').innerText = label;
+}
 </script>
 
     <p>Styling the current cursor line.</p>
+
+    <button onclick="toggleSelProp()" id="toggleButton">Enable styleActiveSelected option</button>
 
   </article>

--- a/demo/activeline.html
+++ b/demo/activeline.html
@@ -68,14 +68,16 @@
 var styleActiveSelected = false;
 var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
   mode: "application/xml",
-  styleActiveLine: true,
+  styleActiveLine: {
+    styleActiveSelected: styleActiveSelected
+  },
   lineNumbers: true,
   lineWrapping: true
 });
 
 function toggleSelProp() {
   styleActiveSelected = !styleActiveSelected;
-  editor.setOption('styleActiveSelected', styleActiveSelected);
+  editor.setOption('styleActiveLine', {styleActiveSelected: styleActiveSelected});
   var label = styleActiveSelected ? 'Disable styleActiveSelected option' : 'Enable styleActiveSelected option';
   document.getElementById('toggleButton').innerText = label;
 }

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2769,8 +2769,10 @@ editor.setOption("extraKeys", {
         line's gutter space.
         </dd>
         <dd>
-        In addition, defines an option <code>styleActiveSelected</code>
-        that controls highlighting behavior when selected. If <code>true</code>,
+        In addition, defines an option <code>styleActiveSelected</code>,
+        that controls highlighting behavior when selected.
+        <code>styleActiveSelected</code> is an optional parameter of
+        <code>styleActiveLine</code>. If <code>true</code>,
         the active line will remain highlighted when text within the line is
         selected. If <code>false</code> or unspecified, the active line will
         become unhighlighted as soon as text is selected. Has no effect if

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2760,12 +2760,24 @@ editor.setOption("extraKeys", {
       like in <a href="../demo/markselection.html">this demo</a>.</dd>
 
       <dt id="addon_active-line"><a href="../addon/selection/active-line.js"><code>selection/active-line.js</code></a></dt>
-      <dd>Defines a <code>styleActiveLine</code> option that, when enabled,
-      gives the wrapper of the active line the class <code>CodeMirror-activeline</code>,
-      adds a background with the class <code>CodeMirror-activeline-background</code>,
-      and adds the class <code>CodeMirror-activeline-gutter</code> to the
-      line's gutter space is enabled. See the
-      <a href="../demo/activeline.html">demo</a>.</dd>
+      <dd>Controls highlighting of the active line.
+        <dd>Defines an option
+        <code>styleActiveLine</code> which, when enabled, gives the wrapper of
+        the active line the class <code>CodeMirror-activeline</code>, adds a
+        background with the class <code>CodeMirror-activeline-background</code>,
+        and adds the class <code>CodeMirror-activeline-gutter</code> to the
+        line's gutter space.
+        </dd>
+        <dd>
+        In addition, defines an option <code>styleActiveSelected</code>
+        that controls highlighting behavior when selected. If <code>true</code>,
+        the active line will remain highlighted when text within the line is
+        selected. If <code>false</code> or unspecified, the active line will
+        become unhighlighted as soon as text is selected. Has no effect if
+        <code>styleActiveLine</code> is not enabled.
+        </dd>
+        <dd>See the <a href="../demo/activeline.html">demo</a>.</dd>
+      </dd>
 
       <dt id="addon_selection-pointer"><a href="../addon/selection/selection-pointer.js"><code>selection/selection-pointer.js</code></a></dt>
       <dd>Defines a <code>selectionPointer</code> option which you can


### PR DESCRIPTION
Currently, when a line is highlighted and the user selects text, the highlight goes away. This PR would change that behavior by keeping the highlight unless the text selection extends outside of the current line.

The current behavior was introduced several years ago: https://github.com/codemirror/CodeMirror/commit/fac94560d2a1fb26902ea74df8de0fefc87d2457#diff-081cd675c6a483cb58a765919bdab1e9

If it makes more sense to have the behavior controlled by a configuration option, let me know and we can implement that as well.