### PR TITLE
improved markdown image lookaheads

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -436,7 +436,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       return getType(state);
     }
 
-    if (ch === '[' && state.imageMarker) {
+    if (ch === '[' && stream.match(/[^\]]*\](\(.*\)| ?\[.*?\])/, false) && state.imageMarker) {
       state.imageMarker = false;
       state.imageAltText = true
       if (modeCfg.highlightFormatting) state.formatting = "image";


### PR DESCRIPTION
Just improved the recognition of images in the markdown mode.

If the url doesn't have correct syntax in a link `[link](url)` the styles aren't applied. This isn't true for image links `![image](url)` where if it's not finished it will continue to parse the rest of the document.

This pull request just ensures the image syntax acts like the link image syntax.

**Examples**:

Before editing, the lines under the unclosed image syntax are parsed as `url`.
![before](https://cloud.githubusercontent.com/assets/1011648/21069095/c4c68208-beca-11e6-9952-c9603889db6f.png)

After, it acts just like the link syntax.
![after](https://cloud.githubusercontent.com/assets/1011648/21069100/de3e2308-beca-11e6-8884-9d4d84bd9d40.png)
