### PR TITLE
Remove !important from CodeMirror-scroll css class

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -156,7 +156,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 }
 
 .CodeMirror-scroll {
-  overflow: scroll !important; /* Things will break if this is overridden */
+  overflow: scroll;
   /* 30px is the magic margin used to hide the element's real scrollbars */
   /* See overflow: hidden in .CodeMirror */
   margin-bottom: -30px; margin-right: -30px;


### PR DESCRIPTION
Forget that !important exists. Breaks Jupyter notebook and can't be simply fixed.