### PR TITLE
Fix errors being thrown if an event emission results in a listener being synchronously removed

### DIFF
--- a/src/util/operation_group.js
+++ b/src/util/operation_group.js
@@ -62,7 +62,7 @@ export function signalLater(emitter, type /*, values...*/) {
     setTimeout(fireOrphanDelayed, 0)
   }
   for (let i = 0; i < arr.length; ++i) {
-    const fn = arr[i];
+    const fn = arr[i]
     list.push(() => fn.apply(null, args))
   }
 }

--- a/src/util/operation_group.js
+++ b/src/util/operation_group.js
@@ -61,8 +61,10 @@ export function signalLater(emitter, type /*, values...*/) {
     list = orphanDelayedCallbacks = []
     setTimeout(fireOrphanDelayed, 0)
   }
-  for (let i = 0; i < arr.length; ++i)
-    list.push(() => arr[i].apply(null, args))
+  for (let i = 0; i < arr.length; ++i) {
+    const fn = arr[i];
+    list.push(() => fn.apply(null, args))
+  }
 }
 
 function fireOrphanDelayed() {


### PR DESCRIPTION
It would result in the array length changing and (from experience!) result a hard-to-track-down error.