### PR TITLE
Validate composition when type enter key

### DIFF
--- a/src/edit/key_events.js
+++ b/src/edit/key_events.js
@@ -104,6 +104,11 @@ export function onKeyDown(e) {
   // IE does strange things with escape.
   if (ie && ie_version < 11 && e.keyCode == 27) e.returnValue = false
   let code = e.keyCode
+  // if Enter key, force read the DOM if a reading is required
+  // before creating the new line
+  if(code == 13 && cm.display.input.readDOMTimeout){
+    cm.display.input.readFromDOM()
+  }
   cm.display.shift = code == 16 || e.shiftKey
   let handled = handleKeyBinding(cm, e)
   if (presto) {

--- a/src/input/ContentEditableInput.js
+++ b/src/input/ContentEditableInput.js
@@ -309,11 +309,19 @@ ContentEditableInput.prototype = copyObj({
   readFromDOMSoon: function() {
     if (this.readDOMTimeout != null) return
     this.readDOMTimeout = setTimeout(() => {
-      this.readDOMTimeout = null
-      if (this.composing) return
-      if (this.cm.isReadOnly() || !this.pollContent())
-        runInOp(this.cm, () => regChange(this.cm))
+      this.readFromDOM()
     }, 80)
+  },
+
+  readFromDOM : function(){
+      if (this.readDOMTimeout != null){
+          clearTimeout(this.readDOMTimeout)
+          this.readDOMTimeout = null
+      }
+      if (this.composing) return
+      if (this.cm.isReadOnly() || !this.pollContent()){
+          runInOp(this.cm, () => regChange(this.cm))
+      }
   },
 
   setUneditable: function(node) {


### PR DESCRIPTION
This PR fixes the issue #4441.
I don't have an exhaustive view of CodeMirror so let me know if some adjustments are needed.