### PR TITLE
CSS: Allow contextual glyph alternatives

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -249,8 +249,8 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   position: relative;
   overflow: visible;
   -webkit-tap-highlight-color: transparent;
-  -webkit-font-variant-ligatures: none;
-  font-variant-ligatures: none;
+  -webkit-font-variant-ligatures: contextual;
+  font-variant-ligatures: contextual;
 }
 .CodeMirror-wrap pre {
   word-wrap: break-word;


### PR DESCRIPTION
Ligatures were disabled in #3899 since some editors didn’t allow placing the cursor inside of them.

“Contextual alternatives” on the other hand still allow this, therefore this commit enables them to support e.g. Fira Code’s main gimmick.