### PR TITLE
[css mode] Add caret-color property

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -468,7 +468,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
     "border-top-left-radius", "border-top-right-radius", "border-top-style",
     "border-top-width", "border-width", "bottom", "box-decoration-break",
     "box-shadow", "box-sizing", "break-after", "break-before", "break-inside",
-    "caption-side", "clear", "clip", "color", "color-profile", "column-count",
+    "caption-side", "caret-color", "clear", "clip", "color", "color-profile", "column-count",
     "column-fill", "column-gap", "column-rule", "column-rule-color",
     "column-rule-style", "column-rule-width", "column-span", "column-width",
     "columns", "content", "counter-increment", "counter-reset", "crop", "cue",


### PR DESCRIPTION
The property is defined in this spec:
https://drafts.csswg.org/css-ui/#caret-color

It has been recently implemented on Chromium and Firefox.