### PR TITLE
Fix bug when popping scopes

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -60,14 +60,17 @@
       };
     }
 
-    function pop(list) {
-      return list && list.next;
-    }
-
     // Reference a variable `name` in `list`.
     // Let `loose` be truthy to ignore missing identifiers.
     function ref(list, name, loose) {
       return contains(list, name) ? "variable-2" : (loose ? "variable" : "variable-2 error");
+    }
+
+    function popscope(state) {
+      if (state.scopes) {
+        state.variables = state.scopes.element;
+        state.scopes = state.scopes.next;
+      }
     }
 
     return {
@@ -168,11 +171,11 @@
           case "tag":
             if (stream.match(/^\/?}/)) {
               if (state.tag == "/template" || state.tag == "/deltemplate") {
-                state.variables = state.scopes = pop(state.scopes);
+                popscope(state);
                 state.indent = 0;
               } else {
                 if (state.tag == "/for" || state.tag == "/foreach") {
-                  state.variables = state.scopes = pop(state.scopes);
+                  popscope(state);
                 }
                 state.indent -= config.indentUnit *
                     (stream.current() == "/}" || indentingTags.indexOf(state.tag) == -1 ? 2 : 1);

--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -60,10 +60,12 @@
      '');
 
   MT('foreach-scope-test',
+     '[keyword {@param] [def bar]: [variable-3 string][keyword }]',
      '[keyword {foreach] [def $foo] [keyword in] [variable-2&error $foos][keyword }]',
      '  [keyword {][variable-2 $foo][keyword }]',
      '[keyword {/foreach}]',
-     '[keyword {][variable-2&error $foo][keyword }]');
+     '[keyword {][variable-2&error $foo][keyword }]',
+     '[keyword {][variable-2 $bar][keyword }]');
 
   MT('foreach-ifempty-indent-test',
      '[keyword {foreach] [def $foo] [keyword in] [variable-2&error $foos][keyword }]',


### PR DESCRIPTION
Although only a single scope should be popped when ending a loop (like with `{/foreach}`), the bug had the equivalent effect of all scopes being popped.

**Currently:**
![soy-broken](https://cloud.githubusercontent.com/assets/703602/21522237/005ca328-cd04-11e6-9157-988c0ada44cb.png)

**Fixed:**
![soy-fixed](https://cloud.githubusercontent.com/assets/703602/21522238/005cc3bc-cd04-11e6-8a2e-30d917e5a76e.png)
