### PR TITLE
[soy mode] Add tests for 9fe2053, find bug and fix it

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -198,8 +198,8 @@
             if (match = stream.match(/^\$([\w]+)/)) {
               return ref(state.variables, match[1]);
             }
-            if (stream.match(/\b(?:as|and|or|not|in)\b/)) {
-              return "keyword";
+            if (match = stream.match(/^\w+/)) {
+              return /^(?:as|and|or|not|in)$/.test(match[0]) ? "keyword" : null;
             }
             stream.next();
             return null;

--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -5,6 +5,12 @@
   var mode = CodeMirror.getMode({indentUnit: 2}, "soy");
   function MT(name) {test.mode(name, mode, Array.prototype.slice.call(arguments, 1));}
 
+  // Test of small keywords and words containing them.
+  MT('keywords-test',
+     '[keyword {] [keyword as] worrying [keyword and] notorious [keyword as]',
+     '    the Fandor-alias assassin, [keyword or]',
+     '    Corcand cannot fit [keyword in] [keyword }]');
+
   MT('let-test',
      '[keyword {template] [def .name][keyword }]',
      '  [keyword {let] [def $name]: [string "world"][keyword /}]',


### PR DESCRIPTION
I got too eager with #4474; forgot to add tests.

The behaviour on https://codemirror.net/ is just as #4468 described:
![keyword-1-now](https://cloud.githubusercontent.com/assets/703602/21542370/857397ce-cdbd-11e6-8b1b-2931bb22ad54.png)

The situation improved after #4474, but didn't take into account the greedy nature of the parser. The regex only examined parts of the words at a time and only the latter `\b` had any effect, meaning that words ending with a keyword would have that incorrectly highlighted:
![keyword-2-partial](https://cloud.githubusercontent.com/assets/703602/21542431/eb2f4e3c-cdbd-11e6-9740-98d11665d633.png)

With these changes, we grab the whole word at once and _then_ check to see if it is in fact a keyword:
![keyword-3-fix](https://cloud.githubusercontent.com/assets/703602/21542570/f596f2c0-cdbe-11e6-952f-14505d3e8cbe.png)
