### PR TITLE
[pascal mode] add missing keywords, parse the code as case insensitive

### DIFF
--- a/mode/pascal/pascal.js
+++ b/mode/pascal/pascal.js
@@ -17,9 +17,13 @@ CodeMirror.defineMode("pascal", function() {
     for (var i = 0; i < words.length; ++i) obj[words[i]] = true;
     return obj;
   }
-  var keywords = words("and array begin case const div do downto else end file for forward integer " +
-                       "boolean char function goto if in label mod nil not of or packed procedure " +
-                       "program record repeat set string then to type until var while with");
+  var keywords = words("absolute and array asm begin boolean break case char const constructor " +
+                       "continue destructor div do downto else end file for forward integer " +
+                       "function goto if implementation in inherited inline interface label mod " +
+                       "nil not object of on operator or packed procedure program record " +
+                       "reintroduce repeat self set shl shr string then to type unit until uses " +
+                       "var while with xor");
+
   var atoms = {"null": true};
 
   var isOperatorChar = /[+\-*&%=<>!?|\/]/;
@@ -56,7 +60,7 @@ CodeMirror.defineMode("pascal", function() {
       return "operator";
     }
     stream.eatWhile(/[\w\$_]/);
-    var cur = stream.current();
+    var cur = stream.current().toLowerCase();
     if (keywords.propertyIsEnumerable(cur)) return "keyword";
     if (atoms.propertyIsEnumerable(cur)) return "atom";
     return "variable";

--- a/mode/pascal/test.js
+++ b/mode/pascal/test.js
@@ -1,0 +1,13 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+(function() {
+  var mode = CodeMirror.getMode({indentUnit: 2}, "pascal");
+  function MT(name) { test.mode(name, mode, Array.prototype.slice.call(arguments, 1)); }
+
+  MT("program",
+     "[keyword program] [variable test];");
+
+  MT("program_case_insensitive",
+     "[keyword Program] [variable test];");
+})();

--- a/test/index.html
+++ b/test/index.html
@@ -27,6 +27,7 @@
 <script src="../mode/javascript/javascript.js"></script>
 <script src="../mode/jsx/jsx.js"></script>
 <script src="../mode/markdown/markdown.js"></script>
+<script src="../mode/pascal/pascal.js"></script>
 <script src="../mode/php/php.js"></script>
 <script src="../mode/python/python.js"></script>
 <script src="../mode/powershell/powershell.js"></script>
@@ -118,6 +119,7 @@
     <script src="../mode/javascript/test.js"></script>
     <script src="../mode/jsx/test.js"></script>
     <script src="../mode/markdown/test.js"></script>
+    <script src="../mode/pascal/test.js"></script>
     <script src="../mode/php/test.js"></script>
     <script src="../mode/powershell/test.js"></script>
     <script src="../mode/ruby/test.js"></script>


### PR DESCRIPTION
I added some keywords for turbo pascal taken from http://wiki.lazarus.freepascal.org/Identifiers
and made the code case insensitive which fixes #4223
I don't know much about pascal, I was only looking something easy to fix.