### PR TITLE
TypeScript: add a test for usage of interface syntax with const

### DIFF
--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -261,6 +261,12 @@
      "    ) [operator =>] [variable-3 Promise] [operator <] [variable-3 AccountHolderNotificationPreferenceInstance] [operator >];",
      "  }")
 
+  TS("typescript_interface_with_const",
+     "[keyword const] [def hello]: {",
+     "  [property prop1][operator ?]: [variable-3 string];",
+     "  [property prop2][operator ?]: [variable-3 string];",
+     "} [operator =] {};")
+
   var jsonld_mode = CodeMirror.getMode(
     {indentUnit: 2},
     {name: "javascript", jsonld: true}


### PR DESCRIPTION
Test contains a valid TypeScript code:
```
const hello: {
  prop1?: string;
  prop2?: string;
} = {};
```
Right now the test fails because prop2 gets evaluated as variable instead of property. The definition should mirror interface syntax. If this is valid:
```
interface Hello {
  prop1?: string;
  prop2?: string;
}
```
then this is also valid:
```
const hello1: Hello = {};
const hello2: {
  prop1?: string;
  prop2?: string;
} = {};
```

