### PR TITLE
TypeScript: test for multiple extends used

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -634,7 +634,11 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (type == "variable") {register(value); return cont(classNameAfter);}
   }
   function classNameAfter(type, value) {
-    if (value == "extends" || value == "implements") return cont(isTS ? typeexpr : expression, classNameAfter);
+    if (value == "extends" || value == "implements") {
+      return isTS ?
+        cont(commasep(typeexpr, "{"), pushlex("}"), classBody, poplex) :
+        cont(expression, classNameAfter);
+    }
     if (type == "{") return cont(pushlex("}"), classBody, poplex);
   }
   function classBody(type, value) {

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -273,6 +273,16 @@
      "  [property prop2][operator ?]: [variable-3 string];",
      "} [operator =] {};")
 
+  TS("typescript_double_extend",
+     "[keyword export] [keyword interface] [def UserAttributes] {",
+     "  [property id][operator ?]: [variable-3 number];",
+     "  [property createdAt][operator ?]: [variable-3 Date];",
+     "}",
+     "[keyword export] [keyword interface] [def UserInstance] [keyword extends] [variable-3 Sequelize].[variable-3 Instance][operator <][variable-3 UserAttributes][operator >], [variable-3 UserAttributes] {",
+     "  [property id]: [variable-3 number];",
+     "  [property createdAt]: [variable-3 Date];",
+     "}");
+
   var jsonld_mode = CodeMirror.getMode(
     {indentUnit: 2},
     {name: "javascript", jsonld: true}


### PR DESCRIPTION
Test for curretly failing real project code:
```
export interface UserAttributes {
  id?: number;
  createdAt?: Date;
}
export interface UserInstance extends Sequelize.Instance<UserAttributes>, UserAttributes {
  id: number;
  createdAt: Date;
}
```
NOTE: I'm not sure which elements should be marked `variable` and which should be marked `variable-3` so feel free to alter the test case as you see proper. What's the difference between those two? Thanks!