### PR TITLE
sTeX folding mode

### DIFF
--- a/addon/fold/stex-fold.js
+++ b/addon/fold/stex-fold.js
@@ -1,0 +1,159 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+// This module is based on code by William Stein, 2016,
+// licensed under a 2-clause BSD license:
+// https://github.com/williamstein/smcbsd/blob/09dbcc74c0ec5a865f654f8cadaa5e88c0bc51a6/src/smc-webapp/misc_page.coffee#L531
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  "use strict";
+
+  function get_latex_environ(s) {
+    var i, j;
+    i = s.indexOf('{');
+    j = s.indexOf('}');
+    if (i !== -1 && j !== -1) {
+      return s.slice(i + 1, j).trim();
+    } else {
+      return null;
+    }
+  }
+
+  function startswith(s, x) {
+    if (typeof x === "string") {
+      return s.indexOf(x) === 0;
+    } else {
+      for (var i = 0; i < x.length; i++) {
+        if (s.indexOf(x[i]) === 0) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
+  CodeMirror.registerHelper("fold", "stex", function(cm, start) {
+    var line = cm.getLine(start.line).trimLeft();
+    function find_close() {
+      var BEGIN = "\\begin";
+      if (startswith(line, BEGIN)) {
+        // \begin{foo}
+        // ...
+        // \end{foo}
+        // find environment close
+        var environ = get_latex_environ(line.slice(BEGIN.length));
+        if (environ == null) {
+          return [null, null];
+        }
+        var END = "\\end";
+        var level = 0;
+        var begin = new RegExp("\\\\begin\\s*{" + environ + "}");
+        var end = new RegExp("\\\\end\\s*{" + environ + "}");
+        for (var i = start.line; i <= cm.lastLine(); i++) {
+          var cur = cm.getLine(i);
+          var m = cur.search(begin);
+          var j = cur.search(end);
+          if (m !== -1 && (j === -1 || m < j)) {
+            level += 1;
+          }
+          if (j !== -1) {
+            level -= 1;
+            if (level === 0) {
+              return [i, j + END.length - 1];
+            }
+          }
+        }
+      } else if (startswith(line, "\\[")) {
+        for (var i = start.line+1; i <= cm.lastLine(); i++) {
+          if (startswith(cm.getLine(i).trimLeft(), "\\]")) {
+            return [i, 0];
+          }
+        }
+      } else if (startswith(line, "\\(")) {
+        for (var i = start.line+1; i <= cm.lastLine(); i++) {
+          if (startswith(cm.getLine(i).trimLeft(), "\\)")) {
+            return [i, 0];
+          }
+        }
+      } else if (startswith(line, "\\documentclass")) {
+        // pre-amble
+        for (var i = start.line+1; i <= cm.lastLine(); i++) {
+          if (startswith(cm.getLine(i).trimLeft(), "\\begin{document}")) {
+            return [i - 1, 0];
+          }
+        }
+      } else if (startswith(line, "\\chapter")) {
+        // book chapter
+        for (var i = start.line+1; i <= cm.lastLine(); i++) {
+          if (startswith(cm.getLine(i).trimLeft(), ["\\chapter", "\\end{document}"])) {
+            return [i - 1, 0];
+          }
+        }
+        return cm.lastLine();
+      } else if (startswith(line, "\\section")) {
+        // article section
+        for (var i = start.line+1; i <= cm.lastLine(); i++) {
+          if (startswith(cm.getLine(i).trimLeft(), ["\\chapter", "\\section", "\\end{document}"])) {
+            return [i - 1, 0];
+          }
+        }
+        return cm.lastLine();
+      } else if (startswith(line, "\\subsection")) {
+        // article subsection
+        for (var i = start.line+1; i <= cm.lastLine(); i++) {
+          if (startswith(cm.getLine(i).trimLeft(), ["\\chapter", "\\section", "\\subsection", "\\end{document}"])) {
+            return [i - 1, 0];
+          }
+        }
+        return cm.lastLine();
+      } else if (startswith(line, "\\subsubsection")) {
+        // article subsubsection
+        for (var i = start.line+1; i <= cm.lastLine(); i++) {
+          if (startswith(cm.getLine(i).trimLeft(), ["\\chapter", "\\section", "\\subsection", "\\subsubsection", "\\end{document}"])) {
+            return [i - 1, 0];
+          }
+        }
+        return cm.lastLine();
+      } else if (startswith(line, "\\subsubsubsection")) {
+        // article subsubsubsection
+        for (var i = start.line+1; i <= cm.lastLine(); i++) {
+          if (startswith(cm.getLine(i).trimLeft(), ["\\chapter", "\\section", "\\subsection", "\\subsubsection", "\\subsubsubsection", "\\end{document}"])) {
+            return [i - 1, 0];
+          }
+        }
+        return cm.lastLine();
+      } else if (startswith(line, "%\\begin{}")) {
+        // support what texmaker supports for custom folding -- http://tex.stackexchange.com/questions/44022/code-folding-in-latex
+        for (var i = start.line+1; i <= cm.lastLine(); i++) {
+          if (startswith(cm.getLine(i).trimLeft(), "%\\end{}")) {
+            return [i, 0];
+          }
+        }
+      }
+      return [null, null];  // no folding here...
+    };
+
+    var close = find_close(), i = close[0], j = close[1];
+    if (i != null) {
+      line = cm.getLine(start.line);
+      var k = line.indexOf("}");
+      if (k === -1) {
+        k = line.length;
+      }
+      return {
+        from: CodeMirror.Pos(start.line, k + 1),
+        to: CodeMirror.Pos(i, j)
+      };
+    } else {
+      // nothing to fold
+      return null;
+    }
+  });
+});

--- a/demo/folding.html
+++ b/demo/folding.html
@@ -13,10 +13,12 @@
   <script src="../addon/fold/brace-fold.js"></script>
   <script src="../addon/fold/xml-fold.js"></script>
   <script src="../addon/fold/markdown-fold.js"></script>
+  <script src="../addon/fold/stex-fold.js"></script>
   <script src="../addon/fold/comment-fold.js"></script>
   <script src="../mode/javascript/javascript.js"></script>
   <script src="../mode/xml/xml.js"></script>
   <script src="../mode/markdown/markdown.js"></script>
+  <script src="../mode/stex/stex.js"></script>
   <style type="text/css">
     .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
   </style>
@@ -43,8 +45,10 @@
     <textarea id="code" name="code"></textarea></div>
     <div style="max-width: 50em; margin-bottom: 1em">HTML:<br>
     <textarea id="code-html" name="code-html"></textarea></div>
-    <div style="max-width: 50em">Markdown:<br>
+    <div style="max-width: 50em; margin-bottom: 1em">Markdown:<br>
     <textarea id="code-markdown" name="code"></textarea></div>
+    <div style="max-width: 50em">sTeX:<br>
+    <textarea id="code-stex" name="code"></textarea></div>
   </form>
   <script id="script">
 /*
@@ -59,6 +63,8 @@ window.onload = function() {
   te_html.value = document.documentElement.innerHTML;
   var te_markdown = document.getElementById("code-markdown");
   te_markdown.value = "# Foo\n## Bar\n\nblah blah\n\n## Baz\n\nblah blah\n\n# Quux\n\nblah blah\n"
+  var te_stex = document.getElementById("code-stex");
+  te_stex.value = "\\documentclass{article}\n\\begin{document}\n\\chapter{First Chapter}\n\\section{First Section}\n\\subsection{Hello}\n\\begin{theorem}\n  All theorems are true.\n\\end{theorem}\n\\subsection{World}\n\\[\n  really big formula\n\\]\n\\chapter{Final Chapter}\n\\section{Final Section}\n\\end{document}"
 
   window.editor = CodeMirror.fromTextArea(te, {
     mode: "javascript",
@@ -83,6 +89,15 @@ window.onload = function() {
 
   window.editor_markdown = CodeMirror.fromTextArea(te_markdown, {
     mode: "markdown",
+    lineNumbers: true,
+    lineWrapping: true,
+    extraKeys: {"Ctrl-Q": function(cm){ cm.foldCode(cm.getCursor()); }},
+    foldGutter: true,
+    gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
+  });
+
+  window.editor_stex = CodeMirror.fromTextArea(te_stex, {
+    mode: "stex",
     lineNumbers: true,
     lineWrapping: true,
     extraKeys: {"Ctrl-Q": function(cm){ cm.foldCode(cm.getCursor()); }},


### PR DESCRIPTION
CodeMirror's fold mode is awesome!  There are built-in folding modules for code, braces, Markdown, XML/HTML, but not for sTeX.  (For comparison, Ace supports all of these.)  This PR fills this hole by providing **folding support in sTeX/LaTeX**.

Conveniently, @williamstein already wrote this code; I'm just putting this together into a PR (and converting from CoffeeScript to JavaScript).  See https://github.com/sagemathinc/smc/issues/1509 which requests that I do this.

I'm new to the CodeMirror source so let me know if I missed anything.  In addition to the new fold module, I added to the obvious demo.