### PR TITLE
Add "//" as a line comment for LESS and SCSS

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -732,6 +732,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
     valueKeywords: valueKeywords,
     fontProperties: fontProperties,
     allowNested: true,
+    lineComment: "//",
     tokenHooks: {
       "/": function(stream, state) {
         if (stream.eat("/")) {
@@ -774,6 +775,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
     valueKeywords: valueKeywords,
     fontProperties: fontProperties,
     allowNested: true,
+    lineComment: "//",
     tokenHooks: {
       "/": function(stream, state) {
         if (stream.eat("/")) {

--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -28,6 +28,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
       colorKeywords = parserConfig.colorKeywords || {},
       valueKeywords = parserConfig.valueKeywords || {},
       allowNested = parserConfig.allowNested,
+      lineComment = parserConfig.lineComment,
       supportsAtComponent = parserConfig.supportsAtComponent === true;
 
   var type, override;
@@ -407,6 +408,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
     electricChars: "}",
     blockCommentStart: "/*",
     blockCommentEnd: "*/",
+    lineComment: lineComment,
     fold: "brace"
   };
 });


### PR DESCRIPTION
Resolves #4509 

Adds an optional `lineComment` property in the base css mode's `parserConfig`, and sets it to `//` for `text/x-less` and `text/x-scss` mime modes.

This enables the `toggleComment` command to properly toggle single line comments, as I think most would expect when using LESS or SCSS.

Am not sure if tests are required for a change like this, but feel free to yell out if so :)

