### PR TITLE
[java mode] Make @interface a defining keyword

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -425,16 +425,19 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
                     "do else enum extends final finally float for goto if implements import " +
                     "instanceof interface native new package private protected public " +
                     "return static strictfp super switch synchronized this throw throws transient " +
-                    "try volatile while"),
+                    "try volatile while @interface"),
     types: words("byte short int long float double boolean char void Boolean Byte Character Double Float " +
                  "Integer Long Number Object Short String StringBuffer StringBuilder Void"),
     blockKeywords: words("catch class do else finally for if switch try while"),
-    defKeywords: words("class interface package enum"),
+    defKeywords: words("class interface package enum @interface"),
     typeFirstDefinitions: true,
     atoms: words("true false null"),
     number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+\.?\d*|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
     hooks: {
       "@": function(stream) {
+        // Don't match the @interface keyword.
+        if (stream.match('interface', false)) return false;
+
         stream.eatWhile(/[\w\$_]/);
         return "meta";
       }


### PR DESCRIPTION
Although `@interface` may look like any other annotation, it is in fact a keyword that works a lot like `class`. The placement is the same, and both define a new type. This makes highlighting more consistent.

![java- interface-before](https://cloud.githubusercontent.com/assets/703602/22207303/ecb09048-e17e-11e6-9f79-75eede5ccc71.png)

With the fix:
![java- interface-after](https://cloud.githubusercontent.com/assets/703602/22207307/eebe1dd8-e17e-11e6-8235-8eae78fa610f.png)
