### PR TITLE
add OCL mode

### DIFF
--- a/mode/index.html
+++ b/mode/index.html
@@ -96,6 +96,7 @@ option.</p>
       <li><a href="ntriples/index.html">NTriples</a></li>
       <li><a href="clike/index.html">Objective C</a></li>
       <li><a href="mllike/index.html">OCaml</a></li>
+      <li><a href="ocl/index.html">OCL</a> (USE-OCL flavour)</li>
       <li><a href="octave/index.html">Octave</a> (MATLAB)</li>
       <li><a href="oz/index.html">Oz</a></li>
       <li><a href="pascal/index.html">Pascal</a></li>

--- a/mode/ocl/index.html
+++ b/mode/ocl/index.html
@@ -1,0 +1,87 @@
+<!doctype html>
+
+<title>CodeMirror: OCL mode</title>
+<meta charset="utf-8"/>
+<link rel=stylesheet href="../../doc/docs.css">
+
+<link rel="stylesheet" href="../../lib/codemirror.css">
+<script src="../../lib/codemirror.js"></script>
+<script src="../../addon/mode/simple.js"></script>
+<script src="ocl.js"></script>
+<style type="text/css">.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
+<div id=nav>
+  <a href="http://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+
+  <ul>
+    <li><a href="../../index.html">Home</a>
+    <li><a href="../../doc/manual.html">Manual</a>
+    <li><a href="https://github.com/codemirror/codemirror">Code</a>
+  </ul>
+  <ul>
+    <li><a href="../index.html">Language modes</a>
+    <li><a class=active href="#">OCL</a>
+  </ul>
+</div>
+
+<article>
+<h2>OCL mode</h2>
+
+    <div><textarea id="code-ocl" name="code-ocl">
+-- OCL constraints definitions
+package bank
+
+context BankAccount
+	inv: balance >= 0
+
+context BankAccount::getBalance(): Integer
+	post: result = balance
+
+context BankAccount::debit(amount: Integer): Integer
+	pre: amount > 0 and balance - amount >= 0
+	post: balance = balance@pre - amount
+
+endpackage
+    </textarea></div>
+    <script>
+      var editor = CodeMirror.fromTextArea(document.getElementById("code-ocl"), {
+        mode: {name: "ocl"},
+        lineNumbers: true,
+        indentUnit: 4,
+        matchBrackets: true
+      });
+    </script>
+
+    <div><textarea id="code-use" name="code-use">
+-- USE OCL flavour
+
+model bank
+
+class BankAccount
+	attributes
+		balance: Int
+	operations
+		getBalance(): Integer
+		debit(amount: Integer)
+end
+
+constraints
+
+context BankAccount
+	inv: balance >= 0
+
+context BankAccount::getBalance(): Integer
+	post: result = balance
+
+context BankAccount::debit(amount: Integer): Integer
+	pre: amount > 0 and balance - amount >= 0
+	post: balance = balance@pre - amount
+    </textarea></div>
+    <script>
+      var editor = CodeMirror.fromTextArea(document.getElementById("code-use"), {
+        mode: {name: "ocl"},
+        lineNumbers: true,
+        indentUnit: 4,
+        matchBrackets: true
+      });
+    </script>
+</article>

--- a/mode/ocl/ocl.js
+++ b/mode/ocl/ocl.js
@@ -1,0 +1,40 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+// By Alexandre Terrasa.
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"), require("../../addon/mode/simple"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror", "../../addon/mode/simple"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  "use strict";
+
+  CodeMirror.defineSimpleMode("ocl", {
+    start: [
+      // OCL keywords
+      {regex: /(?:context|package|endpackage|if|then|else|endif|let|in|true|false|invalid|null|not|and|or|xor|implies)\b/, token: "keyword"},
+
+      // USE-OCL keywords
+      {regex: /(?:class|enum|end|association|between|role|model|constraints|attributes|operations)\b/, token: "keyword"},
+
+      // OCL constraints
+      {regex: /(?:inv|pre|post|body|init|derive|def)\b/, token: "tag"},
+
+      // Special keywords
+      {regex: /(?:self|result|@pre|Set|OrderedSet|Sequence|Bag)\b/, token: "def"},
+
+      // Comments
+      {regex: /--.*/, token: "comment"},
+
+      // String
+      { regex: /'(?:[^\\']|\\.)*'?/, token: "string" },
+
+      // Numerical
+      { regex: /\d+/, token: "number" }
+    ]
+  });
+});


### PR DESCRIPTION
Hey there,

This PR adds a mode for the OCL language that supports the [USE-OCL](useocl.sourceforge.net) flavor for model definition.

Example:
![image](https://cloud.githubusercontent.com/assets/583144/22579845/46aea11e-e9a1-11e6-9866-830ec9f4e6d8.png)

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>