### PR TITLE
add pep/8 mode

### DIFF
--- a/mode/index.html
+++ b/mode/index.html
@@ -100,6 +100,7 @@ option.</p>
       <li><a href="oz/index.html">Oz</a></li>
       <li><a href="pascal/index.html">Pascal</a></li>
       <li><a href="pegjs/index.html">PEG.js</a></li>
+      <li><a href="pep8/index.html">Pep/8</a></li>
       <li><a href="perl/index.html">Perl</a></li>
       <li><a href="asciiarmor/index.html">PGP (ASCII armor)</a></li>
       <li><a href="php/index.html">PHP</a></li>

--- a/mode/pep8/index.html
+++ b/mode/pep8/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+
+<title>CodeMirror: Pep/8 mode</title>
+<meta charset="utf-8"/>
+<link rel=stylesheet href="../../doc/docs.css">
+
+<link rel="stylesheet" href="../../lib/codemirror.css">
+<script src="../../lib/codemirror.js"></script>
+<script src="../../addon/mode/simple.js"></script>
+<script src="pep8.js"></script>
+<style type="text/css">.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
+<div id=nav>
+  <a href="http://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+
+  <ul>
+    <li><a href="../../index.html">Home</a>
+    <li><a href="../../doc/manual.html">Manual</a>
+    <li><a href="https://github.com/codemirror/codemirror">Code</a>
+  </ul>
+  <ul>
+    <li><a href="../index.html">Language modes</a>
+    <li><a class=active href="#">OCL</a>
+  </ul>
+</div>
+
+<article>
+<h2>Pep/8 mode</h2>
+
+    <div><textarea id="code" name="code">
+; Pep/8 mode
+
+DECI n,d
+LDA n,d
+ADDA n,i
+STA n,d
+DECO n,d
+STOP
+
+n: .BLOCK 2
+
+.END
+    </textarea></div>
+    <script>
+      var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
+        mode: {name: "pep8"},
+        lineNumbers: true,
+        indentUnit: 4,
+        matchBrackets: true
+      });
+    </script>
+</article>

--- a/mode/pep8/pep8.js
+++ b/mode/pep8/pep8.js
@@ -1,0 +1,37 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+// By Alexandre Terrasa.
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"), require("../../addon/mode/simple"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror", "../../addon/mode/simple"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  "use strict";
+
+  CodeMirror.defineSimpleMode("pep8", {
+    start: [
+      // Instructions
+      {regex: /(?:stop|rettr|movspa|movflga|br|brle|brlt|breq|brne|brge|brgt|brv|brc|call|nop|deci|deco|stro|chari|charo|addsp|subsp)\b/i, token: "keyword"},
+
+      // Instructions with register
+      {regex: /(?:not|neg|asl|asr|rol|ror|nop|add|sub|and|or|cp|ld|ldbyte|st|stbyte)(n|z|v|c|a|x|pp|co)\b/i, token: "keyword"},
+
+      // Instructions with numbers
+      {regex: /(?:ret)[0-9]\b/i, token: "keyword"},
+
+      // Directives
+      {regex: /(?:\.byte|\.word|\.block|\.ascii|\.addrss|\.equate|\.end|\.burn)\b/i, token: "def"},
+
+      // Comments
+      {regex: /;.*/, token: "comment"},
+
+      // Tags
+      {regex: /^[a-z][a-z0-9_]{0,9}:/i, token: "tag"}
+    ]
+  });
+});


### PR DESCRIPTION
Hey there,

This PR adds a mode for the [Pep/8 assembly](https://github.com/StanWarford/pep8) language.

Example:
![image](https://cloud.githubusercontent.com/assets/583144/22580038/1710928a-e9a3-11e6-89fd-b714080828b0.png)

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>