### PR TITLE
Allow to delete default bindings of the vim keymap through the API

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -4147,8 +4147,8 @@
             var mapping = {
               keys: lhs,
               type: 'keyToEx',
-              exArgs: { input: rhs.substring(1) },
-              user: true};
+              exArgs: { input: rhs.substring(1) }
+            };
             if (ctx) { mapping.context = ctx; }
             defaultKeymap.unshift(mapping);
           } else {
@@ -4156,8 +4156,7 @@
             var mapping = {
               keys: lhs,
               type: 'keyToKey',
-              toKeys: rhs,
-              user: true
+              toKeys: rhs
             };
             if (ctx) { mapping.context = ctx; }
             defaultKeymap.unshift(mapping);
@@ -4178,8 +4177,7 @@
           var keys = lhs;
           for (var i = 0; i < defaultKeymap.length; i++) {
             if (keys == defaultKeymap[i].keys
-                && defaultKeymap[i].context === ctx
-                && defaultKeymap[i].user) {
+                && defaultKeymap[i].context === ctx) {
               defaultKeymap.splice(i, 1);
               return;
             }


### PR DESCRIPTION
The current situation prevents to remove bindings from the default keymap in vim
mode. It is sometimes required to be able to delete them in order to do some
custom mapping.

Example:

1. The `h` binding is defined in the default keymap for moving left.

2. The user want to set the custom binding `h<character>` to behave like
   `r<character>`. It can do so with:

     CodeMirror.Vim.mapCommand('h<character>', 'action', 'replace', {},
                               { isEdit: true, context: 'normal' });

3. When the user press the `h` key, the code searches for all the keybindings
   matching it [1].

4. Two bindings are found:

   - The default binding `h` for moving left. This is a FULL match.
   - The user-defined `h<character>`. This is only a PARTIAL match as it is
     expecting another character.

5. The code is preferring FULL matches over PARTIAL matches whenever they are in
   competition [2]. The code then selects the move left action.

6. The way to let the user-defined binding take over is to let the user delete
   the default binding:

     CodeMirror.Vim.unmap('h');

   but this is not possible because it is not allowed to delete bindings from
   the default keymap [3].

This commit remove such differentiation by treating all bindings in the same
way, letting the responsibility to the user to not mess with the bindings he
needs.

[1] https://github.com/codemirror/CodeMirror/blob/ff84b9ee73b75851801bc4004b75e35fea6291cb/keymap/vim.js#L1098
[2] https://github.com/codemirror/CodeMirror/blob/ff84b9ee73b75851801bc4004b75e35fea6291cb/keymap/vim.js#L1099-L1103
[3] https://github.com/codemirror/CodeMirror/blob/ff84b9ee73b75851801bc4004b75e35fea6291cb/keymap/vim.js#L4182

Signed-off-by: Fabien Dubosson <fabien.dubosson@gmail.com>