### PR TITLE
[vim bindings] regexp support (sort) fixed cursor pos (ex/search)

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1245,11 +1245,13 @@
           }
         }
         function onPromptKeyUp(e, query, close) {
-          var keyName = CodeMirror.keyName(e), up;
+          var keyName = CodeMirror.keyName(e), up, offset;
           if (keyName == 'Up' || keyName == 'Down') {
             up = keyName == 'Up' ? true : false;
+            offset = e.target ? e.target.selectionEnd : 0;
             query = vimGlobalState.searchHistoryController.nextMatch(query, up) || '';
             close(query);
+            if (offset && e.target) e.target.selectionEnd = e.target.selectionStart = Math.min(offset, e.target.value.length);
           } else {
             if ( keyName != 'Left' && keyName != 'Right' && keyName != 'Ctrl' && keyName != 'Alt' && keyName != 'Shift')
               vimGlobalState.searchHistoryController.reset();
@@ -1281,6 +1283,8 @@
             clearInputState(cm);
             close();
             cm.focus();
+          } else if (keyName == 'Up' || keyName == 'Down') {
+            CodeMirror.e_stop(e);  
           } else if (keyName == 'Ctrl-U') {
             // Ctrl-U clears input.
             CodeMirror.e_stop(e);
@@ -1344,7 +1348,7 @@
           exCommandDispatcher.processCommand(cm, input);
         }
         function onPromptKeyDown(e, input, close) {
-          var keyName = CodeMirror.keyName(e), up;
+          var keyName = CodeMirror.keyName(e), up, offset;
           if (keyName == 'Esc' || keyName == 'Ctrl-C' || keyName == 'Ctrl-[' ||
               (keyName == 'Backspace' && input == '')) {
             vimGlobalState.exCommandHistoryController.pushInput(input);
@@ -1355,9 +1359,12 @@
             cm.focus();
           }
           if (keyName == 'Up' || keyName == 'Down') {
+            CodeMirror.e_stop(e);
             up = keyName == 'Up' ? true : false;
+            offset = e.target ? e.target.selectionEnd : 0;
             input = vimGlobalState.exCommandHistoryController.nextMatch(input, up) || '';
             close(input);
+            if (offset && e.target) e.target.selectionEnd = e.target.selectionStart = Math.min(offset, e.target.value.length);
           } else if (keyName == 'Ctrl-U') {
             // Ctrl-U clears input.
             CodeMirror.e_stop(e);
@@ -4310,25 +4317,27 @@
         showConfirm(cm, regInfo);
       },
       sort: function(cm, params) {
-        var reverse, ignoreCase, unique, number;
+        var reverse, ignoreCase, unique, number, pattern;
         function parseArgs() {
           if (params.argString) {
             var args = new CodeMirror.StringStream(params.argString);
             if (args.eat('!')) { reverse = true; }
             if (args.eol()) { return; }
             if (!args.eatSpace()) { return 'Invalid arguments'; }
-            var opts = args.match(/[a-z]+/);
-            if (opts) {
-              opts = opts[0];
-              ignoreCase = opts.indexOf('i') != -1;
-              unique = opts.indexOf('u') != -1;
-              var decimal = opts.indexOf('d') != -1 && 1;
-              var hex = opts.indexOf('x') != -1 && 1;
-              var octal = opts.indexOf('o') != -1 && 1;
+            var opts = args.match(/([dinuox]+)?\s*(\/.+\/)?\s*/);
+            if (!opts && !args.eol()) { return 'Invalid arguments'; }
+            if (opts[1]) {
+              ignoreCase = opts[1].indexOf('i') != -1;
+              unique = opts[1].indexOf('u') != -1;
+              var decimal = opts[1].indexOf('d') != -1 || opts[1].indexOf('n') != -1 && 1;
+              var hex = opts[1].indexOf('x') != -1 && 1;
+              var octal = opts[1].indexOf('o') != -1 && 1;
               if (decimal + hex + octal > 1) { return 'Invalid arguments'; }
               number = decimal && 'decimal' || hex && 'hex' || octal && 'octal';
             }
-            if (args.match(/\/.*\//)) { return 'patterns not supported'; }
+            if (opts[2]) {
+              pattern = new RegExp(opts[2].substr(1, opts[2].length - 2), ignoreCase ? 'i' : '');
+            }
           }
         }
         var err = parseArgs();
@@ -4342,14 +4351,18 @@
         var curStart = Pos(lineStart, 0);
         var curEnd = Pos(lineEnd, lineLength(cm, lineEnd));
         var text = cm.getRange(curStart, curEnd).split('\n');
-        var numberRegex = (number == 'decimal') ? /(-?)([\d]+)/ :
+        var numberRegex = pattern ? pattern :
+           (number == 'decimal') ? /(-?)([\d]+)/ :
            (number == 'hex') ? /(-?)(?:0x)?([0-9a-f]+)/i :
            (number == 'octal') ? /([0-7]+)/ : null;
         var radix = (number == 'decimal') ? 10 : (number == 'hex') ? 16 : (number == 'octal') ? 8 : null;
         var numPart = [], textPart = [];
-        if (number) {
+        if (number || pattern) {
           for (var i = 0; i < text.length; i++) {
-            if (numberRegex.exec(text[i])) {
+            var matchPart = pattern ? text[i].match(pattern) : null;
+            if (matchPart && matchPart[0] != '') {
+              numPart.push(matchPart);
+            } else if (!pattern && numberRegex.exec(text[i])) {
               numPart.push(text[i]);
             } else {
               textPart.push(text[i]);
@@ -4368,8 +4381,17 @@
           bnum = parseInt((bnum[1] + bnum[2]).toLowerCase(), radix);
           return anum - bnum;
         }
-        numPart.sort(compareFn);
-        textPart.sort(compareFn);
+        function comparePatternFn(a, b) {
+          if (reverse) { var tmp; tmp = a; a = b; b = tmp; }
+          if (ignoreCase) { a[0] = a[0].toLowerCase(); b[0] = b[0].toLowerCase(); }
+          return (a[0] < b[0]) ? -1 : 1;
+        }
+        numPart.sort(pattern ? comparePatternFn : compareFn);
+        if (pattern) {
+          for (var i = 0; i < numPart.length; i++) {
+            numPart[i] = numPart[i].input;
+          }
+        } else if (!number) { textPart.sort(compareFn); }
         text = (!reverse) ? textPart.concat(numPart) : numPart.concat(textPart);
         if (unique) { // Remove duplicate lines
           var textOld = text;

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1,4 +1,3 @@
-var Pos = CodeMirror.Pos;
 CodeMirror.Vim.suppressErrorLogging = true;
 
 var code = '' +
@@ -40,63 +39,63 @@ var bracesLine = lines[3];
 var seekBraceLine = lines[4];
 
 var word1 = {
-  start: new Pos(wordLine.line, 1),
-  end: new Pos(wordLine.line, 5)
+  start: { line: wordLine.line, ch: 1 },
+  end: { line: wordLine.line, ch: 5 }
 };
 var word2 = {
-  start: new Pos(wordLine.line, word1.end.ch + 2),
-  end: new Pos(wordLine.line, word1.end.ch + 4)
+  start: { line: wordLine.line, ch: word1.end.ch + 2 },
+  end: { line: wordLine.line, ch: word1.end.ch + 4 }
 };
 var word3 = {
-  start: new Pos(bigWordLine.line, 1),
-  end: new Pos(bigWordLine.line, 5)
+  start: { line: bigWordLine.line, ch: 1 },
+  end: { line: bigWordLine.line, ch: 5 }
 };
 var bigWord1 = word1;
 var bigWord2 = word2;
 var bigWord3 = {
-  start: new Pos(bigWordLine.line, 1),
-  end: new Pos(bigWordLine.line, 7)
+  start: { line: bigWordLine.line, ch: 1 },
+  end: { line: bigWordLine.line, ch: 7 }
 };
 var bigWord4 = {
-  start: new Pos(bigWordLine.line, bigWord1.end.ch + 3),
-  end: new Pos(bigWordLine.line, bigWord1.end.ch + 7)
+  start: { line: bigWordLine.line, ch: bigWord1.end.ch + 3 },
+  end: { line: bigWordLine.line, ch: bigWord1.end.ch + 7 }
 };
 
-var oChars = [ new Pos(charLine.line, 1),
-    new Pos(charLine.line, 3),
-    new Pos(charLine.line, 7) ];
-var pChars = [ new Pos(charLine.line, 2),
-    new Pos(charLine.line, 4),
-    new Pos(charLine.line, 6),
-    new Pos(charLine.line, 8) ];
-var numChars = [ new Pos(charLine.line, 10),
-    new Pos(charLine.line, 12),
-    new Pos(charLine.line, 14),
-    new Pos(charLine.line, 16),
-    new Pos(charLine.line, 18)];
+var oChars = [ { line: charLine.line, ch: 1 },
+    { line: charLine.line, ch: 3 },
+    { line: charLine.line, ch: 7 } ];
+var pChars = [ { line: charLine.line, ch: 2 },
+    { line: charLine.line, ch: 4 },
+    { line: charLine.line, ch: 6 },
+    { line: charLine.line, ch: 8 } ];
+var numChars = [ { line: charLine.line, ch: 10 },
+    { line: charLine.line, ch: 12 },
+    { line: charLine.line, ch: 14 },
+    { line: charLine.line, ch: 16 },
+    { line: charLine.line, ch: 18 }];
 var parens1 = {
-  start: new Pos(bracesLine.line, 1),
-  end: new Pos(bracesLine.line, 3)
+  start: { line: bracesLine.line, ch: 1 },
+  end: { line: bracesLine.line, ch: 3 }
 };
 var squares1 = {
-  start: new Pos(bracesLine.line, 5),
-  end: new Pos(bracesLine.line, 7)
+  start: { line: bracesLine.line, ch: 5 },
+  end: { line: bracesLine.line, ch: 7 }
 };
 var curlys1 = {
-  start: new Pos(bracesLine.line, 9),
-  end: new Pos(bracesLine.line, 11)
+  start: { line: bracesLine.line, ch: 9 },
+  end: { line: bracesLine.line, ch: 11 }
 };
 var seekOutside = {
-  start: new Pos(seekBraceLine.line, 1),
-  end: new Pos(seekBraceLine.line, 16)
+  start: { line: seekBraceLine.line, ch: 1 },
+  end: { line: seekBraceLine.line, ch: 16 }
 };
 var seekInside = {
-  start: new Pos(seekBraceLine.line, 14),
-  end: new Pos(seekBraceLine.line, 11)
+  start: { line: seekBraceLine.line, ch: 14 },
+  end: { line: seekBraceLine.line, ch: 11 }
 };
 
 function copyCursor(cur) {
-  return new Pos(cur.line, cur.ch);
+  return { ch: cur.ch, line: cur.line };
 }
 
 function forEach(arr, func) {
@@ -174,7 +173,7 @@ function testVim(name, run, opts, expectedFail) {
         } else {
           pos = makeCursor(line, ch);
         }
-        eqCursorPos(cm.getCursor(), pos);
+        eqPos(pos, cm.getCursor());
       }
     }
     function fakeOpenDialog(result) {
@@ -293,7 +292,7 @@ testJumplist('jumplist_skip_deleted_mark<c-i>',
 function testMotion(name, keys, endPos, startPos) {
   testVim(name, function(cm, vim, helpers) {
     if (!startPos) {
-      startPos = new Pos(0, 0);
+      startPos = { line: 0, ch: 0 };
     }
     cm.setCursor(startPos);
     helpers.doKeys(keys);
@@ -302,11 +301,11 @@ function testMotion(name, keys, endPos, startPos) {
 };
 
 function makeCursor(line, ch) {
-  return new Pos(line, ch);
+  return { line: line, ch: ch };
 };
 
 function offsetCursor(cur, offsetLine, offsetCh) {
-  return new Pos(cur.line + offsetLine, cur.ch + offsetCh);
+  return { line: cur.line + offsetLine, ch: cur.ch + offsetCh };
 };
 
 // Motion tests
@@ -409,20 +408,20 @@ testVim('Changing lines after Eol operation', function(cm, vim, helpers) {
   helpers.doKeys(['$']);
   helpers.doKeys(['j']);
   // After moving to Eol and then down, we should be at Eol of line 2
-  helpers.assertCursorAt(new Pos(1, lines[1].length - 1));
+  helpers.assertCursorAt({ line: 1, ch: lines[1].length - 1 });
   helpers.doKeys(['j']);
   // After moving down, we should be at Eol of line 3
-  helpers.assertCursorAt(new Pos(2, lines[2].length - 1));
+  helpers.assertCursorAt({ line: 2, ch: lines[2].length - 1 });
   helpers.doKeys(['h']);
   helpers.doKeys(['j']);
   // After moving back one space and then down, since line 4 is shorter than line 2, we should
   // be at Eol of line 2 - 1
-  helpers.assertCursorAt(new Pos(3, lines[3].length - 1));
+  helpers.assertCursorAt({ line: 3, ch: lines[3].length - 1 });
   helpers.doKeys(['j']);
   helpers.doKeys(['j']);
   // After moving down again, since line 3 has enough characters, we should be back to the
   // same place we were at on line 1
-  helpers.assertCursorAt(new Pos(5, lines[2].length - 2));
+  helpers.assertCursorAt({ line: 5, ch: lines[2].length - 2 });
 });
 //making sure gj and gk recover from clipping
 testVim('gj_gk_clipping', function(cm,vim,helpers){
@@ -471,7 +470,7 @@ testVim('gj_gk', function(cm, vim, helpers) {
   // Test moving down preserves column position.
   helpers.doKeys('g', 'j');
   var pos1 = cm.getCursor();
-  var expectedPos2 = new Pos(0, (pos1.ch - 4) * 2 + 4);
+  var expectedPos2 = { line: 0, ch: (pos1.ch - 4) * 2 + 4};
   helpers.doKeys('g', 'j');
   helpers.assertCursorAt(expectedPos2);
 
@@ -531,14 +530,14 @@ testVim('paragraph_motions', function(cm, vim, helpers) {
   // ip inside empty space
   cm.setCursor(10, 0);
   helpers.doKeys('v', 'i', 'p');
-  eqCursorPos(Pos(7, 0), cm.getCursor('anchor'));
-  eqCursorPos(Pos(12, 0), cm.getCursor('head'));
+  eqPos(Pos(7, 0), cm.getCursor('anchor'));
+  eqPos(Pos(12, 0), cm.getCursor('head'));
   helpers.doKeys('i', 'p');
-  eqCursorPos(Pos(7, 0), cm.getCursor('anchor'));
-  eqCursorPos(Pos(13, 1), cm.getCursor('head'));
+  eqPos(Pos(7, 0), cm.getCursor('anchor'));
+  eqPos(Pos(13, 1), cm.getCursor('head'));
   helpers.doKeys('2', 'i', 'p');
-  eqCursorPos(Pos(7, 0), cm.getCursor('anchor'));
-  eqCursorPos(Pos(16, 1), cm.getCursor('head'));
+  eqPos(Pos(7, 0), cm.getCursor('anchor'));
+  eqPos(Pos(16, 1), cm.getCursor('head'));
 
   // should switch to visualLine mode
   cm.setCursor(14, 0);
@@ -547,31 +546,31 @@ testVim('paragraph_motions', function(cm, vim, helpers) {
 
   cm.setCursor(14, 0);
   helpers.doKeys('<Esc>', 'V', 'i', 'p');
-  eqCursorPos(Pos(16, 1), cm.getCursor('head'));
+  eqPos(Pos(16, 1), cm.getCursor('head'));
 
   // ap inside empty space
   cm.setCursor(10, 0);
   helpers.doKeys('<Esc>', 'v', 'a', 'p');
-  eqCursorPos(Pos(7, 0), cm.getCursor('anchor'));
-  eqCursorPos(Pos(13, 1), cm.getCursor('head'));
+  eqPos(Pos(7, 0), cm.getCursor('anchor'));
+  eqPos(Pos(13, 1), cm.getCursor('head'));
   helpers.doKeys('a', 'p');
-  eqCursorPos(Pos(7, 0), cm.getCursor('anchor'));
-  eqCursorPos(Pos(16, 1), cm.getCursor('head'));
+  eqPos(Pos(7, 0), cm.getCursor('anchor'));
+  eqPos(Pos(16, 1), cm.getCursor('head'));
 
   cm.setCursor(13, 0);
   helpers.doKeys('v', 'a', 'p');
-  eqCursorPos(Pos(13, 0), cm.getCursor('anchor'));
-  eqCursorPos(Pos(14, 0), cm.getCursor('head'));
+  eqPos(Pos(13, 0), cm.getCursor('anchor'));
+  eqPos(Pos(14, 0), cm.getCursor('head'));
 
   cm.setCursor(16, 0);
   helpers.doKeys('v', 'a', 'p');
-  eqCursorPos(Pos(14, 0), cm.getCursor('anchor'));
-  eqCursorPos(Pos(16, 1), cm.getCursor('head'));
+  eqPos(Pos(14, 0), cm.getCursor('anchor'));
+  eqPos(Pos(16, 1), cm.getCursor('head'));
 
   cm.setCursor(0, 0);
   helpers.doKeys('v', 'a', 'p');
-  eqCursorPos(Pos(0, 0), cm.getCursor('anchor'));
-  eqCursorPos(Pos(4, 0), cm.getCursor('head'));
+  eqPos(Pos(0, 0), cm.getCursor('anchor'));
+  eqPos(Pos(4, 0), cm.getCursor('head'));
 
   cm.setCursor(0, 0);
   helpers.doKeys('d', 'i', 'p');
@@ -593,7 +592,7 @@ testVim('dl', function(cm, vim, helpers) {
   var register = helpers.getRegisterController().getRegister();
   eq(' ', register.toString());
   is(!register.linewise);
-  eqCursorPos(curStart, cm.getCursor());
+  eqPos(curStart, cm.getCursor());
 }, { value: ' word1 ' });
 testVim('dl_eol', function(cm, vim, helpers) {
   cm.setCursor(0, 6);
@@ -612,7 +611,7 @@ testVim('dl_repeat', function(cm, vim, helpers) {
   var register = helpers.getRegisterController().getRegister();
   eq(' w', register.toString());
   is(!register.linewise);
-  eqCursorPos(curStart, cm.getCursor());
+  eqPos(curStart, cm.getCursor());
 }, { value: ' word1 ' });
 testVim('dh', function(cm, vim, helpers) {
   var curStart = makeCursor(0, 3);
@@ -622,7 +621,7 @@ testVim('dh', function(cm, vim, helpers) {
   var register = helpers.getRegisterController().getRegister();
   eq('o', register.toString());
   is(!register.linewise);
-  eqCursorPos(offsetCursor(curStart, 0 , -1), cm.getCursor());
+  eqPos(offsetCursor(curStart, 0 , -1), cm.getCursor());
 }, { value: ' word1 ' });
 testVim('dj', function(cm, vim, helpers) {
   var curStart = makeCursor(0, 3);
@@ -672,7 +671,7 @@ testVim('dw_space', function(cm, vim, helpers) {
   var register = helpers.getRegisterController().getRegister();
   eq(' ', register.toString());
   is(!register.linewise);
-  eqCursorPos(curStart, cm.getCursor());
+  eqPos(curStart, cm.getCursor());
 }, { value: ' word1 ' });
 testVim('dw_word', function(cm, vim, helpers) {
   var curStart = makeCursor(0, 1);
@@ -682,7 +681,7 @@ testVim('dw_word', function(cm, vim, helpers) {
   var register = helpers.getRegisterController().getRegister();
   eq('word1 ', register.toString());
   is(!register.linewise);
-  eqCursorPos(curStart, cm.getCursor());
+  eqPos(curStart, cm.getCursor());
 }, { value: ' word1 word2' });
 testVim('dw_unicode_word', function(cm, vim, helpers) {
   helpers.doKeys('d', 'w');
@@ -852,7 +851,7 @@ testVim('d_inclusive', function(cm, vim, helpers) {
   var register = helpers.getRegisterController().getRegister();
   eq('word1', register.toString());
   is(!register.linewise);
-  eqCursorPos(curStart, cm.getCursor());
+  eqPos(curStart, cm.getCursor());
 }, { value: ' word1 ' });
 testVim('d_reverse', function(cm, vim, helpers) {
   // Test that deleting in reverse works.
@@ -866,8 +865,8 @@ testVim('d_reverse', function(cm, vim, helpers) {
 }, { value: ' word1\nword2 ' });
 testVim('dd', function(cm, vim, helpers) {
   cm.setCursor(0, 3);
-  var expectedBuffer = cm.getRange(new Pos(0, 0),
-    new Pos(1, 0));
+  var expectedBuffer = cm.getRange({ line: 0, ch: 0 },
+    { line: 1, ch: 0 });
   var expectedLineCount = cm.lineCount() - 1;
   helpers.doKeys('d', 'd');
   eq(expectedLineCount, cm.lineCount());
@@ -878,8 +877,8 @@ testVim('dd', function(cm, vim, helpers) {
 });
 testVim('dd_prefix_repeat', function(cm, vim, helpers) {
   cm.setCursor(0, 3);
-  var expectedBuffer = cm.getRange(new Pos(0, 0),
-    new Pos(2, 0));
+  var expectedBuffer = cm.getRange({ line: 0, ch: 0 },
+    { line: 2, ch: 0 });
   var expectedLineCount = cm.lineCount() - 2;
   helpers.doKeys('2', 'd', 'd');
   eq(expectedLineCount, cm.lineCount());
@@ -890,8 +889,8 @@ testVim('dd_prefix_repeat', function(cm, vim, helpers) {
 });
 testVim('dd_motion_repeat', function(cm, vim, helpers) {
   cm.setCursor(0, 3);
-  var expectedBuffer = cm.getRange(new Pos(0, 0),
-    new Pos(2, 0));
+  var expectedBuffer = cm.getRange({ line: 0, ch: 0 },
+    { line: 2, ch: 0 });
   var expectedLineCount = cm.lineCount() - 2;
   helpers.doKeys('d', '2', 'd');
   eq(expectedLineCount, cm.lineCount());
@@ -902,8 +901,8 @@ testVim('dd_motion_repeat', function(cm, vim, helpers) {
 });
 testVim('dd_multiply_repeat', function(cm, vim, helpers) {
   cm.setCursor(0, 3);
-  var expectedBuffer = cm.getRange(new Pos(0, 0),
-    new Pos(6, 0));
+  var expectedBuffer = cm.getRange({ line: 0, ch: 0 },
+    { line: 6, ch: 0 });
   var expectedLineCount = cm.lineCount() - 6;
   helpers.doKeys('2', 'd', '3', 'd');
   eq(expectedLineCount, cm.lineCount());
@@ -940,20 +939,20 @@ testVim('yw_repeat', function(cm, vim, helpers) {
   var register = helpers.getRegisterController().getRegister();
   eq('word1\nword2', register.toString());
   is(!register.linewise);
-  eqCursorPos(curStart, cm.getCursor());
+  eqPos(curStart, cm.getCursor());
 }, { value: ' word1\nword2' });
 testVim('yy_multiply_repeat', function(cm, vim, helpers) {
   var curStart = makeCursor(0, 3);
   cm.setCursor(curStart);
-  var expectedBuffer = cm.getRange(new Pos(0, 0),
-    new Pos(6, 0));
+  var expectedBuffer = cm.getRange({ line: 0, ch: 0 },
+    { line: 6, ch: 0 });
   var expectedLineCount = cm.lineCount();
   helpers.doKeys('2', 'y', '3', 'y');
   eq(expectedLineCount, cm.lineCount());
   var register = helpers.getRegisterController().getRegister();
   eq(expectedBuffer, register.toString());
   is(register.linewise);
-  eqCursorPos(curStart, cm.getCursor());
+  eqPos(curStart, cm.getCursor());
 });
 // Change commands behave like d commands except that it also enters insert
 // mode. In addition, when the change is linewise, an additional newline is
@@ -974,13 +973,13 @@ testVim('cw_repeat', function(cm, vim, helpers) {
   var register = helpers.getRegisterController().getRegister();
   eq('word1\nword2', register.toString());
   is(!register.linewise);
-  eqCursorPos(curStart, cm.getCursor());
+  eqPos(curStart, cm.getCursor());
   eq('vim-insert', cm.getOption('keyMap'));
 }, { value: ' word1\nword2' });
 testVim('cc_multiply_repeat', function(cm, vim, helpers) {
   cm.setCursor(0, 3);
-  var expectedBuffer = cm.getRange(new Pos(0, 0),
-    new Pos(6, 0));
+  var expectedBuffer = cm.getRange({ line: 0, ch: 0 },
+    { line: 6, ch: 0 });
   var expectedLineCount = cm.lineCount() - 5;
   helpers.doKeys('2', 'c', '3', 'c');
   eq(expectedLineCount, cm.lineCount());
@@ -1074,7 +1073,7 @@ testVim('g~w_repeat', function(cm, vim, helpers) {
   var register = helpers.getRegisterController().getRegister();
   eq('', register.toString());
   is(!register.linewise);
-  eqCursorPos(curStart, cm.getCursor());
+  eqPos(curStart, cm.getCursor());
 }, { value: ' word1\nword2' });
 testVim('g~g~', function(cm, vim, helpers) {
   var curStart = makeCursor(0, 3);
@@ -1086,7 +1085,7 @@ testVim('g~g~', function(cm, vim, helpers) {
   var register = helpers.getRegisterController().getRegister();
   eq('', register.toString());
   is(!register.linewise);
-  eqCursorPos(curStart, cm.getCursor());
+  eqPos(curStart, cm.getCursor());
 }, { value: ' word1\nword2\nword3\nword4\nword5\nword6' });
 testVim('gu_and_gU', function(cm, vim, helpers) {
   var curStart = makeCursor(0, 7);
@@ -1094,21 +1093,21 @@ testVim('gu_and_gU', function(cm, vim, helpers) {
   cm.setCursor(curStart);
   helpers.doKeys('2', 'g', 'U', 'w');
   eq(cm.getValue(), 'wa wb xX WC wd');
-  eqCursorPos(curStart, cm.getCursor());
+  eqPos(curStart, cm.getCursor());
   helpers.doKeys('2', 'g', 'u', 'w');
   eq(cm.getValue(), value);
 
   helpers.doKeys('2', 'g', 'U', 'B');
   eq(cm.getValue(), 'wa WB Xx wc wd');
-  eqCursorPos(makeCursor(0, 3), cm.getCursor());
+  eqPos(makeCursor(0, 3), cm.getCursor());
 
   cm.setCursor(makeCursor(0, 4));
   helpers.doKeys('g', 'u', 'i', 'w');
   eq(cm.getValue(), 'wa wb Xx wc wd');
-  eqCursorPos(makeCursor(0, 3), cm.getCursor());
+  eqPos(makeCursor(0, 3), cm.getCursor());
 
   // TODO: support gUgU guu
-  // eqCursorPos(makeCursor(0, 0), cm.getCursor());
+  // eqPos(makeCursor(0, 0), cm.getCursor());
 
   var register = helpers.getRegisterController().getRegister();
   eq('', register.toString());
@@ -1261,7 +1260,7 @@ testEdit('di[_on_(_should_not_delete', 'foo (bAr) baz', /\(/, 'di[', 'foo (bAr) 
 testEdit('di[_on_)_should_not_delete', 'foo (bAr) baz', /\)/, 'di[', 'foo (bAr) baz');
 testEdit('da[_on_(_should_not_delete', 'foo (bAr) baz', /\(/, 'da[', 'foo (bAr) baz');
 testEdit('da[_on_)_should_not_delete', 'foo (bAr) baz', /\)/, 'da[', 'foo (bAr) baz');
-testMotion('di(_outside_should_stay', ['d', 'i', '('], new Pos(0, 0), new Pos(0, 0));
+testMotion('di(_outside_should_stay', ['d', 'i', '('], { line: 0, ch: 0}, { line: 0, ch: 0});
 
 //  Open and close on different lines, equally indented
 testEdit('di{_middle_spc', 'a{\n\tbar\n}b', /r/, 'di{', 'a{}b');
@@ -1333,7 +1332,7 @@ testVim('C', function(cm, vim, helpers) {
   var register = helpers.getRegisterController().getRegister();
   eq('rd1', register.toString());
   is(!register.linewise);
-  eqCursorPos(curStart, cm.getCursor());
+  eqPos(curStart, cm.getCursor());
   eq('vim-insert', cm.getOption('keyMap'));
 }, { value: ' word1\nword2\n word3' });
 testVim('Y', function(cm, vim, helpers) {
@@ -1446,7 +1445,7 @@ testVim('i_overwrite_backspace', function(cm, vim, helpers) {
   helpers.doKeys('i');
   helpers.doKeys('<Ins>');
   helpers.doInsertModeKeys('Backspace');
-  helpers.assertCursorAt(Pos(0, 9, "after"));
+  helpers.assertCursorAt(0, 9);
   eq('0123456789', cm.getValue());
 }, { value: '0123456789'});
 testVim('A', function(cm, vim, helpers) {
@@ -1879,7 +1878,7 @@ testVim('delmark_all', function(cm, vim, helpers) {
 testVim('visual', function(cm, vim, helpers) {
   helpers.doKeys('l', 'v', 'l', 'l');
   helpers.assertCursorAt(0, 4);
-  eqCursorPos(makeCursor(0, 1), cm.getCursor('anchor'));
+  eqPos(makeCursor(0, 1), cm.getCursor('anchor'));
   helpers.doKeys('d');
   eq('15', cm.getValue());
 }, { value: '12345' });
@@ -1911,24 +1910,24 @@ testVim('visual_crossover_left', function(cm, vim, helpers) {
 testVim('visual_crossover_up', function(cm, vim, helpers) {
   cm.setCursor(3, 2);
   helpers.doKeys('v', 'j', 'k', 'k');
-  eqCursorPos(Pos(2, 2), cm.getCursor('head'));
-  eqCursorPos(Pos(3, 3), cm.getCursor('anchor'));
+  eqPos(Pos(2, 2), cm.getCursor('head'));
+  eqPos(Pos(3, 3), cm.getCursor('anchor'));
   helpers.doKeys('k');
-  eqCursorPos(Pos(1, 2), cm.getCursor('head'));
-  eqCursorPos(Pos(3, 3), cm.getCursor('anchor'));
+  eqPos(Pos(1, 2), cm.getCursor('head'));
+  eqPos(Pos(3, 3), cm.getCursor('anchor'));
 }, { value: 'cross\ncross\ncross\ncross\ncross\n'});
 testVim('visual_crossover_down', function(cm, vim, helpers) {
   cm.setCursor(1, 2);
   helpers.doKeys('v', 'k', 'j', 'j');
-  eqCursorPos(Pos(2, 3), cm.getCursor('head'));
-  eqCursorPos(Pos(1, 2), cm.getCursor('anchor'));
+  eqPos(Pos(2, 3), cm.getCursor('head'));
+  eqPos(Pos(1, 2), cm.getCursor('anchor'));
   helpers.doKeys('j');
-  eqCursorPos(Pos(3, 3), cm.getCursor('head'));
-  eqCursorPos(Pos(1, 2), cm.getCursor('anchor'));
+  eqPos(Pos(3, 3), cm.getCursor('head'));
+  eqPos(Pos(1, 2), cm.getCursor('anchor'));
 }, { value: 'cross\ncross\ncross\ncross\ncross\n'});
 testVim('visual_exit', function(cm, vim, helpers) {
   helpers.doKeys('<C-v>', 'l', 'j', 'j', '<Esc>');
-  eqCursorPos(cm.getCursor('anchor'), cm.getCursor('head'));
+  eqPos(cm.getCursor('anchor'), cm.getCursor('head'));
   eq(vim.visualMode, false);
 }, { value: 'hello\nworld\nfoo' });
 testVim('visual_line', function(cm, vim, helpers) {
@@ -2011,7 +2010,7 @@ testVim('visual_block_crossing_short_line', function(cm, vim, helpers) {
 testVim('visual_block_curPos_on_exit', function(cm, vim, helpers) {
   cm.setCursor(0, 0);
   helpers.doKeys('<C-v>', '3' , 'l', '<Esc>');
-  eqCursorPos(makeCursor(0, 3), cm.getCursor());
+  eqPos(makeCursor(0, 3), cm.getCursor());
   helpers.doKeys('h', '<C-v>', '2' , 'j' ,'3' , 'l');
   eq(cm.getSelections().join(), "3456,,cdef");
   helpers.doKeys('4' , 'h');
@@ -2046,7 +2045,7 @@ testVim('visual_blank', function(cm, vim, helpers) {
 testVim('reselect_visual', function(cm, vim, helpers) {
   helpers.doKeys('l', 'v', 'l', 'l', 'l', 'y', 'g', 'v');
   helpers.assertCursorAt(0, 5);
-  eqCursorPos(makeCursor(0, 1), cm.getCursor('anchor'));
+  eqPos(makeCursor(0, 1), cm.getCursor('anchor'));
   helpers.doKeys('v');
   cm.setCursor(1, 0);
   helpers.doKeys('v', 'l', 'l', 'p');
@@ -2055,15 +2054,15 @@ testVim('reselect_visual', function(cm, vim, helpers) {
   helpers.doKeys('g', 'v');
   // here the fake cursor is at (1, 3)
   helpers.assertCursorAt(1, 4);
-  eqCursorPos(makeCursor(1, 0), cm.getCursor('anchor'));
+  eqPos(makeCursor(1, 0), cm.getCursor('anchor'));
   helpers.doKeys('v');
   cm.setCursor(2, 0);
   helpers.doKeys('v', 'l', 'l', 'g', 'v');
   helpers.assertCursorAt(1, 4);
-  eqCursorPos(makeCursor(1, 0), cm.getCursor('anchor'));
+  eqPos(makeCursor(1, 0), cm.getCursor('anchor'));
   helpers.doKeys('g', 'v');
   helpers.assertCursorAt(2, 3);
-  eqCursorPos(makeCursor(2, 0), cm.getCursor('anchor'));
+  eqPos(makeCursor(2, 0), cm.getCursor('anchor'));
   eq('123456\n2345\nbar', cm.getValue());
 }, { value: '123456\nfoo\nbar' });
 testVim('reselect_visual_line', function(cm, vim, helpers) {
@@ -2079,14 +2078,14 @@ testVim('reselect_visual_block', function(cm, vim, helpers) {
   helpers.doKeys('<C-v>', 'k', 'h', '<C-v>');
   cm.setCursor(2, 1);
   helpers.doKeys('v', 'l', 'g', 'v');
-  eqCursorPos(Pos(1, 2), vim.sel.anchor);
-  eqCursorPos(Pos(0, 1), vim.sel.head);
+  eqPos(Pos(1, 2), vim.sel.anchor);
+  eqPos(Pos(0, 1), vim.sel.head);
   // Ensure selection is done with visual block mode rather than one
   // continuous range.
   eq(cm.getSelections().join(''), '23oo')
   helpers.doKeys('g', 'v');
-  eqCursorPos(Pos(2, 1), vim.sel.anchor);
-  eqCursorPos(Pos(2, 2), vim.sel.head);
+  eqPos(Pos(2, 1), vim.sel.anchor);
+  eqPos(Pos(2, 2), vim.sel.head);
   helpers.doKeys('<Esc>');
   // Ensure selection of deleted range
   cm.setCursor(1, 1);
@@ -2121,14 +2120,14 @@ testVim('o_visual', function(cm, vim, helpers) {
 testVim('o_visual_block', function(cm, vim, helpers) {
   cm.setCursor(0, 1);
   helpers.doKeys('<C-v>','3','j','l','l', 'o');
-  eqCursorPos(Pos(3, 3), vim.sel.anchor);
-  eqCursorPos(Pos(0, 1), vim.sel.head);
+  eqPos(Pos(3, 3), vim.sel.anchor);
+  eqPos(Pos(0, 1), vim.sel.head);
   helpers.doKeys('O');
-  eqCursorPos(Pos(3, 1), vim.sel.anchor);
-  eqCursorPos(Pos(0, 3), vim.sel.head);
+  eqPos(Pos(3, 1), vim.sel.anchor);
+  eqPos(Pos(0, 3), vim.sel.head);
   helpers.doKeys('o');
-  eqCursorPos(Pos(0, 3), vim.sel.anchor);
-  eqCursorPos(Pos(3, 1), vim.sel.head);
+  eqPos(Pos(0, 3), vim.sel.anchor);
+  eqPos(Pos(3, 1), vim.sel.head);
 }, { value: 'abcd\nefgh\nijkl\nmnop'});
 testVim('changeCase_visual', function(cm, vim, helpers) {
   cm.setCursor(0, 0);
@@ -3477,24 +3476,44 @@ testVim('ex_sort_hex', function(cm, vim, helpers) {
 }, { value: '6\nd3\n s5\n&0xB\n.9'});
 testVim('ex_sort_octal', function(cm, vim, helpers) {
   helpers.doEx('sort o');
-  eq('.8\n.9\nd3\n s5\n6', cm.getValue());
+  eq('.9\n.8\nd3\n s5\n6', cm.getValue());
 }, { value: '6\nd3\n s5\n.9\n.8'});
 testVim('ex_sort_decimal_mixed', function(cm, vim, helpers) {
   helpers.doEx('sort d');
-  eq('y\nz\nc1\nb2\na3', cm.getValue());
+  eq('z\ny\nc1\nb2\na3', cm.getValue());
 }, { value: 'a3\nz\nc1\ny\nb2'});
 testVim('ex_sort_decimal_mixed_reverse', function(cm, vim, helpers) {
-  helpers.doEx('sort! d');
+  helpers.doEx('sort! n');
   eq('a3\nb2\nc1\nz\ny', cm.getValue());
 }, { value: 'a3\nz\nc1\ny\nb2'});
-testVim('ex_sort_patterns_not_supported', function(cm, vim, helpers) {
-  var notified = false;
-  cm.openNotification = helpers.fakeOpenNotification(function(text) {
-    notified = /patterns not supported/.test(text);
-  });
-  helpers.doEx('sort /abc/');
-  is(notified, 'No notification.');
-});
+testVim('ex_sort_pattern_alpha', function(cm, vim, helpers) {
+  helpers.doEx('sort /[a-z]/');
+  eq('a3\nb2\nc1\ny\nz', cm.getValue());
+}, { value: 'z\ny\nc1\nb2\na3'});
+testVim('ex_sort_pattern_alpha_reverse', function(cm, vim, helpers) {
+  helpers.doEx('sort! /[a-z]/');
+  eq('z\ny\nc1\nb2\na3', cm.getValue());
+}, { value: 'z\ny\nc1\nb2\na3'});
+testVim('ex_sort_pattern_alpha_ignoreCase', function(cm, vim, helpers) {
+  helpers.doEx('sort i/[a-z]/');
+  eq('a3\nb2\nC1\nY\nz', cm.getValue());
+}, { value: 'z\nY\nC1\nb2\na3'});
+testVim('ex_sort_pattern_alpha_longer', function(cm, vim, helpers) {
+  helpers.doEx('sort /[a-z]+/');
+  eq('a\naa\nab\nade\nadele\nadelle\nadriana\nalex\nalexandra\nb\nc\ny\nz', cm.getValue());
+}, { value: 'z\nab\naa\nade\nadelle\nalexandra\nalex\nadriana\nadele\ny\nc\nb\na'});
+testVim('ex_sort_pattern_alpha_only', function(cm, vim, helpers) {
+  helpers.doEx('sort /^[a-z]$/');
+  eq('z1\ny2\na3\nb\nc', cm.getValue());
+}, { value: 'z1\ny2\na3\nc\nb'});
+testVim('ex_sort_pattern_alpha_only_reverse', function(cm, vim, helpers) {
+  helpers.doEx('sort! /^[a-z]$/');
+  eq('c\nb\nz1\ny2\na3', cm.getValue());
+}, { value: 'z1\ny2\na3\nc\nb'});
+testVim('ex_sort_pattern_alpha_num', function(cm, vim, helpers) {
+  helpers.doEx('sort /[a-z][0-9]/');
+  eq('c\nb\na3\ny2\nz1', cm.getValue());
+}, { value: 'z1\ny2\na3\nc\nb'});
 // test for :global command
 testVim('ex_global', function(cm, vim, helpers) {
   cm.setCursor(0, 0);
@@ -4068,7 +4087,7 @@ testVim('ex_map_key2key_from_colon', function(cm, vim, helpers) {
 // Test event handlers
 testVim('beforeSelectionChange', function(cm, vim, helpers) {
   cm.setCursor(0, 100);
-  eqCursorPos(cm.getCursor('head'), cm.getCursor('anchor'));
+  eqPos(cm.getCursor('head'), cm.getCursor('anchor'));
 }, { value: 'abc' });
 
 


### PR DESCRIPTION
Hi everybody,

First there is a little improvement from my point of view, in the ex and search history navigation : the cursor is sticked to his position (and to his end when some text is selected).

And for the sort command there is regular expression support and also :

- n argument support (same as d)
- not sorting lines that doesn't match the pattern (for regexp and arguments) like vim do

Some tests for sort have been changed in consequence and added ones for regexp support, run them with `sort*` and for regexp only `sort_pattern*`

NB: This time i checked with `bin/lint` before pushing my fork
I hope this pull request will be added in a future release