### PR TITLE
[annotatescrollbar addon] Avoid exception with annotations past EOF

### DIFF
--- a/addon/scroll/annotatescrollbar.js
+++ b/addon/scroll/annotatescrollbar.js
@@ -72,7 +72,6 @@
     var wrapping = cm.getOption("lineWrapping");
     var singleLineH = wrapping && cm.defaultTextHeight() * 1.5;
     var curLine = null, curLineObj = null;
-    var lastLine = cm.lineCount() - 1;
     function getY(pos, top) {
       if (curLine != pos.line) {
         curLine = pos.line;
@@ -85,14 +84,14 @@
       return topY + (top ? 0 : curLineObj.height);
     }
 
+    var lastLine = cm.lineCount() - 1;
     if (cm.display.barWidth) for (var i = 0, nextTop; i < anns.length; i++) {
       var ann = anns[i];
-      if (ann.to > lastLine) {
-        continue;
-      }
+      if (ann.to.line > lastLine) continue;
       var top = nextTop || getY(ann.from, true) * hScale;
       var bottom = getY(ann.to, false) * hScale;
       while (i < anns.length - 1) {
+        if (anns[i + 1].to.line > lastLine) break;
         nextTop = getY(anns[i + 1].from, true) * hScale;
         if (nextTop > bottom + .9) break;
         ann = anns[++i];

--- a/addon/scroll/annotatescrollbar.js
+++ b/addon/scroll/annotatescrollbar.js
@@ -1,25 +1,5 @@
-/**
- * @license
- * Copyright (C) 2014 by Marijn Haverbeke <marijnh@gmail.com> and others
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// CodeMirror, copyright (c) by Marijn Haverbeke and others		 +/**
+// Distributed under an MIT license: http://codemirror.net/LICENSE
 
 (function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS

--- a/addon/scroll/annotatescrollbar.js
+++ b/addon/scroll/annotatescrollbar.js
@@ -1,5 +1,25 @@
-// CodeMirror, copyright (c) by Marijn Haverbeke and others
-// Distributed under an MIT license: http://codemirror.net/LICENSE
+/**
+ * @license
+ * Copyright (C) 2014 by Marijn Haverbeke <marijnh@gmail.com> and others
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 (function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
@@ -74,9 +94,8 @@
     var curLine = null, curLineObj = null;
     var lastLine = cm.lineCount() - 1;
     function getY(pos, top) {
-      var line = Math.min(lastLine, pos.line);
-      if (curLine != line) {
-        curLine = line;
+      if (curLine != pos.line) {
+        curLine = pos.line;
         curLineObj = cm.getLineHandle(curLine);
       }
       if ((curLineObj.widgets && curLineObj.widgets.length) ||
@@ -88,6 +107,9 @@
 
     if (cm.display.barWidth) for (var i = 0, nextTop; i < anns.length; i++) {
       var ann = anns[i];
+      if (ann.to > lastLine) {
+        continue;
+      }
       var top = nextTop || getY(ann.from, true) * hScale;
       var bottom = getY(ann.to, false) * hScale;
       while (i < anns.length - 1) {

--- a/addon/scroll/annotatescrollbar.js
+++ b/addon/scroll/annotatescrollbar.js
@@ -1,4 +1,4 @@
-// CodeMirror, copyright (c) by Marijn Haverbeke and others		 +/**
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: http://codemirror.net/LICENSE
 
 (function(mod) {

--- a/addon/scroll/annotatescrollbar.js
+++ b/addon/scroll/annotatescrollbar.js
@@ -72,9 +72,11 @@
     var wrapping = cm.getOption("lineWrapping");
     var singleLineH = wrapping && cm.defaultTextHeight() * 1.5;
     var curLine = null, curLineObj = null;
+    var lastLine = cm.lineCount() - 1;
     function getY(pos, top) {
-      if (curLine != pos.line) {
-        curLine = pos.line;
+      var line = Math.min(lastLine, pos.line);
+      if (curLine != line) {
+        curLine = line;
         curLineObj = cm.getLineHandle(curLine);
       }
       if ((curLineObj.widgets && curLineObj.widgets.length) ||


### PR DESCRIPTION
Some of our scrollbar annotations update after XHRs complete, which means that we somewhat frequently get exceptions thrown when CodeMirror tries to redraw the scrollbar annotations and the number of lines has decreased.

I think it would be nice to patch the to & from in the change handler, but I'll just leave it at this for now.