### PR TITLE
[php mode] add syntax highlight for heredoc strings

### DIFF
--- a/mode/php/index.html
+++ b/mode/php/index.html
@@ -12,6 +12,7 @@
 <script src="../javascript/javascript.js"></script>
 <script src="../css/css.js"></script>
 <script src="../clike/clike.js"></script>
+<script src="../meta.js"></script>
 <script src="php.js"></script>
 <style type="text/css">.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
@@ -32,6 +33,10 @@
 <h2>PHP mode</h2>
 <form><textarea id="code" name="code">
 <?php
+$foo = <<<HTML
+    <p class="paragraph">A text</p>
+HTML;
+
 $a = array('a' => 1, 'b' => 2, 3 => 'c');
 
 echo "$a[a] ${a[3] /* } comment */} {$a[b]} \$a[a]";

--- a/mode/php/test.js
+++ b/mode/php/test.js
@@ -151,4 +151,28 @@
      "[string <<<here]",
      "[string doc ][variable-2 $]{[variable yay]}[string more]",
      "[string here]; [comment // normal]");
+
+  MT("heredoc_syntax_javascript",
+     "[meta <?php]",
+     "[string <<<JAVASCRIPT]",
+     "[keyword function] [def log]() { [variable console].[property log]([string 'foo']); }",
+     "[string JAVASCRIPT]; [comment // normal]");
+
+  MT("heredoc_syntax_html",
+     "[meta <?php]",
+     "[string <<<HTML]",
+     "[tag&bracket <][tag p] [attribute class]=[string \"paragraph\"][tag&bracket >]A text[tag&bracket </][tag p][tag&bracket >]",
+     "[string HTML]; [comment // normal]");
+
+  MT("heredoc_syntax_sql",
+     "[meta <?php]",
+     "[string <<<SQL]",
+     "[keyword select] * [keyword from] codemirror;",
+     "[string SQL]; [comment // normal]");
+
+  MT("newdoc",
+     "[meta <?php]",
+     "[string <<<'DOC']",
+     "[string doc ${yay} more]",
+     "[string DOC]; [comment // normal]");
 })();


### PR DESCRIPTION
This tentatively fixes https://github.com/codemirror/CodeMirror/issues/4550
The tests I've added pass but in the demo the heredoc string is still highlighted as string instead of using the specific mode. Any idea of why?