### PR TITLE
Updated offset for removeReadOnlyRanges

### DIFF
--- a/src/line/spans.js
+++ b/src/line/spans.js
@@ -163,7 +163,7 @@ export function removeReadOnlyRanges(doc, from, to) {
       if (dto > 0 || !mk.inclusiveRight && !dto)
         newParts.push({from: m.to, to: p.to})
       parts.splice.apply(parts, newParts)
-      j += newParts.length - 1
+      j += newParts.length - 3
     }
   }
   return parts


### PR DESCRIPTION
Subtract by 3 to account for the 2 extra parameters for splice and for replacing an existing part.

I ran the tests for both master and my branch. There were failing tests, but the same for both branches.

I also ran bin/lint, but it seemed to already be upset with some other syntax ('let' to be exact). Since my changes are so small, I thought not to worry about it.

Let me know if there is something I am leaving out. Thanks!

Issue: #4582 