### PR TITLE
TypeScript: broken when index signature is used

### DIFF
--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -283,6 +283,12 @@
      "  [property createdAt]: [variable-3 Date];",
      "}");
 
+  TS("typescript_index_signature",
+     "[keyword interface] [def A] {",
+     "  [[[property prop]: [variable-3 string]]]: [variable-3 any];",
+     "  [property prop1]: [variable-3 any];",
+     "}");
+
   var jsonld_mode = CodeMirror.getMode(
     {indentUnit: 2},
     {name: "javascript", jsonld: true}


### PR DESCRIPTION
following code is parsed incorrectly, because of index signature (it can be seen for example here https://www.typescriptlang.org/docs/handbook/interfaces.html)
```
interface A {
  [prop: string]: any;
  prop1: any;
}
```
`prop1` is currently parsed as a `variable` instead as a `property`