### PR TITLE
Protect from null markedSelection

### DIFF
--- a/addon/selection/mark-selection.js
+++ b/addon/selection/mark-selection.js
@@ -34,11 +34,12 @@
   });
 
   function onCursorActivity(cm) {
-    cm.operation(function() { update(cm); });
+    if (cm.state.markedSelection)
+      cm.operation(function() { update(cm); });
   }
 
   function onChange(cm) {
-    if (cm.state.markedSelection.length)
+    if (cm.state.markedSelection && cm.state.markedSelection.length)
       cm.operation(function() { clear(cm); });
   }
 


### PR DESCRIPTION
markedSelection is set to null as the  onChange and onCursorActivity events are turned off. But inside an operation it is possible for the onChange event to be called after markedSelection is set to null. This causes a runtime error.