### PR TITLE
properly handle linting for multi-document YAML

### DIFF
--- a/addon/lint/yaml-lint.js
+++ b/addon/lint/yaml-lint.js
@@ -19,8 +19,15 @@ CodeMirror.registerHelper("lint", "yaml", function(text) {
   var found = [];
   try { jsyaml.load(text); }
   catch(e) {
-      var loc = e.mark;
-      found.push({ from: CodeMirror.Pos(loc.line, loc.column), to: CodeMirror.Pos(loc.line, loc.column), message: e.message });
+      var loc = e.mark,
+          // js-yaml YAMLException doesn't always provide an accurate lineno
+          // e.g., when there are multiple yaml docs
+          // ---
+          // ---
+          // foo:bar
+          from = loc ? CodeMirror.Pos(loc.line, loc.column) : CodeMirror.Pos(0, 0),
+          to = from;
+      found.push({ from: from, to: to, message: e.message });
   }
   return found;
 });


### PR DESCRIPTION
js-yaml doesn't always provide line/mark data for certain exceptions;
handle this scenario more gracefully

closes: #4600