### PR TITLE
[sql mode] Added "text/x-sqlite" mime type

### DIFF
--- a/addon/hint/sql-hint.js
+++ b/addon/hint/sql-hint.js
@@ -14,6 +14,7 @@
   var tables;
   var defaultTable;
   var keywords;
+  var identifierQuote;
   var CONS = {
     QUERY_DIV: ";",
     ALIAS_KEYWORD: "AS"
@@ -26,6 +27,15 @@
     var mode = editor.doc.modeOption;
     if (mode === "sql") mode = "text/x-sql";
     return CodeMirror.resolveMode(mode).keywords;
+  }
+
+  function getIdentifierQuote(editor) {
+    var mode = editor.doc.modeOption;
+    if (mode === "sql") mode = "text/x-sql";
+    if(CodeMirror.resolveMode(mode).identifierQuote)
+      return CodeMirror.resolveMode(mode).identifierQuote;
+    else
+      return "`";
   }
 
   function getText(item) {
@@ -86,17 +96,17 @@
   }
 
   function cleanName(name) {
-    // Get rid name from backticks(`) and preceding dot(.)
+    // Get rid name from identifierQuote and preceding dot(.)
     if (name.charAt(0) == ".") {
       name = name.substr(1);
     }
-    return name.replace(/`/g, "");
+    return name.replace(new RegExp(identifierQuote,"g"), "");
   }
 
-  function insertBackticks(name) {
+  function insertIdentifierQuotes(name) {
     var nameParts = getText(name).split(".");
     for (var i = 0; i < nameParts.length; i++)
-      nameParts[i] = "`" + nameParts[i] + "`";
+      nameParts[i] = identifierQuote + nameParts[i] + identifierQuote;
     var escaped = nameParts.join(".");
     if (typeof name == "string") return escaped;
     name = shallowClone(name);
@@ -106,13 +116,13 @@
 
   function nameCompletion(cur, token, result, editor) {
     // Try to complete table, column names and return start position of completion
-    var useBacktick = false;
+    var useIdentifierQuotes = false;
     var nameParts = [];
     var start = token.start;
     var cont = true;
     while (cont) {
       cont = (token.string.charAt(0) == ".");
-      useBacktick = useBacktick || (token.string.charAt(0) == "`");
+      useIdentifierQuotes = useIdentifierQuotes || (token.string.charAt(0) == identifierQuote);
 
       start = token.start;
       nameParts.unshift(cleanName(token.string));
@@ -127,12 +137,12 @@
     // Try to complete table names
     var string = nameParts.join(".");
     addMatches(result, string, tables, function(w) {
-      return useBacktick ? insertBackticks(w) : w;
+      return useIdentifierQuotes ? insertIdentifierQuotes(w) : w;
     });
 
     // Try to complete columns from defaultTable
     addMatches(result, string, defaultTable, function(w) {
-      return useBacktick ? insertBackticks(w) : w;
+      return useIdentifierQuotes ? insertIdentifierQuotes(w) : w;
     });
 
     // Try to complete columns
@@ -162,7 +172,7 @@
           w = shallowClone(w);
           w.text = tableInsert + "." + w.text;
         }
-        return useBacktick ? insertBackticks(w) : w;
+        return useIdentifierQuotes ? insertIdentifierQuotes(w) : w;
       });
     }
 
@@ -232,6 +242,7 @@
     var disableKeywords = options && options.disableKeywords;
     defaultTable = defaultTableName && getTable(defaultTableName);
     keywords = getKeywords(editor);
+    identifierQuote = getIdentifierQuote(editor);
 
     if (defaultTableName && !defaultTable)
       defaultTable = findTableByAlias(defaultTableName, editor);
@@ -249,7 +260,7 @@
       token.string = token.string.slice(0, cur.ch - token.start);
     }
 
-    if (token.string.match(/^[.`\w@]\w*$/)) {
+    if (token.string.match(/^[.`"\w@]\w*$/)) {
       search = token.string;
       start = token.start;
       end = token.end;
@@ -257,7 +268,7 @@
       start = end = cur.ch;
       search = "";
     }
-    if (search.charAt(0) == "." || search.charAt(0) == "`") {
+    if (search.charAt(0) == "." || search.charAt(0) == identifierQuote) {
       start = nameCompletion(cur, token, result, editor);
     } else {
       addMatches(result, search, tables, function(w) {return w;});

--- a/addon/hint/sql-hint.js
+++ b/addon/hint/sql-hint.js
@@ -32,10 +32,7 @@
   function getIdentifierQuote(editor) {
     var mode = editor.doc.modeOption;
     if (mode === "sql") mode = "text/x-sql";
-    if(CodeMirror.resolveMode(mode).identifierQuote)
-      return CodeMirror.resolveMode(mode).identifierQuote;
-    else
-      return "`";
+    return CodeMirror.resolveMode(mode).identifierQuote || "`";
   }
 
   function getText(item) {

--- a/mode/meta.js
+++ b/mode/meta.js
@@ -130,6 +130,7 @@
     {name: "SPARQL", mime: "application/sparql-query", mode: "sparql", ext: ["rq", "sparql"], alias: ["sparul"]},
     {name: "Spreadsheet", mime: "text/x-spreadsheet", mode: "spreadsheet", alias: ["excel", "formula"]},
     {name: "SQL", mime: "text/x-sql", mode: "sql", ext: ["sql"]},
+    {name: "SQLite", mime: "text/x-sqlite", mode: "sql"},
     {name: "Squirrel", mime: "text/x-squirrel", mode: "clike", ext: ["nut"]},
     {name: "Stylus", mime: "text/x-styl", mode: "stylus", ext: ["styl"]},
     {name: "Swift", mime: "text/x-swift", mode: "swift", ext: ["swift"]},

--- a/mode/sql/sql.js
+++ b/mode/sql/sql.js
@@ -342,26 +342,26 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
     client: set("auth backup bail binary changes check clone databases dbinfo dump echo eqp exit explain fullschema headers help import imposter indexes iotrace limit lint load log mode nullvalue once open output print prompt quit read restore save scanstats schema separator session shell show stats system tables testcase timeout timer trace vfsinfo vfslist vfsname width"),
     // ref: http://sqlite.org/lang_keywords.html
     keywords: set(sqlKeywords + "abort action add after all analyze attach autoincrement before begin cascade case cast check collate column commit conflict constraint cross current_date current_time current_timestamp database default deferrable deferred detach each else end escape except exclusive exists explain fail for foreign full glob if ignore immediate index indexed initially inner instead intersect isnull key left limit match natural no notnull null of offset outer plan pragma primary query raise recursive references regexp reindex release rename replace restrict right rollback row savepoint temp temporary then to transaction trigger unique using vacuum view virtual when with without"),
-    // SQLite is weakly typed, ref: http://sqlite.org/datatype3.html. This is just a list of some common types. 
+    // SQLite is weakly typed, ref: http://sqlite.org/datatype3.html. This is just a list of some common types.
     builtin: set("bool boolean bit blob decimal double float long longblob longtext medium mediumblob mediumint mediumtext time timestamp tinyblob tinyint tinytext text clob bigint int int2 int8 integer float double char varchar date datetime year unsigned signed numeric real"),
     // ref: http://sqlite.org/syntax/literal-value.html
     atoms: set("null current_date current_time current_timestamp"),
     // ref: http://sqlite.org/lang_expr.html#binaryops
     operatorChars: /^[*+\-%<>!=&|/~]/,
-    // SQLite is weakly typed, ref: http://sqlite.org/datatype3.html. This is just a list of some common types. 
+    // SQLite is weakly typed, ref: http://sqlite.org/datatype3.html. This is just a list of some common types.
     dateSQL: set("date time timestamp datetime"),
     support: set("decimallessFloat zerolessFloat"),
     identifierQuote: "\"",  //ref: http://sqlite.org/lang_keywords.html
     hooks: {
       // bind-parameters ref:http://sqlite.org/lang_expr.html#varparam
-      "@":   hookVar,    
+      "@":   hookVar,
       ":":   hookVar,
       "?":   hookVar,
       "$":   hookVar,
       // The preferred way to escape Identifiers is using double quotes, ref: http://sqlite.org/lang_keywords.html
       "\"":   hookIdentifierDoublequote,
       // there is also support for backtics, ref: http://sqlite.org/lang_keywords.html
-      "`":   hookIdentifier,
+      "`":   hookIdentifier
     }
   });
 

--- a/mode/sql/sql.js
+++ b/mode/sql/sql.js
@@ -217,6 +217,19 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
     return stream.eatWhile(/\w/) ? "variable-2" : null;
   }
 
+  // "identifier"
+  function hookIdentifierDoublequote(stream) {
+    // Standard SQL /SQLite identifiers
+    // ref: http://web.archive.org/web/20160813185132/http://savage.net.au/SQL/sql-99.bnf.html#delimited%20identifier
+    // ref: http://sqlite.org/lang_keywords.html
+    var ch;
+    while ((ch = stream.next()) != null) {
+      if (ch == "\"" && !stream.eat("\"")) return "variable-2";
+    }
+    stream.backUp(stream.current().length - 1);
+    return stream.eatWhile(/\w/) ? "variable-2" : null;
+  }
+
   // variable token
   function hookVar(stream) {
     // variables
@@ -319,6 +332,36 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
       "@":   hookVar,
       "`":   hookIdentifier,
       "\\":  hookClient
+    }
+  });
+
+  // provided by the phpLiteAdmin project - phpliteadmin.org
+  CodeMirror.defineMIME("text/x-sqlite", {
+    name: "sql",
+    // commands of the official SQLite client, ref: https://www.sqlite.org/cli.html#dotcmd
+    client: set("auth backup bail binary changes check clone databases dbinfo dump echo eqp exit explain fullschema headers help import imposter indexes iotrace limit lint load log mode nullvalue once open output print prompt quit read restore save scanstats schema separator session shell show stats system tables testcase timeout timer trace vfsinfo vfslist vfsname width"),
+    // ref: http://sqlite.org/lang_keywords.html
+    keywords: set(sqlKeywords + "abort action add after all analyze attach autoincrement before begin cascade case cast check collate column commit conflict constraint cross current_date current_time current_timestamp database default deferrable deferred detach each else end escape except exclusive exists explain fail for foreign full glob if ignore immediate index indexed initially inner instead intersect isnull key left limit match natural no notnull null of offset outer plan pragma primary query raise recursive references regexp reindex release rename replace restrict right rollback row savepoint temp temporary then to transaction trigger unique using vacuum view virtual when with without"),
+    // SQLite is weakly typed, ref: http://sqlite.org/datatype3.html. This is just a list of some common types. 
+    builtin: set("bool boolean bit blob decimal double float long longblob longtext medium mediumblob mediumint mediumtext time timestamp tinyblob tinyint tinytext text clob bigint int int2 int8 integer float double char varchar date datetime year unsigned signed numeric real"),
+    // ref: http://sqlite.org/syntax/literal-value.html
+    atoms: set("null current_date current_time current_timestamp"),
+    // ref: http://sqlite.org/lang_expr.html#binaryops
+    operatorChars: /^[*+\-%<>!=&|/~]/,
+    // SQLite is weakly typed, ref: http://sqlite.org/datatype3.html. This is just a list of some common types. 
+    dateSQL: set("date time timestamp datetime"),
+    support: set("decimallessFloat zerolessFloat"),
+    identifierQuote: "\"",  //ref: http://sqlite.org/lang_keywords.html
+    hooks: {
+      // bind-parameters ref:http://sqlite.org/lang_expr.html#varparam
+      "@":   hookVar,    
+      ":":   hookVar,
+      "?":   hookVar,
+      "$":   hookVar,
+      // The preferred way to escape Identifiers is using double quotes, ref: http://sqlite.org/lang_keywords.html
+      "\"":   hookIdentifierDoublequote,
+      // there is also support for backtics, ref: http://sqlite.org/lang_keywords.html
+      "`":   hookIdentifier,
     }
   });
 

--- a/test/sql-hint-test.js
+++ b/test/sql-hint-test.js
@@ -115,7 +115,7 @@
     tables: simpleTables,
     list: ["\"users\".\"name\""],
     from: Pos(0, 7),
-    to: Pos(0, 16)
+    to: Pos(0, 16),
     mode: "text/x-sqlite"
   });
 
@@ -144,7 +144,7 @@
     tables: schemaTables,
     list: ["\"schema\".\"users\"", "\"schema\".\"countries\""],
     from: Pos(0, 7),
-    to: Pos(0, 11)
+    to: Pos(0, 11),
     mode: "text/x-sqlite"
   });
 
@@ -178,7 +178,8 @@
            "\"schema\".\"users\".\"score\"",
            "\"schema\".\"users\".\"birthDate\""],
     from: Pos(0, 7),
-    to: Pos(0, 24)
+    to: Pos(0, 24),
+    mode: "text/x-sqlite"
   });
 
   test("displayText_table", {

--- a/test/sql-hint-test.js
+++ b/test/sql-hint-test.js
@@ -34,7 +34,7 @@
       eqCharPos(completion.to, spec.to);
     }, {
       value: spec.value,
-      mode: "text/x-mysql"
+      mode: spec.mode || "text/x-mysql"
     });
   }
 
@@ -90,6 +90,16 @@
     to: Pos(0, 18)
   });
 
+  test("doublequoted", {
+    value: "SELECT \"users\".\"na",
+    cursor: Pos(0, 18),
+    tables: simpleTables,
+    list: ["\"users\".\"name\""],
+    from: Pos(0, 7),
+    to: Pos(0, 18),
+    mode: "text/x-sqlite"
+  });
+
   test("quotedcolumn", {
     value: "SELECT users.`na",
     cursor: Pos(0, 16),
@@ -97,6 +107,16 @@
     list: ["`users`.`name`"],
     from: Pos(0, 7),
     to: Pos(0, 16)
+  });
+
+  test("doublequotedcolumn", {
+    value: "SELECT users.\"na",
+    cursor: Pos(0, 16),
+    tables: simpleTables,
+    list: ["\"users\".\"name\""],
+    from: Pos(0, 7),
+    to: Pos(0, 16)
+    mode: "text/x-sqlite"
   });
 
   test("schema", {
@@ -118,6 +138,16 @@
     to: Pos(0, 11)
   });
 
+  test("schemadoublequoted", {
+    value: "SELECT \"sch",
+    cursor: Pos(0, 11),
+    tables: schemaTables,
+    list: ["\"schema\".\"users\"", "\"schema\".\"countries\""],
+    from: Pos(0, 7),
+    to: Pos(0, 11)
+    mode: "text/x-sqlite"
+  });
+
   test("schemacolumn", {
     value: "SELECT schema.users.",
     cursor: Pos(0, 20),
@@ -136,6 +166,17 @@
     list: ["`schema`.`users`.`name`",
            "`schema`.`users`.`score`",
            "`schema`.`users`.`birthDate`"],
+    from: Pos(0, 7),
+    to: Pos(0, 24)
+  });
+
+  test("schemacolumndoublequoted", {
+    value: "SELECT \"schema\".\"users\".",
+    cursor: Pos(0, 24),
+    tables: schemaTables,
+    list: ["\"schema\".\"users\".\"name\"",
+           "\"schema\".\"users\".\"score\"",
+           "\"schema\".\"users\".\"birthDate\""],
     from: Pos(0, 7),
     to: Pos(0, 24)
   });


### PR DESCRIPTION
Added the "text/x-sqlite" mime type for sql-mode. Neither existing mime-types mysql nor x-sql fit well for SQLite, e.g. important keywords like PRAGMA are missing. Therefore, I added a new mime type based on the SQLite language definition available online. I added references to all sources in comments. Feel free to remove them if you think this is too much.
SQLite says identifiers like columns should be quoted in double quotes preferably, just like in standard SQL, not backticks. Therefore, I made the necessary changes to sql-hint.js, so that a mime type declaration can define the column identifier that the language uses. I guess other SQL dialects will need this as well.