### PR TITLE
situations, when type should not be parsed as a keyword

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -579,6 +579,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (type == "{") return contCommasep(proppattern, "}");
   }
   function proppattern(type, value) {
+    if (type == "type") type = "variable"
     if (type == "variable" && !cx.stream.match(/^\s*:/, false)) {
       register(value);
       return cont(maybeAssign);

--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -625,6 +625,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   }
   function funarg(type) {
     if (type == "spread") return cont(funarg);
+    if (type == "type") cx.marked = "def";
     return pass(pattern, maybetype, maybeAssign);
   }
   function classExpression(type, value) {

--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -405,6 +405,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (type == "{") return contCommasep(objprop, "}", null, maybeop);
     if (type == "quasi") return pass(quasi, maybeop);
     if (type == "new") return cont(maybeTarget(noComma));
+    if (type == "type") cx.marked = "variable-2";
     return cont();
   }
   function maybeexpression(type) {

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -231,10 +231,10 @@
     test.mode(name, ts_mode, Array.prototype.slice.call(arguments, 1))
   }
 
-  TS("extend_type",
+  TS("typescript_extend_type",
      "[keyword class] [def Foo] [keyword extends] [variable-3 Some][operator <][variable-3 Type][operator >] {}")
 
-  TS("arrow_type",
+  TS("typescript_arrow_type",
      "[keyword let] [def x]: ([variable arg]: [variable-3 Type]) [operator =>] [variable-3 ReturnType]")
 
   TS("typescript_class",
@@ -289,10 +289,28 @@
      "  [property prop1]: [variable-3 any];",
      "}");
 
-  TS("generic_class",
+  TS("typescript_generic_class",
      "[keyword class] [def Foo][operator <][variable-3 T][operator >] {",
      "  [property bar]() {}",
      "  [property foo](): [variable-3 Foo] {}",
+     "}")
+
+  TS("typescript_type_when_keyword",
+     "[keyword export] [keyword type] [variable-3 AB] [operator =] [variable-3 A] [operator |] [variable-3 B];",
+     "[keyword type] [variable-3 Flags] [operator =] {",
+     "  [property p1]: [variable-3 string];",
+     "  [property p2]: [variable-3 boolean];",
+     "};")
+
+  TS("typescript_type_when_not_keyword",
+     "[keyword class] [def HasType] {",
+     "  [property type]: [variable-3 string];",
+     "  [property constructor]([def type]: [variable-3 string]) {",
+     "    [keyword this].[property type] [operator =] [variable-2 type];",
+     "  }",
+     "  [property setType]({ [def type] }: { [property type]: [variable-3 string]; }) {",
+     "    [keyword this].[property type] [operator =] [variable-2 type];",
+     "  }",
      "}")
 
   var jsonld_mode = CodeMirror.getMode(


### PR DESCRIPTION
```
class HasType {
  type: string;
  constructor(type: string) {
    this.type = type;
  }
  setType({ type }: { type: string; }) {
    this.type = type;
  }
}
```
tested this as a valid typescript code