### PR TITLE
[sql-hint] identifier quote is not escaped if identifiers contain it - or spaces

### DIFF
--- a/addon/hint/sql-hint.js
+++ b/addon/hint/sql-hint.js
@@ -97,13 +97,21 @@
     if (name.charAt(0) == ".") {
       name = name.substr(1);
     }
-    return name.replace(new RegExp(identifierQuote,"g"), "");
+    // replace doublicated identifierQuotes with single identifierQuotes
+    // and remove single identifierQuotes
+    var nameParts = name.split(identifierQuote+identifierQuote);
+    for (var i = 0; i < nameParts.length; i++)
+      nameParts[i] = nameParts[i].replace(new RegExp(identifierQuote,"g"), "");
+    return nameParts.join(identifierQuote);
   }
 
   function insertIdentifierQuotes(name) {
     var nameParts = getText(name).split(".");
     for (var i = 0; i < nameParts.length; i++)
-      nameParts[i] = identifierQuote + nameParts[i] + identifierQuote;
+      nameParts[i] = identifierQuote + 
+        // doublicate identifierQuotes
+        nameParts[i].replace(new RegExp(identifierQuote,"g"), identifierQuote+identifierQuote) + 
+        identifierQuote;
     var escaped = nameParts.join(".");
     if (typeof name == "string") return escaped;
     name = shallowClone(name);

--- a/test/sql-hint-test.js
+++ b/test/sql-hint-test.js
@@ -21,9 +21,10 @@
               {text: "name", displayText: "name | The name"}]
   }];
 
-  var quoteNameTables = {
+  var problemTables = {
     "backtick`table": ["backtick`col"],
-    "doublequote\"table": ["doublequote\"col"]
+    "doublequote\"table": ["doublequote\"col"],
+    "space table": ["space column"]
   };
 
  namespace = "sql-hint_";
@@ -228,16 +229,25 @@
   test("backticktable", {
     value: "SELECT `backtick",
     cursor: Pos(0, 16),
-    tables: quoteNameTables,
+    tables: problemTables,
     list: ["`backtick``table`"],
     from: Pos(0, 7),
     to: Pos(0, 16)
   });
 
+  test("backticktable2", {
+    value: "SELECT `backtick``ta",
+    cursor: Pos(0, 20),
+    tables: problemTables,
+    list: ["`backtick``table`"],
+    from: Pos(0, 7),
+    to: Pos(0, 20)
+  });
+
   test("backtickcolumn", {
     value: "SELECT `backtick``table`.`back",
     cursor: Pos(0, 29),
-    tables: quoteNameTables,
+    tables: problemTables,
     list: ["`backtick``table`.`backtick``col`"],
     from: Pos(0, 7),
     to: Pos(0, 29)
@@ -246,7 +256,7 @@
   test("doublequotetable", {
     value: "SELECT \"doublequ",
     cursor: Pos(0, 16),
-    tables: quoteNameTables,
+    tables: problemTables,
     list: ["\"doublequote\"\"table\""],
     from: Pos(0, 7),
     to: Pos(0, 16),
@@ -256,12 +266,22 @@
   test("doublequotecolumn", {
     value: "SELECT \"doublequote\"\"table\".\"doubl",
     cursor: Pos(0, 33),
-    tables: quoteNameTables,
+    tables: problemTables,
     list: ["\"doublequote\"\"table\".\"doublequote\"\"col\""],
     from: Pos(0, 7),
     to: Pos(0, 33),
     mode: "text/x-sqlite"
   });
+
+  test("spacetable", {
+    value: "SELECT `space ta",
+    cursor: Pos(0, 16),
+    tables: problemTables,
+    list: ["`space table`"],
+    from: Pos(0, 7),
+    to: Pos(0, 16)
+  });
+
 
   function deepCompare(a, b) {
     if (a === b) return true

--- a/test/sql-hint-test.js
+++ b/test/sql-hint-test.js
@@ -21,7 +21,12 @@
               {text: "name", displayText: "name | The name"}]
   }];
 
-  namespace = "sql-hint_";
+  var quoteNameTables = {
+    "backtick`table": ["backtick`col"],
+    "doublequote\"table": ["doublequote\"col"]
+  };
+
+ namespace = "sql-hint_";
 
   function test(name, spec) {
     testCM(name, function(cm) {
@@ -219,6 +224,44 @@
     from: Pos(0, 7),
     to: Pos(0, 9)
   })
+
+  test("backticktable", {
+    value: "SELECT `backtick",
+    cursor: Pos(0, 16),
+    tables: quoteNameTables,
+    list: ["`backtick``table`"],
+    from: Pos(0, 7),
+    to: Pos(0, 16)
+  });
+
+  test("backtickcolumn", {
+    value: "SELECT `backtick``table`.`back",
+    cursor: Pos(0, 29),
+    tables: quoteNameTables,
+    list: ["`backtick``table`.`backtick``col`"],
+    from: Pos(0, 7),
+    to: Pos(0, 29)
+  });
+
+  test("doublequotetable", {
+    value: "SELECT \"doublequ",
+    cursor: Pos(0, 16),
+    tables: quoteNameTables,
+    list: ["\"doublequote\"\"table\""],
+    from: Pos(0, 7),
+    to: Pos(0, 16),
+    mode: "text/x-sqlite"
+  });
+
+  test("doublequotecolumn", {
+    value: "SELECT \"doublequote\"\"table\".\"doubl",
+    cursor: Pos(0, 33),
+    tables: quoteNameTables,
+    list: ["\"doublequote\"\"table\".\"doublequote\"\"col\""],
+    from: Pos(0, 7),
+    to: Pos(0, 33),
+    mode: "text/x-sqlite"
+  });
 
   function deepCompare(a, b) {
     if (a === b) return true


### PR DESCRIPTION
There are several bugs in sql-hint. The following table / column names don't work correctly. Assume the identifier quote is ", then the identifier `some"name`  needs to be escaped as `"some""name"`.

Also, spaces cause problems: Assume a table is called `table name` and we start auto completion after `table na`, we don't get `table name` but all `na*`hints. 

I wrote several failing tests that show this problem contained in this pull request. Currently, this pull request fixes all except two of the failing tests. Maybe fixing the remaining two is more easy for you than me. It seems it would require me to dig deep into CodeMirror to understand what's going on.