### PR TITLE
keymap/emacs.js: update to match Emacs >= 24.4's RET/C-j mappings.

### DIFF
--- a/keymap/emacs.js
+++ b/keymap/emacs.js
@@ -371,7 +371,9 @@
     "Shift-Alt-,": "goDocStart", "Shift-Alt-.": "goDocEnd",
     "Ctrl-S": "findNext", "Ctrl-R": "findPrev", "Ctrl-G": quit, "Shift-Alt-5": "replace",
     "Alt-/": "autocomplete",
-    "Ctrl-J": "newlineAndIndent", "Enter": false, "Tab": "indentAuto",
+    "Enter": "newlineAndIndent",
+    "Ctrl-J": repeated(function(cm) { cm.replaceSelection("\n", "end"); }),
+    "Tab": "indentAuto",
 
     "Alt-G G": function(cm) {
       var prefix = getPrefix(cm, true);


### PR DESCRIPTION
Starting with Emacs 24.4 the default meanings of Enter and Ctrl+J was swapped, so that
RET does newline-and-indent while C-j is the simple non-electric newline.  This
change makes codemirror match Emacs.

Related:
- Emacs 24.4 was released 20 Oct 2014, FWIW
- #2411 previously visited this partially, but predated the Emacs change by 7
  months, so was rejected.