### PR TITLE
Treat {@inject} same as {@param}

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -256,7 +256,7 @@
             state.scopes = prepend(state.scopes, state.variables);
             state.soyState.push("var-def");
           }
-          if (state.tag.match(/^@param\??/)) {
+          if (state.tag.match(/^@(?:param\??|inject)/)) {
             state.soyState.push("param-def");
           }
           return "keyword";


### PR DESCRIPTION
`{@inject}` is used for injected parameters instead of normal parameters. It behaves the same as `{@param}`.