### PR TITLE
Continue markdown task lists when formated with * and + bullets

### DIFF
--- a/addon/edit/continuelist.js
+++ b/addon/edit/continuelist.js
@@ -11,8 +11,8 @@
 })(function(CodeMirror) {
   "use strict";
 
-  var listRE = /^(\s*)(>[> ]*|- \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/,
-      emptyListRE = /^(\s*)(>[> ]*|- \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/,
+  var listRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/,
+      emptyListRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/,
       unorderedListRE = /[*+-]\s/;
 
   CodeMirror.commands.newlineAndIndentContinueMarkdownList = function(cm) {


### PR DESCRIPTION
The continuelist addon currently supports the `- [ ]` syntax only. 

Even if `* [ ]` and `+ [ ]` syntaxes are not clearly mentioned in [GFM documentation](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) they are supported by most markdown parsers (such as Github's one). This PR aims to support them in the continuelist addon.