### PR TITLE
Support editor rtl mode without wrapped lines

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -27,6 +27,10 @@
   background-color: #f7f7f7;
   white-space: nowrap;
 }
+.CodeMirror-rtl .CodeMirror-gutters {
+  border-right: none;
+  border-left: 1px solid #ddd;
+}
 .CodeMirror-linenumbers {}
 .CodeMirror-linenumber {
   padding: 0 3px 0 5px;
@@ -165,9 +169,21 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   outline: none; /* Prevent dragging from highlighting the element */
   position: relative;
 }
+
+.CodeMirror-rtl .CodeMirror-scroll {
+  /* 30px is the magic margin used to hide the element's real scrollbars */
+  /* See overflow: hidden in .CodeMirror */
+  margin-left: -30px;
+  margin-right: 0;
+}
+
 .CodeMirror-sizer {
   position: relative;
   border-right: 30px solid transparent;
+}
+.CodeMirror-rtl .CodeMirror-sizer {
+  border-right: 0;
+  border-left: 30px solid transparent;
 }
 
 /* The fake, visible scrollbars. Used to force redraw during scrolling
@@ -183,6 +199,9 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   overflow-x: hidden;
   overflow-y: scroll;
 }
+.CodeMirror-rtl .CodeMirror-vscrollbar {
+  left: 0; right: initial;
+}
 .CodeMirror-hscrollbar {
   bottom: 0; left: 0;
   overflow-y: hidden;
@@ -191,8 +210,14 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 .CodeMirror-scrollbar-filler {
   right: 0; bottom: 0;
 }
+.CodeMirror-rtl .CodeMirror-scrollbar-filler {
+  right: initial; left: 0;
+}
 .CodeMirror-gutter-filler {
   left: 0; bottom: 0;
+}
+.CodeMirror-rtl .CodeMirror-gutter-filler {
+  left: initial; right: 0;
 }
 
 .CodeMirror-gutters {
@@ -200,6 +225,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   min-height: 100%;
   z-index: 3;
 }
+.CodeMirror-rtl .CodeMirror-gutters { left: initial }
 .CodeMirror-gutter {
   white-space: normal;
   height: 100%;
@@ -269,7 +295,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 
 .CodeMirror-widget {}
 
-.CodeMirror-rtl pre { direction: rtl; }
+.CodeMirror-rtl { direction: rtl; }
 
 .CodeMirror-code {
   outline: none;

--- a/src/display/scrollbars.js
+++ b/src/display/scrollbars.js
@@ -65,8 +65,8 @@ class NativeScrollbars {
 
     if (needsH) {
       this.horiz.style.display = "block"
-      this.horiz.style.right = needsV ? sWidth + "px" : "0"
-      this.horiz.style.left = measure.barLeft + "px"
+      this.horiz.style[this.cm.doc.direction == "ltr" ? "right" : "left"] = needsV ? sWidth + "px" : "0"
+      this.horiz.style[this.cm.doc.direction == "ltr" ? "left" : "right"] = measure.barLeft + "px"
       let totalWidth = measure.viewWidth - measure.barLeft - (needsV ? sWidth : 0)
       this.horiz.firstChild.style.width =
         Math.max(0, measure.scrollWidth - measure.clientWidth + totalWidth) + "px"
@@ -150,7 +150,8 @@ function updateScrollbarsInner(cm, measure) {
   let d = cm.display
   let sizes = d.scrollbars.update(measure)
 
-  d.sizer.style.paddingRight = (d.barWidth = sizes.right) + "px"
+  d.sizer.style[cm.doc.direction == "ltr" ? "paddingRight" : "paddingLeft"] = (d.barWidth = sizes.right) + "px"
+  d.sizer.style[cm.doc.direction == "ltr" ? "paddingLeft" : "paddingRight"] = 0
   d.sizer.style.paddingBottom = (d.barHeight = sizes.bottom) + "px"
   d.heightForcer.style.borderBottom = sizes.bottom + "px solid transparent"
 

--- a/src/display/update_display.js
+++ b/src/display/update_display.js
@@ -49,7 +49,8 @@ export function maybeClipScrollbars(cm) {
     display.nativeBarWidth = display.scroller.offsetWidth - display.scroller.clientWidth
     display.heightForcer.style.height = scrollGap(cm) + "px"
     display.sizer.style.marginBottom = -display.nativeBarWidth + "px"
-    display.sizer.style.borderRightWidth = scrollGap(cm) + "px"
+    display.sizer.style[cm.doc.direction == "ltr" ? "borderLeftWidth" : "borderRightWidth"] = null
+    display.sizer.style[cm.doc.direction == "ltr" ? "borderRightWidth" : "borderLeftWidth"] = scrollGap(cm) + "px"
     display.scrollbarsClipped = true
   }
 }
@@ -219,7 +220,8 @@ function patchDisplay(cm, updateNumbersFrom, dims) {
 
 export function updateGutterSpace(cm) {
   let width = cm.display.gutters.offsetWidth
-  cm.display.sizer.style.marginLeft = width + "px"
+  cm.display.sizer.style[cm.doc.direction == "ltr" ? "marginRight" : "marginLeft"] = null
+  cm.display.sizer.style[cm.doc.direction == "ltr" ? "marginLeft" : "marginRight"] = width + "px"
 }
 
 export function setDocumentHeight(cm, measure) {

--- a/src/display/update_line.js
+++ b/src/display/update_line.js
@@ -93,17 +93,18 @@ function updateLineGutter(cm, lineView, lineN, dims) {
     lineView.node.removeChild(lineView.gutterBackground)
     lineView.gutterBackground = null
   }
+  let side = (cm.doc.direction == "ltr" ? "left" : "right")
   if (lineView.line.gutterClass) {
     let wrap = ensureLineWrapped(lineView)
     lineView.gutterBackground = elt("div", null, "CodeMirror-gutter-background " + lineView.line.gutterClass,
-                                    `left: ${cm.options.fixedGutter ? dims.fixedPos : -dims.gutterTotalWidth}px; width: ${dims.gutterTotalWidth}px`)
+                                    `${side}: ${cm.options.fixedGutter ? dims.fixedPos : -dims.gutterTotalWidth}px; width: ${dims.gutterTotalWidth}px`)
     cm.display.input.setUneditable(lineView.gutterBackground)
     wrap.insertBefore(lineView.gutterBackground, lineView.text)
   }
   let markers = lineView.line.gutterMarkers
   if (cm.options.lineNumbers || markers) {
     let wrap = ensureLineWrapped(lineView)
-    let gutterWrap = lineView.gutter = elt("div", null, "CodeMirror-gutter-wrapper", `left: ${cm.options.fixedGutter ? dims.fixedPos : -dims.gutterTotalWidth}px`)
+    let gutterWrap = lineView.gutter = elt("div", null, "CodeMirror-gutter-wrapper", `${side}: ${cm.options.fixedGutter ? dims.fixedPos : -dims.gutterTotalWidth}px`)
     cm.display.input.setUneditable(gutterWrap)
     wrap.insertBefore(gutterWrap, lineView.text)
     if (lineView.line.gutterClass)
@@ -112,12 +113,12 @@ function updateLineGutter(cm, lineView, lineN, dims) {
       lineView.lineNumber = gutterWrap.appendChild(
         elt("div", lineNumberFor(cm.options, lineN),
             "CodeMirror-linenumber CodeMirror-gutter-elt",
-            `left: ${dims.gutterLeft["CodeMirror-linenumbers"]}px; width: ${cm.display.lineNumInnerWidth}px`))
+            `${side}: ${dims.gutterLeft["CodeMirror-linenumbers"]}px; width: ${cm.display.lineNumInnerWidth}px`))
     if (markers) for (let k = 0; k < cm.options.gutters.length; ++k) {
       let id = cm.options.gutters[k], found = markers.hasOwnProperty(id) && markers[id]
       if (found)
         gutterWrap.appendChild(elt("div", [found], "CodeMirror-gutter-elt",
-                                   `left: ${dims.gutterLeft[id]}px; width: ${dims.gutterWidth[id]}px`))
+                                   `${side}: ${dims.gutterLeft[id]}px; width: ${dims.gutterWidth[id]}px`))
     }
   }
 }

--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -1,15 +1,16 @@
 import { onBlur } from "../display/focus"
 import { setGuttersForLineNumbers, updateGutters } from "../display/gutters"
-import { alignHorizontally } from "../display/line_numbers"
+import { alignHorizontally, updateFixedGutter } from "../display/line_numbers"
 import { loadMode, resetModeState } from "../display/mode_state"
 import { initScrollbars, updateScrollbars } from "../display/scrollbars"
+import { setScrollLeft } from "../display/scroll_events"
 import { updateSelection } from "../display/selection"
 import { regChange } from "../display/view_tracking"
 import { getKeyMap } from "../input/keymap"
 import { defaultSpecialCharPlaceholder } from "../line/line_data"
 import { Pos } from "../line/pos"
 import { findMaxLine } from "../line/spans"
-import { clearCaches, compensateForHScroll, estimateLineHeights } from "../measurement/position_measurement"
+import { clearCaches, estimateLineHeights } from "../measurement/position_measurement"
 import { replaceRange } from "../model/changes"
 import { mobile, windows } from "../util/browser"
 import { addClass, rmClass } from "../util/dom"
@@ -99,7 +100,7 @@ export function defineOptions(CodeMirror) {
     guttersChanged(cm)
   }, true)
   option("fixedGutter", true, (cm, val) => {
-    cm.display.gutters.style.left = val ? compensateForHScroll(cm.display) + "px" : "0"
+    updateFixedGutter(cm, val)
     cm.refresh()
   }, true)
   option("coverGutterNextToScrollbar", false, cm => updateScrollbars(cm), true)
@@ -153,7 +154,11 @@ export function defineOptions(CodeMirror) {
 
   option("tabindex", null, (cm, val) => cm.display.input.getField().tabIndex = val || "")
   option("autofocus", null)
-  option("direction", "ltr", (cm, val) => cm.doc.setDirection(val), true)
+  option("direction", "ltr", (cm, val) => {
+    cm.doc.setDirection(val)
+    setScrollLeft(cm, 0)
+    guttersChanged(cm)
+  }, true)
 }
 
 function guttersChanged(cm) {

--- a/src/measurement/position_measurement.js
+++ b/src/measurement/position_measurement.js
@@ -528,7 +528,7 @@ export function getDimensions(cm) {
     left[cm.options.gutters[i]] = n.offsetLeft + n.clientLeft + gutterLeft
     width[cm.options.gutters[i]] = n.clientWidth
   }
-  return {fixedPos: compensateForHScroll(d),
+  return {fixedPos: compensateForHScroll(d, cm.doc.direction == "ltr"),
           gutterTotalWidth: d.gutters.offsetWidth,
           gutterLeft: left,
           gutterWidth: width,
@@ -538,8 +538,10 @@ export function getDimensions(cm) {
 // Computes display.scroller.scrollLeft + display.gutters.offsetWidth,
 // but using getBoundingClientRect to get a sub-pixel-accurate
 // result.
-export function compensateForHScroll(display) {
-  return display.scroller.getBoundingClientRect().left - display.sizer.getBoundingClientRect().left
+export function compensateForHScroll(display, isLtr) {
+  let side = isLtr ? "left" : "right"
+  let diff = display.scroller.getBoundingClientRect()[side] - display.sizer.getBoundingClientRect()[side]
+  return isLtr ? diff : -diff
 }
 
 // Returns a function that estimates the height of a line, to use as

--- a/src/model/document_data.js
+++ b/src/model/document_data.js
@@ -100,7 +100,7 @@ export function attachDoc(cm, doc) {
 }
 
 function setDirectionClass(cm) {
-  ;(cm.doc.direction == "rtl" ? addClass : rmClass)(cm.display.lineDiv, "CodeMirror-rtl")
+  ;(cm.doc.direction == "rtl" ? addClass : rmClass)(cm.display.wrapper, "CodeMirror-rtl")
 }
 
 export function directionChanged(cm) {


### PR DESCRIPTION
This seems to work pretty well, even with changing `fixedGutter` and `direction`.