### PR TITLE
Added configurable search specific closeOnBlur setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .idea
 *.iml
 /lib/codemirror.js
+/.vscode

--- a/addon/dialog/dialog.js
+++ b/addon/dialog/dialog.js
@@ -123,13 +123,11 @@
         CodeMirror.on(b, "focus", function() { ++blurring; });
       }
       CodeMirror.on(b, "keydown", function(e) {
-        if (options && options.onKeyDown && options.onKeyDown(e, inp.value, close)) { return; }
         if (e.keyCode == 27) {
           b.blur();
           CodeMirror.e_stop(e);
           close();
         }
-        if (e.keyCode == 13) callback(inp.value, e);
       });
     }
   });

--- a/addon/dialog/dialog.js
+++ b/addon/dialog/dialog.js
@@ -115,11 +115,22 @@
           if (callback) callback(me);
         });
       })(callbacks[i]);
-      CodeMirror.on(b, "blur", function() {
-        --blurring;
-        setTimeout(function() { if (blurring <= 0) close(); }, 200);
+      if (options.closeOnBlur !== false) {
+        CodeMirror.on(b, "blur", function() {
+          --blurring;
+          setTimeout(function() { if (blurring <= 0) close(); }, 200);
+        });
+        CodeMirror.on(b, "focus", function() { ++blurring; });
+      }
+      CodeMirror.on(b, "keydown", function(e) {
+        if (options && options.onKeyDown && options.onKeyDown(e, inp.value, close)) { return; }
+        if (e.keyCode == 27) {
+          b.blur();
+          CodeMirror.e_stop(e);
+          close();
+        }
+        if (e.keyCode == 13) callback(inp.value, e);
       });
-      CodeMirror.on(b, "focus", function() { ++blurring; });
     }
   });
 

--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -63,17 +63,24 @@
       selectValueOnOpen: true,
       closeOnEnter: false,
       onClose: function() { clearSearch(cm); },
-      onKeyDown: onKeyDown
+      onKeyDown: onKeyDown,
+      closeOnBlur: cm.getOption("searchSettings") ? cm.getOption("searchSettings").closeOnBlur : true
     });
   }
 
   function dialog(cm, text, shortText, deflt, f) {
-    if (cm.openDialog) cm.openDialog(text, f, {value: deflt, selectValueOnOpen: true});
+    if (cm.openDialog) cm.openDialog(text, f, {
+      value: deflt, 
+      selectValueOnOpen: true,
+      closeOnBlur: cm.getOption("searchSettings") ? cm.getOption("searchSettings").closeOnBlur : true
+    });
     else f(prompt(shortText, deflt));
   }
 
   function confirmDialog(cm, text, shortText, fs) {
-    if (cm.openConfirm) cm.openConfirm(text, fs);
+    if (cm.openConfirm) cm.openConfirm(text, fs, {
+      closeOnBlur: cm.getOption("searchSettings") ? cm.getOption("searchSettings").closeOnBlur : true
+    });
     else if (confirm(shortText)) fs[0]();
   }
 

--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -70,7 +70,7 @@
 
   function dialog(cm, text, shortText, deflt, f) {
     if (cm.openDialog) cm.openDialog(text, f, {
-      value: deflt, 
+      value: deflt,
       selectValueOnOpen: true,
       closeOnBlur: cm.getOption("searchSettings") ? cm.getOption("searchSettings").closeOnBlur : true
     });


### PR DESCRIPTION
It seems that search and replace will often require that the dialog stays open on blur (for instance when copying the text to replace from another window).  However, rather than changing the behaviour of all dialogs in the editor, this allows the search and replace dialogs to be configured differently.

As part of this, I added a similar behaviour to the confirm dialog, which did not use the closeOnBlur setting.

Because it is desirable to have an intuitive way to close the confirm dialog (other than assigning that behaviour to a button), I also added a close behaviour if the user presses escape while any of the buttons have focus.