### PR TITLE
[mode soy] Don't require colon in @params

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -152,8 +152,8 @@
             return null;
 
           case "param-def":
-            if (match = stream.match(/^([\w]+)(?=:)/)) {
-              state.variables = prepend(state.variables, match[1]);
+            if (match = stream.match(/^\w+/)) {
+              state.variables = prepend(state.variables, match[0]);
               state.soyState.pop();
               state.soyState.push("param-type");
               return "def";

--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -92,4 +92,13 @@
      '  [tag&bracket </][tag div][tag&bracket >]',
      '[keyword {/template}]',
      '');
+
+  MT('allow-missing-colon-in-@param',
+     '[keyword {template] [def .foo][keyword }]',
+     '  [keyword {@param] [def showThing] [variable-3 bool][keyword }]',
+     '  [keyword {if] [variable-2 $showThing][keyword }]',
+     '    Yo!',
+     '  [keyword {/if}]',
+     '[keyword {/template}]',
+     '');
 })();


### PR DESCRIPTION
If the colon `:` character was missing from a declaration like `{@param foo: type}`, the Soy mode would break the highlighting of all following code until it encountered a valid `@param` declaration. This can be quite annoying when editing templates, and it doesn't add any value to the experience. The TypeScript doesn't break highlighting due to missing `:` in argument lists. Neither should the Soy mode.