### PR TITLE
[clike mode] Improve destructor highlighting for C++

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -103,7 +103,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     }
     stream.eatWhile(/[\w\$_\xa1-\uffff]/);
     if (namespaceSeparator) while (stream.match(namespaceSeparator))
-      stream.eatWhile(/[\w\$_\xa1-\uffff]/);
+      stream.eatWhile(/[\w\$_~\xa1-\uffff]/);
 
     var cur = stream.current();
     if (contains(keywords, cur)) {
@@ -314,7 +314,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
   }
 
   function cppLooksLikeConstructor(word) {
-    var lastTwo = /(\w+)::(\w+)$/.exec(word);
+    var lastTwo = /(\w+)::~?(\w+)$/.exec(word);
     return lastTwo && lastTwo[1] == lastTwo[2];
   }
 

--- a/mode/clike/test.js
+++ b/mode/clike/test.js
@@ -52,4 +52,8 @@
     "[number 0b10'000];",
     "[number 0x10'000];",
     "[string '100000'];");
+
+  MTCPP("ctor_dtor",
+     "[def Foo::Foo]() {}",
+     "[def Foo::~Foo]() {}");
 })();


### PR DESCRIPTION
Destructor are now parsed the same way as constructor.