### PR TITLE
Fix missing docs for passing config object to show-hint

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2603,9 +2603,11 @@ editor.setOption("extraKeys", {
         of the global one passed with the full list of completions.</dd>
       </dl></dd>
 
-      <dd>The plugin understands the following options (the options object
+      <dd>Pass options to the show-hint addon by setting a 'hintOptions'
+      property on the CodeMirror options object (the 'hintOptions' object
       will also be passed along to the hinting function, which may
-      understand additional options):
+      understand additional options.) 
+      The plugin understands the following options:
       <dl>
         <dt><code><strong>hint</strong>: function</code></dt>
         <dd>A hinting function, as specified above. It is possible to


### PR DESCRIPTION
There is nothing in the docs that explains how to pass options to show-hint (or not that I could find at least). I finally found the answer here: https://discuss.codemirror.net/t/how-to-support-global-object-mode-autocomplete/536/3 and used that to update the manual.