### PR TITLE
List indentation addon for markdown

### DIFF
--- a/addon/edit/indentlist.js
+++ b/addon/edit/indentlist.js
@@ -1,0 +1,70 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  "use strict";
+
+  var Pos = CodeMirror.Pos;
+  var listTokenRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/;
+
+  function matchListToken(pos, cm) {
+    /* Get some info about the current state */
+    var eolState = cm.getStateAfter(pos.line);
+    var inList = eolState.list !== false;
+    var inQuote = eolState.quote !== 0;
+
+    /* Get the line from the start to where the cursor currently is */
+    var lineStart = cm.getRange(Pos(pos.line, 0), pos);
+
+    /* Matches the beginning of the list line with the list token RE */
+    var match = listTokenRE.exec(lineStart);
+
+    /* Not being in a list, or being in a list but not right after the list
+     * token, are both not considered a match */
+    if ((!inList && !inQuote) || !match)
+      return false
+    else
+      return true
+  }
+
+  CodeMirror.commands.autoIndentMarkdownList = function(cm) {
+    if (cm.getOption("disableInput")) return CodeMirror.Pass;
+    var ranges = cm.listSelections();
+    for (var i = 0; i < ranges.length; i++) {
+      var pos = ranges[i].head;
+
+      if (!ranges[i].empty() || !matchListToken(pos, cm)) {
+        /* If no match, call regular Tab handler */
+        cm.execCommand("defaultTab");
+        return;
+      }
+
+      /* Select the whole list line and indent it by one unit */
+      cm.indentLine(pos.line, "add");
+    }
+  };
+
+  CodeMirror.commands.autoUnindentMarkdownList = function(cm) {
+    if (cm.getOption("disableInput")) return CodeMirror.Pass;
+    var ranges = cm.listSelections();
+    for (var i = 0; i < ranges.length; i++) {
+      var pos = ranges[i].head;
+
+      if (!ranges[i].empty() || !matchListToken(pos, cm)) {
+        /* If no match, call regular Shift-Tab handler */
+        cm.execCommand("indentAuto");
+        return;
+      }
+
+      /* Select the whole list line and unindent it by one unit */
+      cm.indentLine(pos.line, "subtract");
+    }
+  };
+});

--- a/mode/markdown/index.html
+++ b/mode/markdown/index.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../../lib/codemirror.css">
 <script src="../../lib/codemirror.js"></script>
 <script src="../../addon/edit/continuelist.js"></script>
+<script src="../../addon/edit/indentlist.js"></script>
 <script src="../xml/xml.js"></script>
 <script src="markdown.js"></script>
 <style type="text/css">
@@ -346,7 +347,9 @@ Output:
         mode: 'markdown',
         lineNumbers: true,
         theme: "default",
-        extraKeys: {"Enter": "newlineAndIndentContinueMarkdownList"}
+        extraKeys: {"Enter": "newlineAndIndentContinueMarkdownList",
+                    "Tab": "autoIndentMarkdownList",
+                    "Shift-Tab": "autoUnindentMarkdownList"}
       });
     </script>
 


### PR DESCRIPTION
Hi,

A few months ago, I suggested the idea of a feature that would be quite convenient for Markdown: see #4355 

I finally found the time to work on it and came up with the implementation of a new addon, based on the continuelist addon (they could potentially be merged in the same file I imagine). This indentlist addon provides two functions to indent or unindent list items when pressing Tab or Shift-Tab. As far as I can tell, it works flawlessly in the markdown demo (mode/markdown/index.html), even with multiple selections!

Let me know if you have any questions or any improvement requests,
Thanks,
Joël