### PR TITLE
Fix check for undefined

### DIFF
--- a/demo/complete.html
+++ b/demo/complete.html
@@ -83,7 +83,7 @@ var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
   mode: {name: "javascript", globalVars: true}
 });
 
-if (typeof Promise !== undefined) {
+if (typeof Promise !== "undefined") {
   var comp = [
     ["here", "hither"],
     ["asynchronous", "nonsynchronous"],


### PR DESCRIPTION
When checking for definedness the `typeof` operator returns a string. Unfortunately comparing it to `undefined` will always yield false. I expect this was just a typo.

I tested this in Firefox 16 and confirmed this specific case.

This bug was found using [lgtm.com](https://lgtm.com/projects/g/codemirror/CodeMirror/), where we analyse many open source repositories including CodeMirror, and in fact we use and rely on CodeMirror every day.