### PR TITLE
remove a double semicolon

### DIFF
--- a/mode/sieve/sieve.js
+++ b/mode/sieve/sieve.js
@@ -170,7 +170,7 @@ CodeMirror.defineMode("sieve", function(config) {
       if (stream.eatSpace())
         return null;
 
-      return (state.tokenize || tokenBase)(stream, state);;
+      return (state.tokenize || tokenBase)(stream, state);
     },
 
     indent: function(state, _textAfter) {


### PR DESCRIPTION
Highly trivial I know but this PR removes a double semicolon which is technically a statement with no effect and also an unreachable statement as it comes after the `return`. Not harmful at all but easy to fix at least.