### PR TITLE
Fix a bug with the vb mode test reporting

### DIFF
--- a/mode/vb/index.html
+++ b/mode/vb/index.html
@@ -39,8 +39,8 @@ function test(golden, text) {
 		//console.log(String(token) + " " + String(style) + " " + String(lineNo) + " " + String(pos));
     var result = [String(token), String(style)];
     if (golden[i][0] != result[0] || golden[i][1] != result[1]){
-      return "Error, expected: " + String(golden[i]) + ", got: " + String(result);
       ok = false;
+      return "Error, expected: " + String(golden[i]) + ", got: " + String(result);
     }
     i++;
   }

--- a/mode/vb/index.html
+++ b/mode/vb/index.html
@@ -46,7 +46,7 @@ function test(golden, text) {
   }
   CodeMirror.runMode(text, "text/x-vb",callback); 
 
-  if (ok) return "Tests OK";
+  return (ok) ? "Tests OK" : "Tests Failed";
 }
 function testTypes() {
   var golden = [['Integer','keyword'],[' ','null'],['Float','keyword']]


### PR DESCRIPTION
There was a problem with the callback from the `test` function in that it tried to set the `ok` value after returning and hence all tests would always pass. You could see this by introducing a test that should have failed but didn't.
Secondly what would happen when a test failed was it would print "undefined", which wasn't very friendly, and this could be improved a bit.

This bug was found using [lgtm.com](https://lgtm.com/projects/g/codemirror/CodeMirror/).