### PR TITLE
Fix indent throwing when using stylus in htmlmixed

### DIFF
--- a/mode/htmlmixed/htmlmixed.js
+++ b/mode/htmlmixed/htmlmixed.js
@@ -133,11 +133,11 @@
         return state.token(stream, state);
       },
 
-      indent: function (state, textAfter) {
+      indent: function (state, textAfter, line) {
         if (!state.localMode || /^\s*<\//.test(textAfter))
           return htmlMode.indent(state.htmlState, textAfter);
         else if (state.localMode.indent)
-          return state.localMode.indent(state.localState, textAfter);
+          return state.localMode.indent(state.localState, textAfter, line);
         else
           return CodeMirror.Pass;
       },


### PR DESCRIPTION
Attempting to use stylus syntax highlighting in htmlmixed mode throws with `TypeError: line is undefined` on [line 675 of stylus.js](https://github.com/codemirror/CodeMirror/blob/c2a11a315ebe95478134e9eb94c040f14021df4f/mode/stylus/stylus.js#L675).

The error occurs due to htmlmixed mode [not passing](https://github.com/codemirror/CodeMirror/blob/c2a11a315ebe95478134e9eb94c040f14021df4f/mode/htmlmixed/htmlmixed.js#L140) the line argument to the local mode's indent function.

This pull request fixes that issue by passing the argument to the local mode's indent function.