### PR TITLE
[soy mode] Don't highlight functions in the start of tags as keywords

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -251,7 +251,9 @@
           state.indent += config.indentUnit;
           state.soyState.push("literal");
           return "keyword";
-        } else if (match = stream.match(/^\{([\/@\\]?[\w?]*)/)) {
+
+        // A tag-keyword must be followed by whitespace or a closing tag.
+        } else if (match = stream.match(/^\{([\/@\\]?\w+\??)(?=[\s\}])/)) {
           if (match[1] != "/switch")
             state.indent += (/^(\/|(else|elseif|ifempty|case|fallbackmsg|default)$)/.test(match[1]) && state.tag != "switch" ? 1 : 2) * config.indentUnit;
           state.tag = match[1];
@@ -282,6 +284,13 @@
           if (state.tag.match(/^@(?:param\??|inject)/)) {
             state.soyState.push("param-def");
           }
+          return "keyword";
+
+        // Not a tag-keyword; it's an implicit print tag.
+        } else if (stream.eat('{')) {
+          state.tag = "print";
+          state.indent += 2 * config.indentUnit;
+          state.soyState.push("tag");
           return "keyword";
         }
 

--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -93,6 +93,12 @@
      '[keyword {/template}]',
      '');
 
+  MT('tag-starting-with-function-call-is-not-a-keyword',
+     '[keyword {]index([variable-2&error $foo])[keyword }]',
+     '[keyword {css] [string "some-class"][keyword }]',
+     '[keyword {]css([string "some-class"])[keyword }]',
+     '');
+
   MT('allow-missing-colon-in-@param',
      '[keyword {template] [def .foo][keyword }]',
      '  [keyword {@param] [def showThing] [variable-3 bool][keyword }]',


### PR DESCRIPTION
## Before
![soy-function-before](https://cloud.githubusercontent.com/assets/703602/26057705/08613a5a-397b-11e7-897f-4af36f0c2077.png)

## After
![soy-function-after](https://cloud.githubusercontent.com/assets/703602/26057710/0d056a04-397b-11e7-9ec2-8f86e4acde0d.png)
