### PR TITLE
Fixes keyboard trap when readOnly option is 'nocursor'

### DIFF
--- a/src/input/TextareaInput.js
+++ b/src/input/TextareaInput.js
@@ -353,7 +353,8 @@ export default class TextareaInput {
   }
 
   readOnlyChanged(val) {
-    if (!val) this.reset()
+    if (val == "nocursor") this.textarea.disabled = true
+    else if (!val) this.reset()
   }
 
   setUneditable() {}


### PR DESCRIPTION
Fixes a keyboard trap when readOnly option is set to `'nocursor'`. I think this has regressed from #1909