### PR TITLE
Fix misplaced semicolon in searchcursor.js

### DIFF
--- a/addon/search/searchcursor.js
+++ b/addon/search/searchcursor.js
@@ -1,7 +1,7 @@
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: http://codemirror.net/LICENSE
 
-;(function(mod) {
+(function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
     mod(require("../../lib/codemirror"))
   else if (typeof define == "function" && define.amd) // AMD
@@ -278,4 +278,4 @@
     if (ranges.length)
       this.setSelections(ranges, 0)
   })
-})
+});


### PR DESCRIPTION
Hi

Fixed a misplaced semicolon in the searchcursor.js that was causing some parsing problems.

Thanks for your awesome work!

Cumps