### PR TITLE
Fix invalid CodeMirror module path in PowerShell mode

### DIFF
--- a/mode/powershell/powershell.js
+++ b/mode/powershell/powershell.js
@@ -4,9 +4,9 @@
 (function(mod) {
   'use strict';
   if (typeof exports == 'object' && typeof module == 'object') // CommonJS
-    mod(require('codemirror'));
+    mod(require('../../lib/codemirror'));
   else if (typeof define == 'function' && define.amd) // AMD
-    define(['codemirror'], mod);
+    define(['../../lib/codemirror'], mod);
   else // Plain browser env
     mod(window.CodeMirror);
 })(function(CodeMirror) {


### PR DESCRIPTION
It caused the `powershell` mode not loading correctly.
Just fixing `require` & `define` statements to be same as other modes.