### PR TITLE
Use document.getElementsByClassName directly

### DIFF
--- a/src/edit/global_events.js
+++ b/src/edit/global_events.js
@@ -6,8 +6,8 @@ import { on } from "../util/event"
 // garbage collected.
 
 function forEachCodeMirror(f) {
-  if (!document.body.getElementsByClassName) return
-  let byClass = document.body.getElementsByClassName("CodeMirror")
+  if (!document.getElementsByClassName) return
+  let byClass = document.getElementsByClassName("CodeMirror")
   for (let i = 0; i < byClass.length; i++) {
     let cm = byClass[i].CodeMirror
     if (cm) f(cm)


### PR DESCRIPTION
Sometimes attemping to call `document.body.getElementsByClassName` results in an error like: `Cannot read property 'getElementsByClassName' of null`. I'm not sure what causes `document.body` to be null, but the MDN standard seems to suggest that calling `getElementsByClassName` directly on `document` is standard now:  https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName.