### PR TITLE
[vim] remove special handling for blank line from linewise delete.

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -890,9 +890,6 @@
     }
     RegisterController.prototype = {
       pushText: function(registerName, operator, text, linewise, blockwise) {
-        if (linewise && text.charAt(0) == '\n') {
-          text = text.slice(1) + '\n';
-        }
         if (linewise && text.charAt(text.length - 1) !== '\n'){
           text += '\n';
         }

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -940,6 +940,10 @@ testVim('yy_multiply_repeat', function(cm, vim, helpers) {
   is(register.linewise);
   eqPos(curStart, cm.getCursor());
 });
+testVim('2dd_blank_P', function(cm, vim, helpers) {
+  helpers.doKeys('2', 'd', 'd', 'P');
+  eq('\na\n\n', cm.getValue());
+}, { value: '\na\n\n' });
 // Change commands behave like d commands except that it also enters insert
 // mode. In addition, when the change is linewise, an additional newline is
 // inserted so that insert mode starts on that line.


### PR DESCRIPTION
I'm not sure why that handling was ever there in the first place.  Removing it fixes my newly added test and breaks none of the unit tests.  Also verified manually in the vim demo that deleting and pasting seems to be doing the right thing.