### PR TITLE
fix an off-by-one error in bracket matching.

### DIFF
--- a/addon/edit/matchbrackets.js
+++ b/addon/edit/matchbrackets.js
@@ -17,8 +17,8 @@
   var matching = {"(": ")>", ")": "(<", "[": "]>", "]": "[<", "{": "}>", "}": "{<"};
 
   function findMatchingBracket(cm, where, strict, config) {
-    var line = cm.getLineHandle(where.line), pos = where.ch - 1;
-    var match = (pos >= 0 && matching[line.text.charAt(pos)]) || matching[line.text.charAt(++pos)];
+    var line = cm.getLineHandle(where.line), pos = where.ch;
+    var match = (pos >= 0 && matching[line.text.charAt(pos)]);
     if (!match) return null;
     var dir = match.charAt(1) == ">" ? 1 : -1;
     if (strict && (dir > 0) != (pos == where.ch)) return null;


### PR DESCRIPTION
Parenthesis matching highlight is off by one.  In my example, my cursor is at the end of the line (last close parenthesis), yet the highlight is showing the matching for the previous parenthesis pair. It should be highlighting the parenthesis pair under the cursor. 

I'm not yet sure how to add a unit test for this.