### PR TITLE
Add proper MIME type for Rust

### DIFF
--- a/mode/rust/rust.js
+++ b/mode/rust/rust.js
@@ -68,4 +68,5 @@ CodeMirror.defineSimpleMode("rust",{
 
 
 CodeMirror.defineMIME("text/x-rustsrc", "rust");
+CodeMirror.defineMIME("text/rust", "rust");
 });


### PR DESCRIPTION
leave the old one for now (maybe some old code depends on it).

See:
https://bugs.freedesktop.org/show_bug.cgi?id=90487
https://github.com/rust-lang/kate-config/pull/6