### PR TITLE
Use cursor stickiness in ensureCursorVisible

### DIFF
--- a/src/display/scrolling.js
+++ b/src/display/scrolling.js
@@ -35,6 +35,13 @@ export function maybeScrollWindow(cm, rect) {
 export function scrollPosIntoView(cm, pos, end, margin) {
   if (margin == null) margin = 0
   let rect
+  if (!cm.options.lineWrapping && pos == end) {
+    // Set pos and end to the cursor positions around the character pos sticks to
+    // If pos.sticky == "before", that is around pos.ch - 1, otherwise around pos.ch
+    // If pos == Pos(_, 0, "before"), pos and end are unchanged
+    pos = pos.ch ? Pos(pos.line, pos.sticky == "before" ? pos.ch - 1 : pos.ch, "after") : pos
+    end = pos.sticky == "before" ? Pos(pos.line, pos.ch + 1, "before") : pos
+  }
   for (let limit = 0; limit < 5; limit++) {
     let changed = false
     let coords = cursorCoords(cm, pos)
@@ -109,12 +116,8 @@ export function addToScrollTop(cm, top) {
 // shown.
 export function ensureCursorVisible(cm) {
   resolveScrollToPos(cm)
-  let cur = cm.getCursor(), from = cur, to = cur
-  if (!cm.options.lineWrapping) {
-    from = cur.ch ? Pos(cur.line, cur.ch - 1) : cur
-    to = Pos(cur.line, cur.ch + 1)
-  }
-  cm.curOp.scrollToPos = {from: from, to: to, margin: cm.options.cursorScrollMargin}
+  let cur = cm.getCursor()
+  cm.curOp.scrollToPos = {from: cur, to: cur, margin: cm.options.cursorScrollMargin}
 }
 
 export function scrollToCoords(cm, x, y) {

--- a/test/scroll_test.js
+++ b/test/scroll_test.js
@@ -112,4 +112,15 @@
     cm.scrollTo(null, 10);
     is(cm.getScrollInfo().top < 5);
   }, {lineNumbers: true});
+
+  testCM("bidi_ensureCursorVisible", function(cm) {
+    cm.setValue("<dd>وضع الاستخدام. عندما لا تعطى، وهذا الافتراضي إلى الطريقة الاولى\n");
+    cm.execCommand("goLineStart");
+    eq(cm.getScrollInfo().left, 0);
+    cm.execCommand("goCharRight");
+    cm.execCommand("goCharRight");
+    cm.execCommand("goCharRight");
+    eqCursorPos(cm.getCursor(), Pos(0, 3, "before"));
+    eq(cm.getScrollInfo().left, 0);
+  }, {lineWrapping: false});
 })();


### PR DESCRIPTION
This way, only one char's left and right edges are used, instead of its
(logical) neighbour's right edges.

In bidi content, this avoids trying to scroll to two logically close,
but visually far apart positions in some situations.

Refer to #2254 for the original reason for this code.