### PR TITLE
[search] Apply normalization in adjustPos, too

### DIFF
--- a/addon/search/searchcursor.js
+++ b/addon/search/searchcursor.js
@@ -129,7 +129,7 @@
   function adjustPos(orig, folded, pos) {
     if (orig.length == folded.length) return pos
     for (var pos1 = Math.min(pos, orig.length);;) {
-      var len1 = orig.slice(0, pos1).toLowerCase().length
+      var len1 = doFold(orig.slice(0, pos1)).length
       if (len1 < pos) ++pos1
       else if (len1 > pos) --pos1
       else return pos1

--- a/test/search_test.js
+++ b/test/search_test.js
@@ -70,7 +70,6 @@
   })
 
   test("expandingCaseFold", function() {
-    if (phantom) return; // A Phantom bug makes this hang
     var doc = new CodeMirror.Doc("<b>İİ İİ</b>\n<b>uu uu</b>")
     run(doc, "</b>", true, 0, 8, 0, 12, 1, 8, 1, 12);
     run(doc, "İİ", true, 0, 3, 0, 5, 0, 6, 0, 8);


### PR DESCRIPTION
This prevents the test case search_expandingCaseFold from hanging in
Firefox 54 on Linux. Also enables the test in phantom.