### PR TITLE
Make line height calculations more tolerant of browser rounding errors

### DIFF
--- a/src/display/update_lines.js
+++ b/src/display/update_lines.js
@@ -21,7 +21,7 @@ export function updateHeightsInViewport(cm) {
     }
     let diff = cur.line.height - height
     if (height < 2) height = textHeight(display)
-    if (diff > .001 || diff < -.001) {
+    if (diff > .005 || diff < -.005) {
       updateLineHeight(cur.line, height)
       updateWidgetHeight(cur.line)
       if (cur.rest) for (let j = 0; j < cur.rest.length; j++)


### PR DESCRIPTION
I've got an application which basically uses CodeMirror to display a monospace grid of characters, e.g. terminal emulator. Each row should be the same height. But I've noticed that when about 1000 lines of content is put into CodeMirror, scrolling around the document will cause the pixel height of the document to change slightly. My app combines multiple instances of CodeMirror on the same page, and is somewhat sensitive to changes in CodeMirror height. By sensitive I mean that these changes in height appear as misalignments in the UI and/or flickering as things resize for no apparent reason.

This only seems to happen when Electron (read: Chrome/Blink) is run on my laptop and it automatically scales the UI and content by approximately 120% (due to the high DPI of the screen). With this scaling factor in place, a lot of fractional pixels sizes are generated and reported by `element.getBoundingClientRect()`.

I see that CodeMirror's `updateHeightsInViewport()` method tries to update it list of line sizes as and when they are shown in the viewport. This is the cause of the document size changes during scrolling. I also see the tolerance factor of 0.001 being used. From my tests I'm seeing height differences of about 0.0046.

My proposal is to up the tolerance from 0.001 to 0.005 to avoid unneeded changes to the height of the whole document.

(This is on Electron 1.6.8 which is basically Chromium 56. CodeMirror 5.21.0)
