### PR TITLE
Provide better error messages if the source library is missing.

### DIFF
--- a/addon/lint/coffeescript-lint.js
+++ b/addon/lint/coffeescript-lint.js
@@ -17,6 +17,12 @@
 
 CodeMirror.registerHelper("lint", "coffeescript", function(text) {
   var found = [];
+  if (!window.coffeelint) {
+    if (window.console) {
+      window.console.error("Error: window.coffeelint not defined, CodeMirror CoffeeScript linting cannot run.");
+    }
+    return found;
+  }
   var parseError = function(err) {
     var loc = err.lineNumber;
     found.push({from: CodeMirror.Pos(loc-1, 0),

--- a/addon/lint/css-lint.js
+++ b/addon/lint/css-lint.js
@@ -17,7 +17,12 @@
 
 CodeMirror.registerHelper("lint", "css", function(text) {
   var found = [];
-  if (!window.CSSLint) return found;
+  if (!window.CSSLint) {
+    if (window.console) {
+        window.console.error("Error: window.CSSLint not defined, CodeMirror CSS linting cannot run.");
+    }
+    return found;
+  }
   var results = CSSLint.verify(text), messages = results.messages, message = null;
   for ( var i = 0; i < messages.length; i++) {
     message = messages[i];

--- a/addon/lint/html-lint.js
+++ b/addon/lint/html-lint.js
@@ -29,7 +29,12 @@
 
   CodeMirror.registerHelper("lint", "html", function(text, options) {
     var found = [];
-    if (!window.HTMLHint) return found;
+    if (!window.HTMLHint) {
+      if (window.console) {
+          window.console.error("Error: window.HTMLHint not defined, CodeMirror HTML linting cannot run.");
+      }
+      return found;
+    }
     var messages = HTMLHint.verify(text, options && options.rules || defaultRules);
     for (var i = 0; i < messages.length; i++) {
       var message = messages[i];

--- a/addon/lint/javascript-lint.js
+++ b/addon/lint/javascript-lint.js
@@ -22,7 +22,12 @@
                  "Unclosed string", "Stopping, unable to continue" ];
 
   function validator(text, options) {
-    if (!window.JSHINT) return [];
+    if (!window.JSHINT) {
+      if (window.console) {
+        window.console.error("Error: window.JSHINT not defined, CodeMirror JavaScript linting cannot run.");
+      }
+      return [];
+    }
     JSHINT(text, options, options.globals);
     var errors = JSHINT.data().errors, result = [];
     if (errors) parseErrors(errors, result);

--- a/addon/lint/json-lint.js
+++ b/addon/lint/json-lint.js
@@ -17,6 +17,12 @@
 
 CodeMirror.registerHelper("lint", "json", function(text) {
   var found = [];
+  if (!window.jsonlint) {
+    if (window.console) {
+      window.console.error("Error: window.jsonlint not defined, CodeMirror JSON linting cannot run.");
+    }
+    return found;
+  }
   jsonlint.parseError = function(str, hash) {
     var loc = hash.loc;
     found.push({from: CodeMirror.Pos(loc.first_line - 1, loc.first_column),

--- a/addon/lint/yaml-lint.js
+++ b/addon/lint/yaml-lint.js
@@ -17,6 +17,12 @@
 
 CodeMirror.registerHelper("lint", "yaml", function(text) {
   var found = [];
+  if (!window.jsyaml) {
+    if (window.console) {
+      window.console.error("Error: window.jsyaml not defined, CodeMirror YAML linting cannot run.");
+    }
+    return found;
+  }
   try { jsyaml.load(text); }
   catch(e) {
       var loc = e.mark,


### PR DESCRIPTION
This should help developers building this functionality out that may not
realize they need to source the linting library separately.

I ran into this after having it fail silently before I realized I needed the external library.