### PR TITLE
Expose startOperation/endOperation in CodeMirror API.

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2048,6 +2048,17 @@ editor.setOption("extraKeys", {
       lot faster. The return value from this method will be the return
       value of your function.</dd>
 
+      <dt><code><strong>cm.startOperation</strong>()</code></dt>
+      <dt><code><strong>cm.endOperation</strong>()</code></dt>
+      <dd>In normal circumstances, use the above <code>operation</code>
+      method. But if you want to buffer operations happening asynchronously,
+      or that can't all be wrapped in a callback function, you can
+      call <code>startOperation</code> to tell CodeMirror to start
+      buffering changes, and <code>endOperation</code> to actually
+      render all the updates. <em>Be careful:</em> if you use this
+      API and forget to call <code>endOperation</code>, the editor will
+      just never update.</dd>
+
       <dt id="indentLine"><code><strong>cm.indentLine</strong>(line: integer, ?dir: string|integer)</code></dt>
       <dd>Adjust the indentation of the given line. The second
       argument (which defaults to <code>"smart"</code>) may be one of:

--- a/src/edit/methods.js
+++ b/src/edit/methods.js
@@ -10,7 +10,7 @@ import { onKeyDown, onKeyPress, onKeyUp } from "./key_events"
 import { onMouseDown } from "./mouse_events"
 import { getKeyMap } from "../input/keymap"
 import { endOfLine, moveLogically, moveVisually } from "../input/movement"
-import { methodOp, operation, runInOp } from "../display/operations"
+import { endOperation, methodOp, operation, runInOp, startOperation } from "../display/operations"
 import { clipLine, clipPos, equalCursorPos, Pos } from "../line/pos"
 import { charCoords, charWidth, clearCaches, clearLineMeasurementCache, coordsChar, cursorCoords, displayHeight, displayWidth, estimateLineHeights, fromCoordSystem, intoCoordSystem, scrollGap, textHeight } from "../measurement/position_measurement"
 import { Range } from "../model/selection"
@@ -405,6 +405,8 @@ export default function(CodeMirror) {
     }),
 
     operation: function(f){return runInOp(this, f)},
+    startOperation: function(){return startOperation(this)},
+    endOperation: function(){return endOperation(this)},
 
     refresh: methodOp(function() {
       let oldHeight = this.display.cachedTextHeight


### PR DESCRIPTION
This PR makes it possible for users to call `startOperation` and `endOperation` to batch changes that occur asynchronously. It also adds docs for those methods making clear that they are not for normal use cases and require some care. ([As discussed in this Discuss thread](https://discuss.codemirror.net/t/expose-startoperation-and-endoperation/1301/2))

