### PR TITLE
[sublime keymap] "Add to selection" bindings

### DIFF
--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -164,7 +164,7 @@
     if (fullWord)
       cm.state.sublimeFindFullWord = cm.doc.sel;
   };
-  
+
   function addCursorToSelection(cm, dir) {
     var ranges = cm.listSelections(), newRanges = [];
     for (var i = 0; i < ranges.length; i++) {
@@ -177,7 +177,7 @@
     }
     cm.setSelections(newRanges);
   }
-  
+
   var addCursorToLineCombo = mac ? "Shift-Cmd" : 'Alt-Ctrl';
   cmds[map[addCursorToLineCombo + "Up"] = "addCursorToPrevLine"] = function(cm) { addCursorToSelection(cm, -1); };
   cmds[map[addCursorToLineCombo + "Down"] = "addCursorToNextLine"] = function(cm) { addCursorToSelection(cm, 1); };

--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -164,6 +164,23 @@
     if (fullWord)
       cm.state.sublimeFindFullWord = cm.doc.sel;
   };
+  
+  function addCursorToSelection(cm, dir) {
+    var ranges = cm.listSelections(), newRanges = [];
+    for (var i = 0; i < ranges.length; i++) {
+      var range = ranges[i];
+      var newAnchor = cm.findPosV(range.anchor, dir, "line");
+      var newHead = cm.findPosV(range.head, dir, "line");
+      var newRange = {anchor: newAnchor, head: newHead};
+      newRanges.push(range);
+      newRanges.push(newRange);
+    }
+    cm.setSelections(newRanges);
+  }
+  
+  var addCursorToLineCombo = mac ? "Shift-Cmd" : 'Alt-Ctrl';
+  cmds[map[addCursorToLineCombo + "Up"] = "addCursorToPrevLine"] = function(cm) { addCursorToSelection(cm, -1); };
+  cmds[map[addCursorToLineCombo + "Down"] = "addCursorToNextLine"] = function(cm) { addCursorToSelection(cm, 1); };
 
   function isSelectedRange(ranges, from, to) {
     for (var i = 0; i < ranges.length; i++)


### PR DESCRIPTION
These bindings clone the cursors by moving them up or down by one line (Ctrl-Alt-Up/Down on Windows, Cmd-Shift-Up/Down on Mac). Closes #4850.