### PR TITLE
Line numbers should be placed before dropmarkers

### DIFF
--- a/src/display/gutters.js
+++ b/src/display/gutters.js
@@ -26,7 +26,7 @@ export function updateGutters(cm) {
 export function setGuttersForLineNumbers(options) {
   let found = indexOf(options.gutters, "CodeMirror-linenumbers")
   if (found == -1 && options.lineNumbers) {
-    options.gutters.unshift(["CodeMirror-linenumbers"])
+    options.gutters.unshift("CodeMirror-linenumbers")
   } else if (found > -1 && !options.lineNumbers) {
     options.gutters = options.gutters.slice(0)
     options.gutters.splice(found, 1)

--- a/src/display/gutters.js
+++ b/src/display/gutters.js
@@ -26,7 +26,7 @@ export function updateGutters(cm) {
 export function setGuttersForLineNumbers(options) {
   let found = indexOf(options.gutters, "CodeMirror-linenumbers")
   if (found == -1 && options.lineNumbers) {
-    options.gutters = options.gutters.concat(["CodeMirror-linenumbers"])
+    options.gutters.unshift(["CodeMirror-linenumbers"])
   } else if (found > -1 && !options.lineNumbers) {
     options.gutters = options.gutters.slice(0)
     options.gutters.splice(found, 1)


### PR DESCRIPTION
Firefox bug 1381523:
Line numbers are created after dropmarkers in some cases. They should be placed before dropmarkers.
https://bugzilla.mozilla.org/show_bug.cgi?id=1381523