### PR TITLE
SQL line comments start with "--"

### DIFF
--- a/mode/sql/sql.js
+++ b/mode/sql/sql.js
@@ -193,7 +193,7 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
 
     blockCommentStart: "/*",
     blockCommentEnd: "*/",
-    lineComment: support.commentSlashSlash ? "//" : support.commentHash ? "#" : null
+    lineComment: support.commentSlashSlash ? "//" : support.commentHash ? "#" : "--"
   };
 });
 


### PR DESCRIPTION
SQL line comments start with "--" unless it's explicitly something else (i.e. `//` or `#`). Currently `lineComment` in the SQL mode is set to `null` whenever there isn't an explicit exception, which forces typical SQL modes to only do block comments. 