### PR TITLE
D Mode: Fix nested comments

### DIFF
--- a/mode/d/d.js
+++ b/mode/d/d.js
@@ -44,7 +44,7 @@ CodeMirror.defineMode("d", function(config, parserConfig) {
     }
     if (ch == "/") {
       if (stream.eat("+")) {
-        state.tokenize = tokenComment;
+        state.tokenize = tokenNestedComment;
         return tokenNestedComment(stream, state);
       }
       if (stream.eat("*")) {


### PR DESCRIPTION
The D mode for CodeMirror currently doesn't work well with [nested comments](http://dlang.org/spec/lex.html#comment).

Example
------------

```d
/+
I am a fancy string
+/
void main(){}
```

Try the following e.g. [here](http://codemirror.net/mode/d/index.html) - The entire text will be highlighted as comment.

See also:
- https://github.com/dlang-tour/core/pull/607
- http://dlang.org/spec/lex.html#comment

I have already applied this fix for run.dlang.io and put it in the merge queue. It should appear at e.g. https://run.dlang.io/gist/ddccbc1c0bf3ea9fb5723f1ccb9c3e42?compiler=dmd soon.