### PR TITLE
Use background-color for cm-searching

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -319,8 +319,8 @@ div.CodeMirror-dragcursors {
 .CodeMirror-line::-moz-selection, .CodeMirror-line > span::-moz-selection, .CodeMirror-line > span > span::-moz-selection { background: #d7d4f0; }
 
 .cm-searching {
-  background: #ffa;
-  background: rgba(255, 255, 0, .4);
+  background-color: #ffa;
+  background-color: rgba(255, 255, 0, .4);
 }
 
 /* Used to force a border model for a node */


### PR DESCRIPTION
At work we use a spell-checker plugin for CodeMirror, and give misspelled words a wiggly red underline with this CSS:

```css
.cm-spell-error {
    background-image: image-url('resources/red_underline.png');
    background-position: bottom;
    background-repeat: repeat-x;
}
```

Unfortunately, misspelled things don't get underlined when you search for them, because the `cm-searching` style sets the `background` property, rather than just the `background-color`, so it overrides everything.