### PR TITLE
[markdown mode] disallow lists and fencedCode inside blockquote

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -196,7 +196,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     } else if (stream.match(hrRE, true)) {
       state.hr = true;
       return tokenTypes.hr;
-    } else if (match = stream.match(listRE)) {
+    } else if (!state.quote && (match = stream.match(listRE))) {
       var listType = match[1] ? "ol" : "ul";
 
       state.indentation = lineIndentation + stream.current().length;
@@ -211,7 +211,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       state.f = state.inline;
       if (modeCfg.highlightFormatting) state.formatting = ["list", "list-" + listType];
       return getType(state);
-    } else if (modeCfg.fencedCodeBlocks && (match = stream.match(fencedCodeRE, true))) {
+    } else if (modeCfg.fencedCodeBlocks && !state.quote && (match = stream.match(fencedCodeRE, true))) {
       state.fencedChars = match[1]
       // try switching mode
       state.localMode = getMode(match[2]);
@@ -400,7 +400,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       if (modeCfg.highlightFormatting) state.formatting = "code";
       stream.eatWhile('`');
       var count = stream.current().length
-      if (state.code == 0) {
+      if (state.code == 0 && (!state.quote || count == 1)) {
         state.code = count
         return getType(state)
       } else if (count == state.code) { // Must be exact

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -323,6 +323,20 @@
      "",
      "hello");
 
+  // disallow lists inside blockquote for now because it causes problems outside blockquote
+  // TODO: fix to be CommonMark-compliant
+  MT("listNestedInBlockquote",
+     "[quote&quote-1 > - foo]");
+
+  // disallow fenced blocks inside blockquote because it causes problems outside blockquote
+  // TODO: fix to be CommonMark-compliant
+  MT("fencedBlockNestedInBlockquote",
+     "[quote&quote-1 > ```]",
+     "[quote&quote-1 > code]",
+     "[quote&quote-1 > ```]",
+     // ensure we still allow inline code
+     "[quote&quote-1 > ][quote&quote-1&comment `code`]");
+
   // Header with leading space after continued blockquote (#3287, negative indentation)
   MT("headerAfterContinuedBlockquote",
      "[quote&quote-1 > foo]",


### PR DESCRIPTION
Semi-fixes https://github.com/codemirror/CodeMirror/issues/4151 where fencedBlock in blockquotes was badly styled and lists leaked outside.

This is not a CM-compliant fix but is better than the previous buggy behavior.

Sometimes in the future I may look into making it CM-compliant (i.e. properly allow lists and codeBlocks inside blockquotes).