### PR TITLE
Add additional MIME types

### DIFF
--- a/mode/asciiarmor/asciiarmor.js
+++ b/mode/asciiarmor/asciiarmor.js
@@ -68,6 +68,7 @@
   });
 
   CodeMirror.defineMIME("application/pgp", "asciiarmor");
+  CodeMirror.defineMIME("application/pgp-encrypted", "asciiarmor");
   CodeMirror.defineMIME("application/pgp-keys", "asciiarmor");
   CodeMirror.defineMIME("application/pgp-signature", "asciiarmor");
 });

--- a/mode/asciiarmor/index.html
+++ b/mode/asciiarmor/index.html
@@ -41,6 +41,6 @@ var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
 </script>
 
 <p><strong>MIME types
-defined:</strong> <code>application/pgp</code>, <code>application/pgp-keys</code>, <code>application/pgp-signature</code></p>
+defined:</strong> <code>application/pgp</code>, <code>application/pgp-encrypted</code>, <code>application/pgp-keys</code>, <code>application/pgp-signature</code></p>
 
 </article>

--- a/mode/coffeescript/coffeescript.js
+++ b/mode/coffeescript/coffeescript.js
@@ -349,6 +349,10 @@ CodeMirror.defineMode("coffeescript", function(conf, parserConf) {
   return external;
 });
 
+// IANA registered media type
+// https://www.iana.org/assignments/media-types/
+CodeMirror.defineMIME("application/vnd.coffeescript", "coffeescript");
+
 CodeMirror.defineMIME("text/x-coffeescript", "coffeescript");
 CodeMirror.defineMIME("text/coffeescript", "coffeescript");
 

--- a/mode/coffeescript/index.html
+++ b/mode/coffeescript/index.html
@@ -733,7 +733,7 @@ wrapper::value = -> this._wrapped
       var editor = CodeMirror.fromTextArea(document.getElementById("code"), {});
     </script>
 
-    <p><strong>MIME types defined:</strong> <code>text/x-coffeescript</code>.</p>
+    <p><strong>MIME types defined:</strong> <code>application/vnd.coffeescript</code>, <code>text/coffeescript</code>, <code>text/x-coffeescript</code>.</p>
 
     <p>The CoffeeScript mode was written by Jeff Pickhardt.</p>
 

--- a/mode/meta.js
+++ b/mode/meta.js
@@ -121,7 +121,7 @@
     {name: "Scala", mime: "text/x-scala", mode: "clike", ext: ["scala"]},
     {name: "Scheme", mime: "text/x-scheme", mode: "scheme", ext: ["scm", "ss"]},
     {name: "SCSS", mime: "text/x-scss", mode: "css", ext: ["scss"]},
-    {name: "Shell", mime: "text/x-sh", mode: "shell", ext: ["sh", "ksh", "bash"], alias: ["bash", "sh", "zsh"], file: /^PKGBUILD$/},
+    {name: "Shell", mimes: ["text/x-sh", "application/x-sh"], mode: "shell", ext: ["sh", "ksh", "bash"], alias: ["bash", "sh", "zsh"], file: /^PKGBUILD$/},
     {name: "Sieve", mime: "application/sieve", mode: "sieve", ext: ["siv", "sieve"]},
     {name: "Slim", mimes: ["text/x-slim", "application/x-slim"], mode: "slim", ext: ["slim"]},
     {name: "Smalltalk", mime: "text/x-stsrc", mode: "smalltalk", ext: ["st"]},

--- a/mode/meta.js
+++ b/mode/meta.js
@@ -25,7 +25,7 @@
     {name: "ClojureScript", mime: "text/x-clojurescript", mode: "clojure", ext: ["cljs"]},
     {name: "Closure Stylesheets (GSS)", mime: "text/x-gss", mode: "css", ext: ["gss"]},
     {name: "CMake", mime: "text/x-cmake", mode: "cmake", ext: ["cmake", "cmake.in"], file: /^CMakeLists.txt$/},
-    {name: "CoffeeScript", mime: "text/x-coffeescript", mode: "coffeescript", ext: ["coffee"], alias: ["coffee", "coffee-script"]},
+    {name: "CoffeeScript", mimes: ["application/vnd.coffeescript", "text/coffeescript", "text/x-coffeescript"], mode: "coffeescript", ext: ["coffee"], alias: ["coffee", "coffee-script"]},
     {name: "Common Lisp", mime: "text/x-common-lisp", mode: "commonlisp", ext: ["cl", "lisp", "el"], alias: ["lisp"]},
     {name: "Cypher", mime: "application/x-cypher-query", mode: "cypher", ext: ["cyp", "cypher"]},
     {name: "Cython", mime: "text/x-cython", mode: "python", ext: ["pyx", "pxd", "pxi"]},

--- a/mode/meta.js
+++ b/mode/meta.js
@@ -13,7 +13,7 @@
 
   CodeMirror.modeInfo = [
     {name: "APL", mime: "text/apl", mode: "apl", ext: ["dyalog", "apl"]},
-    {name: "PGP", mimes: ["application/pgp", "application/pgp-keys", "application/pgp-signature"], mode: "asciiarmor", ext: ["pgp"]},
+    {name: "PGP", mimes: ["application/pgp", "application/pgp-encrypted", "application/pgp-keys", "application/pgp-signature"], mode: "asciiarmor", ext: ["asc", "pgp", "sig"]},
     {name: "ASN.1", mime: "text/x-ttcn-asn", mode: "asn.1", ext: ["asn", "asn1"]},
     {name: "Asterisk", mime: "text/x-asterisk", mode: "asterisk", file: /^extensions\.conf$/i},
     {name: "Brainfuck", mime: "text/x-brainfuck", mode: "brainfuck", ext: ["b", "bf"]},

--- a/mode/shell/index.html
+++ b/mode/shell/index.html
@@ -62,5 +62,5 @@ exit 0</textarea>
   });
 </script>
 
-<p><strong>MIME types defined:</strong> <code>text/x-sh</code>.</p>
+<p><strong>MIME types defined:</strong> <code>text/x-sh</code>, <code>application/x-sh</code>.</p>
 </article>

--- a/mode/shell/shell.js
+++ b/mode/shell/shell.js
@@ -135,5 +135,8 @@ CodeMirror.defineMode('shell', function() {
 });
 
 CodeMirror.defineMIME('text/x-sh', 'shell');
+// Apache uses a slightly different Media Type for Shell scripts
+// http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types
+CodeMirror.defineMIME('application/x-sh', 'shell');
 
 });


### PR DESCRIPTION
Found a few more useful additions.

Most of these findings are from using the https://github.com/jshttp/mime-db/ project which attempts to aggregate the IANA, Apache, and nginx type lists.

I've not made it through their whole JSON file (yet! :wink:):
https://github.com/jshttp/mime-db/blob/master/db.json

I'll send a few more of these (most likely) as I trip over ones I need. Hope that's OK!

Tnx!
🎩 