### PR TITLE
[markdown mode] improve CommonMark compliance for several rules

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -270,14 +270,17 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   }
 
   function local(stream, state) {
-    if (state.fencedChars && stream.match(state.fencedChars)) {
+    var hasExitedList = state.indentation < state.listStack[state.listStack.length - 1];
+    if (state.fencedChars && (hasExitedList || stream.match(state.fencedChars))) {
       if (modeCfg.highlightFormatting) state.formatting = "code-block";
-      var returnType = getType(state)
+      var returnType;
+      if (!hasExitedList) returnType = getType(state)
       state.localMode = state.localState = null;
       state.block = blockNormal;
       state.f = inlineNormal;
       state.fencedChars = null;
       state.code = 0
+      if (hasExitedList) return switchBlock(stream, state, state.block);
       return returnType;
     } else if (state.fencedChars && stream.skipTo(state.fencedChars)) {
       return "comment"

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -138,7 +138,6 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   }
 
   function blockNormal(stream, state) {
-    var sol = stream.sol();
     var firstTokenOnLine = stream.column() === state.indentation;
     var prevLineLineIsEmpty = lineIsEmpty(state.prevLine);
     var prevLineIsIndentedCode = state.indentedCode;
@@ -189,8 +188,8 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       if (modeCfg.highlightFormatting) state.formatting = "header";
       state.f = state.inline;
       return getType(state);
-    } else if (stream.eat('>')) {
-      state.quote = sol ? 1 : state.quote + 1;
+    } else if (state.indentation <= maxNonCodeIndentation && stream.eat('>')) {
+      state.quote = firstTokenOnLine ? 1 : state.quote + 1;
       if (modeCfg.highlightFormatting) state.formatting = "quote";
       stream.eatSpace();
       return getType(state);

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -90,6 +90,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   ,   textRE = /^[^#!\[\]*_\\<>` "'(~:]+/
   ,   fencedCodeRE = new RegExp("^(" + (modeCfg.fencedCodeBlocks === true ? "~~~+|```+" : modeCfg.fencedCodeBlocks) +
                                 ")[ \\t]*([\\w+#\-]*)")
+  ,   linkDefRE = /^\s*\[[^\]]+?\]:\s*\S+(\s*\S*\s*)?$/ // naive link-definition
   ,   punctuation = /[!\"#$%&\'()*+,\-\.\/:;<=>?@\[\\\]^_`{|}~—]/
   ,   expandedTab = "    " // CommonMark specifies tab as 4 spaces
 
@@ -110,6 +111,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   // Blocks
 
   function blankLine(state) {
+    state.hr = false;
     // Reset linkTitle state
     state.linkTitle = false;
     // Reset EM state
@@ -137,16 +139,18 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
   function blockNormal(stream, state) {
     var sol = stream.sol();
+    var prevLineLineIsEmpty = lineIsEmpty(state.prevLine);
+    var prevLineIsIndentedCode = state.indentedCode;
+    var prevLineIsHr = state.hr;
+    var prevLineIsList = state.list !== false;
+    var maxNonCodeIndentation = (state.listStack[state.listStack.length - 1] || 0) + 3;
 
-    var prevLineIsList = state.list !== false,
-        prevLineIsIndentedCode = state.indentedCode;
-
+    state.hr = false;
     state.indentedCode = false;
 
-    var lineIndentation;
+    var lineIndentation = state.indentation;
     // compute once per line (on first token)
     if (state.indentationDiff === null) {
-      lineIndentation = state.indentation;
       state.indentationDiff = state.indentation;
       if (prevLineIsList) {
         state.list = null;
@@ -168,8 +172,11 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       }
     }
 
+    var isHr = (state.list === false || prevLineIsHr || prevLineLineIsEmpty) &&
+      state.indentation <= maxNonCodeIndentation && stream.match(hrRE);
+
     var match = null;
-    if (state.indentationDiff >= 4 && (prevLineIsIndentedCode || lineIsEmpty(state.prevLine))) {
+    if (state.indentationDiff >= 4 && (prevLineIsIndentedCode || prevLineLineIsEmpty)) {
       stream.skipToEnd();
       state.indentedCode = true;
       return tokenTypes.code;
@@ -180,23 +187,12 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       if (modeCfg.highlightFormatting) state.formatting = "header";
       state.f = state.inline;
       return getType(state);
-    } else if (!lineIsEmpty(state.prevLine) && !state.quote && !prevLineIsList &&
-               !prevLineIsIndentedCode && (match = stream.match(setextHeaderRE))) {
-      state.header = match[0].charAt(0) == '=' ? 1 : 2;
-      if (modeCfg.highlightFormatting) state.formatting = "header";
-      state.f = state.inline;
-      return getType(state);
     } else if (stream.eat('>')) {
       state.quote = sol ? 1 : state.quote + 1;
       if (modeCfg.highlightFormatting) state.formatting = "quote";
       stream.eatSpace();
       return getType(state);
-    } else if (stream.peek() === '[') {
-      return switchInline(stream, state, footnoteLink);
-    } else if (stream.match(hrRE, true)) {
-      state.hr = true;
-      return tokenTypes.hr;
-    } else if (!state.quote && (match = stream.match(listRE))) {
+    } else if (!isHr && !state.quote && (match = stream.match(listRE))) {
       var listType = match[1] ? "ol" : "ul";
 
       state.indentation = lineIndentation + stream.current().length;
@@ -220,6 +216,35 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       if (modeCfg.highlightFormatting) state.formatting = "code-block";
       state.code = -1
       return getType(state);
+    // SETEXT has lowest block-scope precedence after HR, so check it after
+    //  the others (code, blockquote, list...)
+    } else if (
+      // if setext set, indicates line after ---/===
+      state.setext || (
+        // line before ---/===
+        !state.quote && state.list === false && !state.code && !isHr &&
+        !prevLineIsList && !linkDefRE.test(stream.string) &&
+        (match = stream.lookAhead(1)) && (match = match.match(setextHeaderRE))
+      )
+    ) {
+      if ( !state.setext ) {
+        state.header = match[0].charAt(0) == '=' ? 1 : 2;
+        state.setext = state.header;
+      } else {
+        state.header = state.setext;
+        // has no effect on type so we can reset it now
+        state.setext = 0;
+        stream.skipToEnd();
+        if (modeCfg.highlightFormatting) state.formatting = "header";
+      }
+      state.f = state.inline;
+      return getType(state);
+    } else if (isHr) {
+      stream.skipToEnd();
+      state.hr = true;
+      return tokenTypes.hr;
+    } else if (stream.peek() === '[') {
+      return switchInline(stream, state, footnoteLink);
     }
 
     return switchInline(stream, state, state.inline);
@@ -703,6 +728,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
         em: false,
         strong: false,
         header: 0,
+        setext: 0,
         hr: false,
         taskList: false,
         list: false,
@@ -741,6 +767,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
         strikethrough: s.strikethrough,
         emoji: s.emoji,
         header: s.header,
+        setext: s.setext,
         hr: s.hr,
         taskList: s.taskList,
         list: s.list,
@@ -760,9 +787,8 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       state.formatting = false;
 
       if (stream != state.thisLine) {
-        // Reset state.header and state.hr
+        // Reset state.header
         state.header = 0;
-        state.hr = false;
 
         if (stream.match(/^\s*$/, true)) {
           blankLine(state);

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -228,6 +228,19 @@
   MT("atxH1inline",
      "[header&header-1 # foo ][header&header-1&em *bar*]");
 
+  MT("atxIndentedTooMuch",
+     "[header&header-1 # foo]",
+     "    # bar");
+
+  // disable atx inside blockquote until we implement proper blockquote inner mode
+  // TODO: fix to be CommonMark-compliant
+  MT("atxNestedInsideBlockquote",
+     "[quote&quote-1 > # foo]");
+
+  MT("atxAfterBlockquote",
+     "[quote&quote-1 > foo]",
+     "[header&header-1 # bar]");
+
   // Setext headers - H1, H2
   // Per documentation, "Any number of underlining =’s or -’s will work."
   // http://daringfireball.net/projects/markdown/syntax#header
@@ -587,6 +600,19 @@
      "\t[variable-3 * list2]",
      "",
      "\t\t[variable-3 part of list2]");
+
+  MT("listAfterBlockquote",
+     "[quote&quote-1 > foo]",
+     "[variable-2 - bar]");
+
+  // shouldn't create sublist if it's indented more than allowed
+  MT("nestedListIndentedTooMuch",
+     "[variable-2 - foo]",
+     "          [variable-2 - bar]");
+
+  MT("listIndentedTooMuchAfterParagraph",
+     "foo",
+     "    - bar");
 
   // Blockquote
   MT("blockquote",
@@ -1095,6 +1121,19 @@
      "[comment foo]",
      "[comment ~~~]",
      "bar");
+
+  FencedTest("fencedCodeBlocksAfterBlockquote",
+     "[quote&quote-1 > foo]",
+     "[comment ```]",
+     "[comment bar]",
+     "[comment ```]");
+
+  // fencedCode indented too much should act as simple indentedCode
+  //  (hence has no highlight formatting)
+  FT("tooMuchIndentedFencedCode",
+     "    [comment ```]",
+     "    [comment code]",
+     "    [comment ```]");
 
   // Tests that require XML mode
 

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -67,7 +67,7 @@
      "[header&header-1&formatting&formatting-header&formatting-header-1 # ][header&header-1 foo # bar ][header&header-1&formatting&formatting-header&formatting-header-1 #]");
 
   FT("formatting_setextHeader",
-     "foo",
+     "[header&header-1 foo]",
      "[header&header-1&formatting&formatting-header&formatting-header-1 =]");
 
   FT("formatting_blockquote",
@@ -237,27 +237,27 @@
   //
   // Check if single underlining = works
   MT("setextH1",
-     "foo",
+     "[header&header-1 foo]",
      "[header&header-1 =]");
 
   // Check if 3+ ='s work
   MT("setextH1",
-     "foo",
+     "[header&header-1 foo]",
      "[header&header-1 ===]");
 
   // Check if single underlining - works
   MT("setextH2",
-     "foo",
+     "[header&header-2 foo]",
      "[header&header-2 -]");
 
   // Check if 3+ -'s work
   MT("setextH2",
-     "foo",
+     "[header&header-2 foo]",
      "[header&header-2 ---]");
 
   // http://spec.commonmark.org/0.19/#example-45
   MT("setextH2AllowSpaces",
-     "foo",
+     "[header&header-2 foo]",
      "   [header&header-2 ----      ]");
 
   // http://spec.commonmark.org/0.19/#example-44
@@ -265,14 +265,49 @@
      "     [comment foo]",
      "[hr ---]");
 
+  MT("setextAfterFencedCode",
+     "[comment ```]",
+     "[comment foo]",
+     "[comment ```]",
+     "[header&header-2 bar]",
+     "[header&header-2 ---]");
+
+  MT("setextAferATX",
+     "[header&header-1 # foo]",
+     "[header&header-2 bar]",
+     "[header&header-2 ---]");
+
   // http://spec.commonmark.org/0.19/#example-51
   MT("noSetextAfterQuote",
      "[quote&quote-1 > foo]",
+     "[hr ---]",
+     "",
+     "[quote&quote-1 > foo]",
+     "[quote&quote-1 bar]",
      "[hr ---]");
 
   MT("noSetextAfterList",
      "[variable-2 - foo]",
+     "[hr ---]",
+     "",
+     "[variable-2 - foo]",
+     "bar",
      "[hr ---]");
+
+  MT("setext_nestedInlineMarkup",
+     "[header&header-1 foo ][em&header&header-1 *bar*]",
+     "[header&header-1 =]");
+
+  MT("setext_linkDef",
+     "[link [[aaa]]:] [string&url http://google.com 'title']",
+     "[hr ---]");
+
+  // currently, looks max one line ahead, thus won't catch valid CommonMark
+  //  markup
+  MT("setext_oneLineLookahead",
+     "foo",
+     "[header&header-1 bar]",
+     "[header&header-1 =]");
 
   // Single-line blockquote with trailing space
   MT("blockquoteSpace",
@@ -393,6 +428,27 @@
   MT("hrAfterList",
      "[variable-2 - foo]",
      "[hr -----]");
+
+  MT("hrAfterFencedCode",
+     "[comment ```]",
+     "[comment code]",
+     "[comment ```]",
+     "[hr ---]");
+
+  // allow hr inside lists
+  // (require prev line to be empty or hr, TODO: non-CommonMark-compliant)
+  MT("hrInsideList",
+     "[variable-2 - foo]",
+     "",
+     "  [hr ---]",
+     "     [hr ---]",
+     "",
+     "      [comment ---]");
+
+  MT("consecutiveHr",
+     "[hr ---]",
+     "[hr ---]",
+     "[hr ---]");
 
   // Formatting in lists (*)
   MT("listAsteriskFormatting",

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -335,11 +335,21 @@
      "foo",
      "[quote&quote-1 > bar]");
 
-  // Nested blockquote
-  MT("blockquoteSpace",
+  MT("blockquoteNested",
      "[quote&quote-1 > foo]",
      "[quote&quote-1 >][quote&quote-2 > foo]",
      "[quote&quote-1 >][quote&quote-2 >][quote&quote-3 > foo]");
+
+  // ensure quote-level is inferred correctly even if indented
+  MT("blockquoteNestedIndented",
+     " [quote&quote-1 > foo]",
+     " [quote&quote-1 >][quote&quote-2 > foo]",
+     " [quote&quote-1 >][quote&quote-2 >][quote&quote-3 > foo]");
+
+  // ensure quote-level is inferred correctly even if indented
+  MT("blockquoteIndentedTooMuch",
+     "foo",
+     "    > bar");
 
   // Single-line blockquote followed by normal paragraph
   MT("blockquoteThenParagraph",

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -1135,6 +1135,16 @@
      "    [comment code]",
      "    [comment ```]");
 
+  FencedTest("autoTerminateFencedCodeWhenLeavingList",
+     "[variable-2 - list1]",
+     "  [variable-3 - list2]",
+     "    [variable-3&comment ```]",
+     "    [comment code]",
+     "  [variable-3 - list2]",
+     "  [variable-2&comment ```]",
+     "  [comment code]",
+     "[quote&quote-1 > foo]");
+
   // Tests that require XML mode
 
   MT("xmlMode",


### PR DESCRIPTION
# Notes

- improving CommonMark compliance
- aimed at common cases, thus some fixes are still not 100% CommonMark-compliant
- separated PR into several commits to bunch related changes together for easier review
- __SUGGESTION:__ I'd make `fencedCodeBlocks` default in `markdown` to align with CommonMark. It'll simplify the code + solve some bugs which I didn't fix for this purpose.

# Commit notes

- __commit 1__ - _improve setext & hr tokenization_
    - `setext` tokenization
        - semi-fixes [2143](https://github.com/codemirror/CodeMirror/issues/2143) and other improvements
        - __NOT-CM-COMPLIANT:__ looks ahead just one line, thus:
            ```
            heading-line-1
            heading-line-2
            -----
            ```
            will parse as `header-2` only line `[1,2]`, but I aimed at most common cases.
        - shuffled the code a bit due to precedence + took a bit of liberty with stylyguide in the setex conditional expression because it was getting crazy
    - `hr` tokenization
         - recognizes few cases such as multiple hrs after each other, and other improvements
         - __NOT-CM-COMPLIANT:__ require empty line before `hr` if inside list (IMO better to have false-negatives than false-positives -- will lead people to cleaner code, e.g. blank lines around hrs) -- will be fixed in the future.
- __commit 2__ - _improve header, list & fencedCode behavior around blockquote &_ indentation
    - fixes some cases such as lists/fencedCode directly after blockquotes
    - fixes some cases where the block should result in `codeBlock` instead of `header`/`list`...
    - disabled `header` in blockquotes, too, until we implement proper block tokenizing inside blockquotes.
- __commit 3__ - _auto-terminate fencedCode after exiting list_
    - as per CommonMark. Works only for `gfm`/`fencedCodeBlocks`, see notes above.
- __commit 4__ - _improve blockquote indentation behavior_
    - ensure indented blockquotes correctly infers blockquote-levels
    - other indentation fixes

Notable changes:

![image](https://user-images.githubusercontent.com/5153846/28792532-40c8d69a-7630-11e7-8826-4340a4fa653d.png)

