### PR TITLE
[markdown mode] meta stuff

### DIFF
--- a/mode/gfm/gfm.js
+++ b/mode/gfm/gfm.js
@@ -114,7 +114,6 @@ CodeMirror.defineMode("gfm", function(config, modeConfig) {
 
   var markdownConfig = {
     taskLists: true,
-    fencedCodeBlocks: '```',
     strikethrough: true,
     emoji: true
   };

--- a/mode/gfm/index.html
+++ b/mode/gfm/index.html
@@ -103,6 +103,34 @@ See http://github.github.com/github-flavored-markdown/.
 
     <p>Optionally depends on other modes for properly highlighted code blocks.</p>
 
+    <p>Gfm mode supports these options (apart those from base Markdown mode):</p>
+    <ul>
+      <li>
+        <d1>
+          <dt><code>gitHubSpice: boolean</code></dt>
+          <dd>Hashes, issues... (default: <code>true</code>).</dd>
+        </d1>
+      </li>
+      <li>
+        <d1>
+          <dt><code>taskLists: boolean</code></dt>
+          <dd><code>- [ ]</code> syntax (default: <code>true</code>).</dd>
+        </d1>
+      </li>
+      <li>
+        <d1>
+          <dt><code>strikethrough: boolean</code></dt>
+          <dd><code>~~foo~~</code> syntax (default: <code>true</code>).</dd>
+        </d1>
+      </li>
+      <li>
+        <d1>
+          <dt><code>emoji: boolean</code></dt>
+          <dd><code>:emoji:</code> syntax (default: <code>true</code>).</dd>
+        </d1>
+      </li>
+    </ul>
+
     <p><strong>Parsing/Highlighting Tests:</strong> <a href="../../test/index.html#gfm_*">normal</a>,  <a href="../../test/index.html#verbose,gfm_*">verbose</a>.</p>
 
   </article>

--- a/mode/gfm/test.js
+++ b/mode/gfm/test.js
@@ -14,11 +14,6 @@
   FT("doubleBackticks",
      "[comment&formatting&formatting-code ``][comment foo ` bar][comment&formatting&formatting-code ``]");
 
-  FT("codeBlock",
-     "[comment&formatting&formatting-code-block ```css]",
-     "[tag foo]",
-     "[comment&formatting&formatting-code-block ```]");
-
   FT("taskList",
      "[variable-2&formatting&formatting-list&formatting-list-ul - ][meta&formatting&formatting-task [ ]]][variable-2  foo]",
      "[variable-2&formatting&formatting-list&formatting-list-ul - ][property&formatting&formatting-task [x]]][variable-2  foo]");
@@ -40,31 +35,6 @@
 
   MT("emStrongUnderscore",
      "[em&strong ___foo___] bar");
-
-  MT("fencedCodeBlocks",
-     "[comment ```]",
-     "[comment foo]",
-     "",
-     "[comment ```]",
-     "bar");
-
-  MT("fencedCodeBlockModeSwitching",
-     "[comment ```javascript]",
-     "[variable foo]",
-     "",
-     "[comment ```]",
-     "bar");
-
-  MT("fencedCodeBlockModeSwitchingObjc",
-     "[comment ```objective-c]",
-     "[keyword @property] [variable NSString] [operator *] [variable foo];",
-     "[comment ```]",
-     "bar");
-
-  MT("fencedCodeBlocksNoTildes",
-     "~~~",
-     "foo",
-     "~~~");
 
   MT("taskListAsterisk",
      "[variable-2 * ][link&variable-2 [[]]][variable-2 foo]", // Invalid; must have space or x between []
@@ -167,11 +137,6 @@
      "foo asfd:asdf bar");
 
   MT("notALink",
-     "[comment ```css]",
-     "[tag foo] {[property color]:[keyword black];}",
-     "[comment ```][link http://www.example.com/]");
-
-  MT("notALink",
      "[comment ``foo `bar` http://www.example.com/``] hello");
 
   MT("notALink",
@@ -180,17 +145,6 @@
      "[comment `] foo",
      "",
      "[link http://www.example.com/]");
-
-  MT("headerCodeBlockGithub",
-     "[header&header-1 # heading]",
-     "",
-     "[comment ```]",
-     "[comment code]",
-     "[comment ```]",
-     "",
-     "Commit: [link be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2]",
-     "Issue: [link #1]",
-     "Link: [link http://www.example.com/]");
 
   MT("strikethrough",
      "[strikethrough ~~foo~~]");

--- a/mode/markdown/index.html
+++ b/mode/markdown/index.html
@@ -87,7 +87,7 @@ Markdown:
 
     A First Level Header
     ====================
-    
+
     A Second Level Header
     ---------------------
 
@@ -97,11 +97,11 @@ Markdown:
 
     The quick brown fox jumped over the lazy
     dog's back.
-    
+
     ### Header 3
 
     &gt; This is a blockquote.
-    &gt; 
+    &gt;
     &gt; This is the second paragraph in the blockquote.
     &gt;
     &gt; ## This is an H2 in a blockquote
@@ -110,23 +110,23 @@ Markdown:
 Output:
 
     &lt;h1&gt;A First Level Header&lt;/h1&gt;
-    
+
     &lt;h2&gt;A Second Level Header&lt;/h2&gt;
-    
+
     &lt;p&gt;Now is the time for all good men to come to
     the aid of their country. This is just a
     regular paragraph.&lt;/p&gt;
-    
+
     &lt;p&gt;The quick brown fox jumped over the lazy
     dog's back.&lt;/p&gt;
-    
+
     &lt;h3&gt;Header 3&lt;/h3&gt;
-    
+
     &lt;blockquote&gt;
         &lt;p&gt;This is a blockquote.&lt;/p&gt;
-        
+
         &lt;p&gt;This is the second paragraph in the blockquote.&lt;/p&gt;
-        
+
         &lt;h2&gt;This is an H2 in a blockquote&lt;/h2&gt;
     &lt;/blockquote&gt;
 
@@ -140,7 +140,7 @@ Markdown:
 
     Some of these words *are emphasized*.
     Some of these words _are emphasized also_.
-    
+
     Use two asterisks for **strong emphasis**.
     Or, if you prefer, __use two underscores instead__.
 
@@ -148,10 +148,10 @@ Output:
 
     &lt;p&gt;Some of these words &lt;em&gt;are emphasized&lt;/em&gt;.
     Some of these words &lt;em&gt;are emphasized also&lt;/em&gt;.&lt;/p&gt;
-    
+
     &lt;p&gt;Use two asterisks for &lt;strong&gt;strong emphasis&lt;/strong&gt;.
     Or, if you prefer, &lt;strong&gt;use two underscores instead&lt;/strong&gt;.&lt;/p&gt;
-   
+
 
 
 ## Lists ##
@@ -204,7 +204,7 @@ list item text. You can create multi-paragraph list items by indenting
 the paragraphs by 4 spaces or 1 tab:
 
     *   A list item.
-    
+
         With multiple paragraphs.
 
     *   Another item in the list.
@@ -216,7 +216,7 @@ Output:
     &lt;p&gt;With multiple paragraphs.&lt;/p&gt;&lt;/li&gt;
     &lt;li&gt;&lt;p&gt;Another item in the list.&lt;/p&gt;&lt;/li&gt;
     &lt;/ul&gt;
-    
+
 
 
 ### Links ###
@@ -311,7 +311,7 @@ Output:
 
     &lt;p&gt;I strongly recommend against using any
     &lt;code&gt;&amp;lt;blink&amp;gt;&lt;/code&gt; tags.&lt;/p&gt;
-    
+
     &lt;p&gt;I wish SmartyPants used named entities like
     &lt;code&gt;&amp;amp;mdash;&lt;/code&gt; instead of decimal-encoded
     entites like &lt;code&gt;&amp;amp;#8212;&lt;/code&gt;.&lt;/p&gt;
@@ -334,11 +334,20 @@ Output:
 
     &lt;p&gt;If you want your page to validate under XHTML 1.0 Strict,
     you've got to put paragraph tags in your blockquotes:&lt;/p&gt;
-    
+
     &lt;pre&gt;&lt;code&gt;&amp;lt;blockquote&amp;gt;
         &amp;lt;p&amp;gt;For example.&amp;lt;/p&amp;gt;
     &amp;lt;/blockquote&amp;gt;
     &lt;/code&gt;&lt;/pre&gt;
+
+## Fenced code blocks (and syntax highlighting)
+
+```javascript
+for (var i = 0; i < items.length; i++) {
+    console.log(items[i], i); // log them
+}
+```
+
 </textarea></form>
 
     <script>
@@ -350,10 +359,11 @@ Output:
       });
     </script>
 
-    <p>You might want to use the <a href="../gfm/index.html">Github-Flavored Markdown mode</a> instead, which adds support for fenced code blocks and a few other things.</p>
+    <p>If you also want support <code>strikethrough</code>, <code>emoji</code> and few other goodies, check out <a href="../gfm/index.html">Github-Flavored Markdown mode</a>.</p>
 
-    <p>Optionally depends on the XML mode for properly highlighted inline XML blocks.</p>
-    
+    <p>Optionally depends on other modes for properly highlighted code blocks,
+      and XML mode for properly highlighted inline XML blocks.</p>
+
     <p><strong>MIME types defined:</strong> <code>text/x-markdown</code>.</p>
 
     <p><strong>Parsing/Highlighting Tests:</strong> <a href="../../test/index.html#markdown_*">normal</a>,  <a href="../../test/index.html#verbose,markdown_*">verbose</a>.</p>

--- a/mode/markdown/index.html
+++ b/mode/markdown/index.html
@@ -364,6 +364,40 @@ for (var i = 0; i < items.length; i++) {
     <p>Optionally depends on other modes for properly highlighted code blocks,
       and XML mode for properly highlighted inline XML blocks.</p>
 
+    <p>Markdown mode supports these options:</p>
+    <ul>
+      <li>
+        <d1>
+          <dt><code>highlightFormatting: boolean</code></dt>
+          <dd>Whether to separately highlight markdown meta characterts (<code>*[]()</code>etc.) (default: <code>false</code>).</dd>
+        </d1>
+      </li>
+      <li>
+        <d1>
+          <dt><code>maxBlockquoteDepth: boolean</code></dt>
+          <dd>Maximum allowed blockquote nesting (default: <code>0</code> - infinite nesting).</dd>
+        </d1>
+      </li>
+      <li>
+        <d1>
+          <dt><code>xml: boolean</code></dt>
+          <dd>Whether to highlight inline XML (default: <code>true</code>).</dd>
+        </d1>
+      </li>
+      <li>
+        <d1>
+          <dt><code>fencedCodeBlockHighlighting: boolean</code></dt>
+          <dd>Whether to syntax-highlight fenced code blocks, if given mode is included (default: <code>true</code>).</dd>
+        </d1>
+      </li>
+      <li>
+        <d1>
+          <dt><code>tokenTypeOverrides: Object</code></dt>
+          <dd>When you want ot override default token type names (e.g. <code>{code: "code"}</code>).</dd>
+        </d1>
+      </li>
+    </ul>
+
     <p><strong>MIME types defined:</strong> <code>text/x-markdown</code>.</p>
 
     <p><strong>Parsing/Highlighting Tests:</strong> <a href="../../test/index.html#markdown_*">normal</a>,  <a href="../../test/index.html#verbose,markdown_*">verbose</a>.</p>

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -45,6 +45,12 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   if (modeCfg.emoji === undefined)
     modeCfg.emoji = false;
 
+  if (modeCfg.fencedCodeBlockHighlighting === undefined)
+    modeCfg.fencedCodeBlockHighlighting = true;
+
+  if (modeCfg.xml === undefined)
+    modeCfg.xml = true;
+
   // Allow token types to be overridden by user-provided token types.
   if (modeCfg.tokenTypeOverrides === undefined)
     modeCfg.tokenTypeOverrides = {};
@@ -207,7 +213,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       state.quote = 0;
       state.fencedChars = match[1]
       // try switching mode
-      state.localMode = getMode(match[2]);
+      state.localMode = modeCfg.fencedCodeBlockHighlighting && getMode(match[2]);
       if (state.localMode) state.localState = CodeMirror.startState(state.localMode);
       state.f = state.block = local;
       if (modeCfg.highlightFormatting) state.formatting = "code-block";
@@ -510,7 +516,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       return type + tokenTypes.linkEmail;
     }
 
-    if (ch === '<' && stream.match(/^(!--|[a-z]+(?:\s+[a-z_:.\-]+(?:\s*=\s*[^ >]+)?)*\s*>)/i, false)) {
+    if (modeCfg.xml && ch === '<' && stream.match(/^(!--|[a-z]+(?:\s+[a-z_:.\-]+(?:\s*=\s*[^ >]+)?)*\s*>)/i, false)) {
       var end = stream.string.indexOf(">", stream.pos);
       if (end != -1) {
         var atts = stream.string.substring(stream.start, end);
@@ -521,7 +527,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       return switchBlock(stream, state, htmlBlock);
     }
 
-    if (ch === '<' && stream.match(/^\/\w*?>/)) {
+    if (modeCfg.xml && ch === '<' && stream.match(/^\/\w*?>/)) {
       state.md_inside = false;
       return "tag";
     } else if (ch === "*" || ch === "_") {

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -35,11 +35,6 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   if (modeCfg.maxBlockquoteDepth === undefined)
     modeCfg.maxBlockquoteDepth = 0;
 
-  // Use `fencedCodeBlocks` to configure fenced code blocks. false to
-  // disable, string to specify a precise regexp that the fence should
-  // match, and true to allow three or more backticks or tildes (as
-  // per CommonMark).
-
   // Turn on task lists? ("- [ ] " and "- [x] ")
   if (modeCfg.taskLists === undefined) modeCfg.taskLists = false;
 
@@ -88,8 +83,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   ,   atxHeaderRE = modeCfg.allowAtxHeaderWithoutSpace ? /^(#+)/ : /^(#+)(?: |$)/
   ,   setextHeaderRE = /^ *(?:\={1,}|-{1,})\s*$/
   ,   textRE = /^[^#!\[\]*_\\<>` "'(~:]+/
-  ,   fencedCodeRE = new RegExp("^(" + (modeCfg.fencedCodeBlocks === true ? "~~~+|```+" : modeCfg.fencedCodeBlocks) +
-                                ")[ \\t]*([\\w+#\-]*)")
+  ,   fencedCodeRE = /^(~~~+|```+)[ \t]*([\w+#-]*)/
   ,   linkDefRE = /^\s*\[[^\]]+?\]:\s*\S+(\s*\S*\s*)?$/ // naive link-definition
   ,   punctuation = /[!\"#$%&\'()*+,\-\.\/:;<=>?@\[\\\]^_`{|}~—]/
   ,   expandedTab = "    " // CommonMark specifies tab as 4 spaces
@@ -209,7 +203,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       state.f = state.inline;
       if (modeCfg.highlightFormatting) state.formatting = ["list", "list-" + listType];
       return getType(state);
-    } else if (modeCfg.fencedCodeBlocks && firstTokenOnLine && state.indentation <= maxNonCodeIndentation && (match = stream.match(fencedCodeRE, true))) {
+    } else if (firstTokenOnLine && state.indentation <= maxNonCodeIndentation && (match = stream.match(fencedCodeRE, true))) {
       state.quote = 0;
       state.fencedChars = match[1]
       // try switching mode

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -7,6 +7,10 @@
   function MT(name) { test.mode(name, mode, Array.prototype.slice.call(arguments, 1)); }
   var modeHighlightFormatting = CodeMirror.getMode(config, {name: "markdown", highlightFormatting: true});
   function FT(name) { test.mode(name, modeHighlightFormatting, Array.prototype.slice.call(arguments, 1)); }
+  var modeMT_noXml = CodeMirror.getMode(config, {name: "markdown", xml: false});
+  function MT_noXml(name) { test.mode(name, modeMT_noXml, Array.prototype.slice.call(arguments, 1)); }
+  var modeMT_noFencedHighlight = CodeMirror.getMode(config, {name: "markdown", fencedCodeBlockHighlighting: false});
+  function MT_noFencedHighlight(name) { test.mode(name, modeMT_noFencedHighlight, Array.prototype.slice.call(arguments, 1)); }
   var modeAtxNoSpace = CodeMirror.getMode(config, {name: "markdown", allowAtxHeaderWithoutSpace: true});
   function AtxNoSpaceTest(name) { test.mode(name, modeAtxNoSpace, Array.prototype.slice.call(arguments, 1)); }
   var modeOverrideClasses = CodeMirror.getMode(config, {
@@ -1103,6 +1107,11 @@
      "[comment ```]",
      "bar");
 
+  MT_noFencedHighlight("fencedCodeBlock_noHighlight",
+     "[comment ```javascript]",
+     "[comment foo]",
+     "[comment ```]");
+
   MT("fencedCodeBlockModeSwitchingObjc",
      "[comment ```objective-c]",
      "[keyword @property] [variable NSString] [operator *] [variable foo];",
@@ -1185,5 +1194,8 @@
      "[link <http://github.com/>]",
      "[tag&bracket <][tag div][tag&bracket >]",
      "[tag&bracket </][tag div][tag&bracket >]");
+
+  MT_noXml("xmlHighlightDisabled",
+     "<div>foo</div>");
 
 })();

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -9,8 +9,6 @@
   function FT(name) { test.mode(name, modeHighlightFormatting, Array.prototype.slice.call(arguments, 1)); }
   var modeAtxNoSpace = CodeMirror.getMode(config, {name: "markdown", allowAtxHeaderWithoutSpace: true});
   function AtxNoSpaceTest(name) { test.mode(name, modeAtxNoSpace, Array.prototype.slice.call(arguments, 1)); }
-  var modeFenced = CodeMirror.getMode(config, {name: "markdown", fencedCodeBlocks: true});
-  function FencedTest(name) { test.mode(name, modeFenced, Array.prototype.slice.call(arguments, 1)); }
   var modeOverrideClasses = CodeMirror.getMode(config, {
     name: "markdown",
     strikethrough: true,
@@ -96,6 +94,11 @@
 
   FT("formatting_image",
      "[formatting&formatting-image&image&image-marker !][formatting&formatting-image&image&image-alt-text&link [[][image&image-alt-text&link alt text][formatting&formatting-image&image&image-alt-text&link ]]][formatting&formatting-link-string&string&url (][url&string http://link.to/image.jpg][formatting&formatting-link-string&string&url )]");
+
+  FT("codeBlock",
+     "[comment&formatting&formatting-code-block ```css]",
+     "[tag foo]",
+     "[comment&formatting&formatting-code-block ```]");
 
   MT("plainText",
      "foo");
@@ -587,7 +590,7 @@
      "  [variable-2 de-indented text part of list1 again]",
      "",
      "  [variable-2&comment ```]",
-     "  [variable-2&comment code]",
+     "  [comment code]",
      "  [variable-2&comment ```]",
      "",
      "  [variable-2 text after fenced code]");
@@ -1085,18 +1088,28 @@
   MT("taskList",
      "[variable-2 * ][link&variable-2 [[ ]]][variable-2 bar]");
 
-  MT("noFencedCodeBlocks",
-     "~~~",
-     "foo",
-     "~~~");
-
-  FencedTest("fencedCodeBlocks",
+  MT("fencedCodeBlocks",
      "[comment ```]",
      "[comment foo]",
+     "",
+     "[comment bar]",
+     "[comment ```]",
+     "baz");
+
+  MT("fencedCodeBlockModeSwitching",
+     "[comment ```javascript]",
+     "[variable foo]",
+     "",
      "[comment ```]",
      "bar");
 
-  FencedTest("fencedCodeBlocksMultipleChars",
+  MT("fencedCodeBlockModeSwitchingObjc",
+     "[comment ```objective-c]",
+     "[keyword @property] [variable NSString] [operator *] [variable foo];",
+     "[comment ```]",
+     "bar");
+
+  MT("fencedCodeBlocksMultipleChars",
      "[comment `````]",
      "[comment foo]",
      "[comment ```]",
@@ -1104,20 +1117,20 @@
      "[comment `````]",
      "bar");
 
-  FencedTest("fencedCodeBlocksTildes",
+  MT("fencedCodeBlocksTildes",
      "[comment ~~~]",
      "[comment foo]",
      "[comment ~~~]",
      "bar");
 
-  FencedTest("fencedCodeBlocksTildesMultipleChars",
+  MT("fencedCodeBlocksTildesMultipleChars",
      "[comment ~~~~~]",
      "[comment ~~~]",
      "[comment foo]",
      "[comment ~~~~~]",
      "bar");
 
-  FencedTest("fencedCodeBlocksMultipleChars",
+  MT("fencedCodeBlocksMultipleChars",
      "[comment `````]",
      "[comment foo]",
      "[comment ```]",
@@ -1125,14 +1138,14 @@
      "[comment `````]",
      "bar");
 
-  FencedTest("fencedCodeBlocksMixed",
+  MT("fencedCodeBlocksMixed",
      "[comment ~~~]",
      "[comment ```]",
      "[comment foo]",
      "[comment ~~~]",
      "bar");
 
-  FencedTest("fencedCodeBlocksAfterBlockquote",
+  MT("fencedCodeBlocksAfterBlockquote",
      "[quote&quote-1 > foo]",
      "[comment ```]",
      "[comment bar]",
@@ -1145,7 +1158,7 @@
      "    [comment code]",
      "    [comment ```]");
 
-  FencedTest("autoTerminateFencedCodeWhenLeavingList",
+  MT("autoTerminateFencedCodeWhenLeavingList",
      "[variable-2 - list1]",
      "  [variable-3 - list2]",
      "    [variable-3&comment ```]",


### PR DESCRIPTION
- __commit 1__ - _support fencedCodeBlocks in base markdown as per CommonMark_
    - Base markdown first-class support.
    - Aligned with CommonMark, thus not disable-able nor customizable `fenceChars`.
    - Moved fencedCode tests to `markdown/test.js` with minor tweaks.
    - Updated doc, (auto) removed trailing whitespace so a bit mess there.
    - Thought I'd simplify `gfm.js` after this change, but it turns out that's not yet easily possible.
- __commit 2__ - _allow to disable xml and fencedCodeBlock highlighting_
    - Added `xml` option to disable inline xml highlighting. This is a good idea to support when one doesn't want to support HTML for security reasons, while want to retain ability to highlight xml in fenced code blocks.
    - Added `fencedCodeBlockHighlighting` to enable previous behavior of not highlighting fenced code blocks even if they have language specified.
- __commit 3__ - _update doc with available options_