### PR TITLE
[jsx mode] Fix string interpolation with HTML string

### DIFF
--- a/mode/jsx/jsx.js
+++ b/mode/jsx/jsx.js
@@ -103,7 +103,7 @@
     }
 
     function jsToken(stream, state, cx) {
-      if (stream.peek() == "<" && jsMode.expressionAllowed(stream, cx.state)) {
+      if (stream.peek() == "<" && (cx.state.tokenize.name !== "tokenQuasi" && jsMode.expressionAllowed(stream, cx.state))) {
         jsMode.skipExpression(cx.state)
         state.context = new Context(CodeMirror.startState(xmlMode, jsMode.indent(cx.state, "")),
                                     xmlMode, 0, state.context)

--- a/mode/jsx/test.js
+++ b/mode/jsx/test.js
@@ -33,6 +33,9 @@
   MT("preserve_js_context",
      "[variable x] [operator =] [string-2 `quasi${][bracket&tag <][tag foo][bracket&tag />][string-2 }quoted`]")
 
+  MT("string_interpolation",
+    "[variable x] [operator =] [string-2 `quasi<code>${] [number 10] [string-2 }</code>`]")
+
   MT("line_comment",
      "([bracket&tag <][tag foo] [comment // hello]",
      "   [bracket&tag ></][tag foo][bracket&tag >][operator ++])")


### PR DESCRIPTION
Fixes #4908 

This change fixes a bug where interpolated strings containing HTML in CodeMirror's JSX can cause CodeMirror to parse a string in XML mode rather than JavaScript mode.

This PR also adds a test to prevent regressions on this case in the future.