### PR TITLE
[markdown mode] codeBlocks & setext improvements

### DIFF
--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -327,11 +327,41 @@
 
   MT("noSetextAfterList",
      "[variable-2 - foo]",
-     "[hr ---]",
-     "",
+     "[hr ---]");
+
+  MT("noSetextAfterList_listContinuation",
      "[variable-2 - foo]",
      "bar",
      "[hr ---]");
+
+  MT("setextAfterList_afterIndentedCode",
+     "[variable-2 - foo]",
+     "",
+     "      [comment bar]",
+     "[header&header-2 baz]",
+     "[header&header-2 ---]");
+
+  MT("setextAfterList_afterFencedCodeBlocks",
+     "[variable-2 - foo]",
+     "",
+     "      [comment ```]",
+     "      [comment bar]",
+     "      [comment ```]",
+     "[header&header-2 baz]",
+     "[header&header-2 ---]");
+
+  MT("setextAfterList_afterHeader",
+     "[variable-2 - foo]",
+     "  [variable-2&header&header-1 # bar]",
+     "[header&header-2 baz]",
+     "[header&header-2 ---]");
+
+  MT("setextAfterList_afterHr",
+     "[variable-2 - foo]",
+     "",
+     "  [hr ---]",
+     "[header&header-2 bar]",
+     "[header&header-2 ---]");
 
   MT("setext_nestedInlineMarkup",
      "[header&header-1 foo ][em&header&header-1 *bar*]",
@@ -347,6 +377,12 @@
      "foo",
      "[header&header-1 bar]",
      "[header&header-1 =]");
+
+  // ensure we don't regard space after dash as a list
+  MT("setext_emptyList",
+     "[header&header-2 foo]",
+     "[header&header-2 - ]",
+     "foo");
 
   // Single-line blockquote with trailing space
   MT("blockquoteSpace",

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -151,6 +151,21 @@
      "Foo",
      "    Bar");
 
+  MT("codeBlocksAfterATX",
+     "[header&header-1 # foo]",
+     "    [comment code]");
+
+  MT("codeBlocksAfterSetext",
+     "[header&header-2 foo]",
+     "[header&header-2 ---]",
+     "    [comment code]");
+
+  MT("codeBlocksAfterFencedCode",
+     "[comment ```]",
+     "[comment foo]",
+     "[comment ```]",
+     "    [comment code]");
+
   // Inline code using backticks
   MT("inlineCodeUsingBackticks",
      "foo [comment `bar`]");
@@ -191,6 +206,10 @@
   // Closed with several different groups of backticks
   MT("closedBackticks",
      "[comment ``foo ``` bar` hello``] world");
+
+  // info string cannot contain backtick, thus should result in inline code
+  MT("closingFencedMarksOnSameLine",
+     "[comment ``` code ```] foo");
 
   // atx headers
   // http://daringfireball.net/projects/markdown/syntax#header
@@ -237,7 +256,7 @@
 
   MT("atxIndentedTooMuch",
      "[header&header-1 # foo]",
-     "    # bar");
+     "    [comment # bar]");
 
   // disable atx inside blockquote until we implement proper blockquote inner mode
   // TODO: fix to be CommonMark-compliant
@@ -1099,6 +1118,39 @@
      "[comment bar]",
      "[comment ```]",
      "baz");
+
+  MT("fencedCodeBlocks_invalidClosingFence_trailingText",
+     "[comment ```]",
+     "[comment foo]",
+     "[comment ``` must not have trailing text]",
+     "[comment baz]");
+
+  MT("fencedCodeBlocks_invalidClosingFence_trailingTabs",
+     "[comment ```]",
+     "[comment foo]",
+     "[comment ```\t]",
+     "[comment baz]");
+
+  MT("fencedCodeBlocks_validClosingFence",
+     "[comment ```]",
+     "[comment foo]",
+     // may have trailing spaces
+     "[comment ```     ]",
+     "baz");
+
+  MT("fencedCodeBlocksInList_closingFenceIndented",
+     "[variable-2 - list]",
+     "    [variable-2&comment ```]",
+     "    [comment foo]",
+     "     [variable-2&comment ```]",
+     "    [variable-2 baz]");
+
+  MT("fencedCodeBlocksInList_closingFenceIndentedTooMuch",
+     "[variable-2 - list]",
+     "    [variable-2&comment ```]",
+     "    [comment foo]",
+     "      [comment ```]",
+     "    [comment baz]");
 
   MT("fencedCodeBlockModeSwitching",
      "[comment ```javascript]",


### PR DESCRIPTION
- more CommonMark compliance improvements, and some setext regression fixes
- changed `state.prevLine/thisLine` value a bit
- also closes https://github.com/codemirror/CodeMirror/issues/4137