### PR TITLE
Move instantiation of diff_match_patch into getDiff()

### DIFF
--- a/addon/merge/merge.js
+++ b/addon/merge/merge.js
@@ -644,9 +644,11 @@
   }
 
   // Operations on diffs
-  
+  var dmp = undefined;
   function getDiff(a, b, ignoreWhitespace) {
-    var dmp = new diff_match_patch();
+    if(!dmp) {
+       dmp = new diff_match_patch();
+    }
     var diff = dmp.diff_main(a, b);
     // The library sometimes leaves in empty parts, which confuse the algorithm
     for (var i = 0; i < diff.length; ++i) {

--- a/addon/merge/merge.js
+++ b/addon/merge/merge.js
@@ -644,9 +644,9 @@
   }
 
   // Operations on diffs
-
-  var dmp = new diff_match_patch();
+  
   function getDiff(a, b, ignoreWhitespace) {
+    var dmp = new diff_match_patch();
     var diff = dmp.diff_main(a, b);
     // The library sometimes leaves in empty parts, which confuse the algorithm
     for (var i = 0; i < diff.length; ++i) {


### PR DESCRIPTION
Move instantiation into getDiff to make merge.js bundleable. 
With var dmp = new diff_match_patch(); outside the function, it will be called during require, before diff_match_patch could be exposed to global.