### PR TITLE
Pass lint options (rules) into CSSLint.verify()

### DIFF
--- a/addon/lint/css-lint.js
+++ b/addon/lint/css-lint.js
@@ -15,7 +15,7 @@
 })(function(CodeMirror) {
 "use strict";
 
-CodeMirror.registerHelper("lint", "css", function(text) {
+CodeMirror.registerHelper("lint", "css", function(text, options) {
   var found = [];
   if (!window.CSSLint) {
     if (window.console) {
@@ -23,7 +23,7 @@ CodeMirror.registerHelper("lint", "css", function(text) {
     }
     return found;
   }
-  var results = CSSLint.verify(text), messages = results.messages, message = null;
+  var results = CSSLint.verify(text, options), messages = results.messages, message = null;
   for ( var i = 0; i < messages.length; i++) {
     message = messages[i];
     var startLine = message.line -1, endLine = message.line -1, startCol = message.col -1, endCol = message.col;


### PR DESCRIPTION
It is not currently possible to pass a custom CSSLInt ruleset to the `css-lint` addon. The second argument to `CSSLint.verify()` is the `ruleset`, which is `options` here:

https://github.com/CSSLint/csslint/blob/a4361d4b4cdfa9f04ebe7e8e3a4d4e991e6af5c8/src/core/CSSLint.js#L166-L175

There should be parity with the the `javascript-lint` addon which passes the `options` to `JSHINT`:

https://github.com/codemirror/CodeMirror/blob/883fd008d29fdcaab18b50f47c248e3d112f39ed/addon/lint/javascript-lint.js#L24-L31

And similarly for the `html-lint` addon: 

https://github.com/codemirror/CodeMirror/blob/883fd008d29fdcaab18b50f47c248e3d112f39ed/addon/lint/html-lint.js#L30-L40

Incidentally, the `csslint` rule for HTMLHint _does_ allow you to pass in a custom ruleset, but this only works `htmlmixed` mode.