### PR TITLE
[lint plugins] Undeprecate passing linter rules via lint.options

### DIFF
--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -138,7 +138,11 @@
 
   function startLinting(cm) {
     var state = cm.state.lint, options = state.options;
-    var passOptions = options.options || options; // Support deprecated passing of `options` property in options
+    /*
+     * Passing rules in `options` property prevents JSHint (and other linters) from complaining
+     * about unrecognized rules like `onUpdateLinting`, `delay`, `lintOnChange`, etc.
+     */
+    var passOptions = options.options || options;
     var getAnnotations = options.getAnnotations || cm.getHelper(CodeMirror.Pos(0, 0), "lint");
     if (!getAnnotations) return;
     if (options.async || getAnnotations.async) {


### PR DESCRIPTION
Linters like JSHint will complain if rules are mixed with the options for the linter addon, like `onUpdateLinting` and `delay`. If the options are not separated out like this, then JSHint complains:

<img width="605" alt="screen shot 2017-08-29 at 20 48 41" src="https://user-images.githubusercontent.com/134745/29854925-942a9a38-8cfd-11e7-99b6-2651445ce37a.png">
