### PR TITLE
fixed bug in mark-selection

### DIFF
--- a/addon/selection/mark-selection.js
+++ b/addon/selection/mark-selection.js
@@ -86,7 +86,7 @@
     if (!array.length) return coverRange(cm, from, to);
 
     var coverStart = array[0].find(), coverEnd = array[array.length - 1].find();
-    if (!coverStart || !coverEnd || to.line - from.line < CHUNK_SIZE ||
+    if (!coverStart || !coverEnd || to.line - from.line <= CHUNK_SIZE ||
         cmp(from, coverEnd.to) >= 0 || cmp(to, coverStart.from) <= 0)
       return reset(cm);
 


### PR DESCRIPTION
Found a minor issue with the `mark-selection` addon.

### To reproduce:

* Go to http://codemirror.net/demo/markselection.html
* Enter at least 14 lines of text
* Create a selection starting inside line 6, ending inside line 14
* Press <kbd>Shift</kbd> + <kbd>←</kbd> (i.e., move selection one char to the left)

An error will appear in the console at this stage, and the selected text will also go from white to black.