### PR TITLE
Add functionality to provide aria-label

### DIFF
--- a/src/edit/fromTextArea.js
+++ b/src/edit/fromTextArea.js
@@ -53,7 +53,7 @@ export function fromTextArea(textarea, options) {
       }
     }
   }
-  
+
   let labelNewTextarea = cm => {
     let cmTextarea = cm.display.input.textarea
     if (textarea.id) cmTextarea.setAttribute('aria-label', textarea.id)

--- a/src/edit/fromTextArea.js
+++ b/src/edit/fromTextArea.js
@@ -53,9 +53,15 @@ export function fromTextArea(textarea, options) {
       }
     }
   }
+  
+  let labelNewTextarea = cm => {
+    let cmTextarea = cm.display.input.textarea
+    if (textarea.id) cmTextarea.setAttribute('aria-label', textarea.id)
+  }
 
   textarea.style.display = "none"
   let cm = CodeMirror(node => textarea.parentNode.insertBefore(node, textarea.nextSibling),
     options)
+  labelNewTextarea(cm)
   return cm
 }


### PR DESCRIPTION
The textarea generated by CodeMirror should be attributed with an aria-label to support people with disabilities and comply with web accessibility standards. 
If there is a more elegant way to fix the problem, please let me know.