### PR TITLE
Remove HTMLHint from being require()'d and instead use window global like other linters

### DIFF
--- a/addon/lint/html-lint.js
+++ b/addon/lint/html-lint.js
@@ -7,12 +7,12 @@
 
 (function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
-    mod(require("../../lib/codemirror"), require("htmlhint"));
+    mod(require("../../lib/codemirror"));
   else if (typeof define == "function" && define.amd) // AMD
-    define(["../../lib/codemirror", "htmlhint"], mod);
+    define(["../../lib/codemirror"], mod);
   else // Plain browser env
-    mod(CodeMirror, window.HTMLHint);
-})(function(CodeMirror, HTMLHint) {
+    mod(CodeMirror);
+})(function(CodeMirror) {
   "use strict";
 
   var defaultRules = {
@@ -29,11 +29,11 @@
 
   CodeMirror.registerHelper("lint", "html", function(text, options) {
     var found = [];
+    var HTMLHint = window.HTMLHint;
     if (HTMLHint && !HTMLHint.verify) HTMLHint = HTMLHint.HTMLHint;
-    if (!HTMLHint) HTMLHint = window.HTMLHint;
     if (!HTMLHint) {
       if (window.console) {
-          window.console.error("Error: HTMLHint not found, not defined on window, or not available through define/require, CodeMirror HTML linting cannot run.");
+          window.console.error("Error: window.HTMLHint not defined, CodeMirror HTML linting cannot run.");
       }
       return found;
     }


### PR DESCRIPTION
I'm working on integrating CodeMirror into WordPress core to be part of the November release of 4.9. The work is being done in the [Better Code Editing](https://github.com/WordPress/better-code-editing) feature plugin. In order to improve performance of loading CodeMirror, we needed to create a bundle of [the assets that we're going to be using](https://github.com/WordPress/better-code-editing/blob/a86241c2eb453a4fa05dde5872271824e12ea9d7/wp-includes/js/codemirror/codemirror.manifest.js). See https://github.com/WordPress/better-code-editing/pull/92 if helpful.

When using Browserify, however, I came across a problem where HTMLHint was being imported into the bundle unlike the other linting libraries which all look at `window`. When HTMLHint is imported into the bundle, then there is no `window.HTMLHint` for other scripts to interface with. This is a particular problem in this case because the plugin [adds a new rule to HTMLHint](https://github.com/WordPress/better-code-editing/blob/master/wp-includes/js/htmlhint-kses.js) to flag HTML as invalid if the user does not have permission (e.g. to add scripts).

So I suggest, to better align with all of the other linters, that CodeMirror defer to `window.HTMLHint` as well.