### PR TITLE
Update gfm.js

### DIFF
--- a/mode/gfm/gfm.js
+++ b/mode/gfm/gfm.js
@@ -81,10 +81,9 @@ CodeMirror.defineMode("gfm", function(config, modeConfig) {
       if (stream.sol() || state.ateSpace) {
         state.ateSpace = false;
         if (modeConfig.gitHubSpice !== false) {
-          if(stream.match(/^(?:[a-zA-Z0-9\-_]+\/)?(?:[a-zA-Z0-9\-_]+@)?(?:[a-f0-9]{7,40}\b)/)) {
+          if(stream.match(/^(?:[a-zA-Z0-9\-_]+\/)?(?:[a-zA-Z0-9\-_]+@)(?:[a-f0-9]{7,40}\b)/)) {
             // User/Project@SHA
             // User@SHA
-            // SHA
             state.combineTokens = true;
             return "link";
           } else if (stream.match(/^(?:[a-zA-Z0-9\-_]+\/)?(?:[a-zA-Z0-9\-_]+)?#[0-9]+\b/)) {

--- a/mode/gfm/test.js
+++ b/mode/gfm/test.js
@@ -61,24 +61,6 @@
      "[variable-2 3. ][meta [ ]]][variable-2  world]", // Valid; tests reference style links
      "    [variable-3 1. ][property [x]]][variable-3  foo]"); // Valid; can be nested
 
-  MT("SHA",
-     "foo [link be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2] bar");
-
-  MT("SHAEmphasis",
-     "[em *foo ][em&link be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2][em *]");
-
-  MT("shortSHA",
-     "foo [link be6a8cc] bar");
-
-  MT("tooShortSHA",
-     "foo be6a8c bar");
-
-  MT("longSHA",
-     "foo be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd22 bar");
-
-  MT("badSHA",
-     "foo be6a8cc1c1ecfe9489fb51e4869af15a13fc2cg2 bar");
-
   MT("userSHA",
      "foo [link bar@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2] hello");
 


### PR DESCRIPTION
Remove SHA hash from being treated specially.

Now this will require 

// User/Project@SHA
// User@SHA

The existing regex matches arbitrary code that is a series of `[a-f0-9]{7,40}` not matter how they appear in a sentence.