### PR TITLE
Rewrite coordsCharInner

### DIFF
--- a/src/measurement/position_measurement.js
+++ b/src/measurement/position_measurement.js
@@ -563,7 +563,7 @@ function coordsBidiPartWrapped(cm, lineObj, _lineNo, preparedMeasure, order, x, 
     let p = order[i]
     if (p.from >= end || p.to <= begin) continue
     let ltr = p.level != 1
-    let endX = measureCharPrepared(cm, preparedMeasure, ltr ? p.to - 1 : p.from).right
+    let endX = measureCharPrepared(cm, preparedMeasure, ltr ? Math.min(end, p.to) - 1 : Math.max(begin, p.from)).right
     // Weigh against spans ending before this, so that they are only
     // picked if nothing ends after
     let dist = endX < x ? x - endX + 1e9 : endX - x

--- a/test/test.js
+++ b/test/test.js
@@ -1165,6 +1165,12 @@ testCM("measureEndOfLineBidi", function(cm) {
   eqCursorPos(cm.coordsChar({left: 5000, top: cm.charCoords(Pos(0, 0)).top}), Pos(0, 8, "after"))
 }, {value: "إإإإuuuuإإإإ"})
 
+testCM("measureWrappedBidiLevel2", function(cm) {
+  cm.setSize(cm.charCoords(Pos(0, 6), "editor").right + 60)
+  var c9 = cm.charCoords(Pos(0, 9))
+  eqCharPos(cm.coordsChar({left: c9.right - 1, top: c9.top + 1}), Pos(0, 9))
+}, {value: "foobar إإ إإ إإ إإ 555 بببببب", lineWrapping: true})
+
 testCM("measureWrappedBeginOfLine", function(cm) {
   if (phantom) return;
   cm.setSize(null, "auto");

--- a/test/test.js
+++ b/test/test.js
@@ -1161,6 +1161,10 @@ testCM("measureWrappedEndOfLine", function(cm) {
   }
 }, {mode: "text/html", value: "0123456789abcde0123456789", lineWrapping: true}, ie_lt8 || opera_lt10);
 
+testCM("measureEndOfLineBidi", function(cm) {
+  eqCursorPos(cm.coordsChar({left: 5000, top: cm.charCoords(Pos(0, 0)).top}), Pos(0, 8, "after"))
+}, {value: "إإإإuuuuإإإإ"})
+
 testCM("measureWrappedBeginOfLine", function(cm) {
   if (phantom) return;
   cm.setSize(null, "auto");


### PR DESCRIPTION
Hi @adrianheine, do you have time to take a look at this? Since you were the last to think about this stuff, you might be able to spot mistakes that I didn't notice.

I basically made `coordsCharInner` for bidi lines run two binary searches, one on the bidi spans and one on the actual characters of a single span. It's conceptually simpler, and probably faster (though I didn't benchmark). Since the other algorithm was found to be running into its infinite loop guard in some cases (see issue #4926), I figured it'd be better to start over rather than try to salvage that.

The main question is whether doing a binary search on the bidi spans makes sense on wrapped lines. I think it does, because as we also found with `wrappedLineExtent`, even when an rtl span is wrapped, as a whole it remains inside the computed ordering.