### PR TITLE
gfm: Fix false detection as a hexadecimal number.

### DIFF
--- a/mode/gfm/gfm.js
+++ b/mode/gfm/gfm.js
@@ -81,7 +81,7 @@ CodeMirror.defineMode("gfm", function(config, modeConfig) {
       if (stream.sol() || state.ateSpace) {
         state.ateSpace = false;
         if (modeConfig.gitHubSpice !== false) {
-          if(stream.match(/^(?:[a-zA-Z0-9\-_]+\/)?(?:[a-zA-Z0-9\-_]+@)?(?:[a-f0-9]{7,40}\b)/)) {
+          if(stream.match(/^(?:[a-zA-Z0-9\-_]+\/)?(?:[a-zA-Z0-9\-_]+@)?(#)(?:[a-f0-9]{7,40}\b)/)) {
             // User/Project@SHA
             // User@SHA
             // SHA


### PR DESCRIPTION
In cases like `defamed` or while typing `feedbac`, gfm-mode recognizes the token as hex. This was because of the setting to highlight such patterns of length 7-40, most likely to easily identify commit hashes. However, this causes a false detection as faced by some users at https://github.com/jbt/markdown-editor/issues/72 .