### PR TITLE
[soy mode] Support @param declarations in comments

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -128,6 +128,13 @@
             } else {
               stream.skipToEnd();
             }
+            if (!state.scopes) {
+              var paramRe = /@param\??\s+(\S+)/g;
+              var current = stream.current();
+              for (var match; (match = paramRe.exec(current)); ) {
+                state.variables = prepend(state.variables, match[1]);
+              }
+            }
             return "comment";
 
           case "templ-def":
@@ -187,6 +194,7 @@
             if (stream.match(/^\/?}/)) {
               if (state.tag == "/template" || state.tag == "/deltemplate") {
                 popscope(state);
+                state.variables = prepend(null, 'ij');
                 state.indent = 0;
               } else {
                 if (state.tag == "/for" || state.tag == "/foreach") {
@@ -248,8 +256,14 @@
 
         if (stream.match(/^\/\*/)) {
           state.soyState.push("comment");
+          if (!state.scopes) {
+            state.variables = prepend(null, 'ij');
+          }
           return "comment";
         } else if (stream.match(stream.sol() ? /^\s*\/\/.*/ : /^\s+\/\/.*/)) {
+          if (!state.scopes) {
+            state.variables = prepend(null, 'ij');
+          }
           return "comment";
         } else if (stream.match(/^\{literal}/)) {
           state.indent += config.indentUnit;
@@ -274,18 +288,18 @@
           state.soyState.push("tag");
           if (state.tag == "template" || state.tag == "deltemplate") {
             state.soyState.push("templ-def");
-          }
-          if (state.tag == "call" || state.tag == "delcall") {
+          } else if (state.tag == "call" || state.tag == "delcall") {
             state.soyState.push("templ-ref");
-          }
-          if (state.tag == "let") {
+          } else if (state.tag == "let") {
             state.soyState.push("var-def");
-          }
-          if (state.tag == "for" || state.tag == "foreach") {
+          } else if (state.tag == "for" || state.tag == "foreach") {
             state.scopes = prepend(state.scopes, state.variables);
             state.soyState.push("var-def");
-          }
-          if (state.tag.match(/^@(?:param\??|inject)/)) {
+          } else if (state.tag == "namespace") {
+            if (!state.scopes) {
+              state.variables = prepend(null, 'ij');
+            }
+          } else if (state.tag.match(/^@(?:param\??|inject)/)) {
             state.soyState.push("param-def");
           }
           return "keyword";


### PR DESCRIPTION
@param specified in a template comment is older but still supported way of
declaring a parameter. The comment must directly precede {template}.

Reference: https://developers.google.com/closure/templates/docs/concepts#namespace-decl