### PR TITLE
Support esper SQL dialect

### DIFF
--- a/mode/meta.js
+++ b/mode/meta.js
@@ -47,6 +47,7 @@
     {name: "Embedded Javascript", mime: "application/x-ejs", mode: "htmlembedded", ext: ["ejs"]},
     {name: "Embedded Ruby", mime: "application/x-erb", mode: "htmlembedded", ext: ["erb"]},
     {name: "Erlang", mime: "text/x-erlang", mode: "erlang", ext: ["erl"]},
+    {name: "Esper", mime: "text/x-esper", mode: "sql"},
     {name: "Factor", mime: "text/x-factor", mode: "factor", ext: ["factor"]},
     {name: "FCL", mime: "text/x-fcl", mode: "fcl"},
     {name: "Forth", mime: "text/x-forth", mode: "forth", ext: ["forth", "fth", "4th"]},

--- a/mode/sql/index.html
+++ b/mode/sql/index.html
@@ -49,7 +49,7 @@ SELECT SQL_NO_CACHE DISTINCT
 	LIMIT 1 OFFSET 0;
 </textarea>
             </form>
-            <p><strong>MIME types defined:</strong> 
+            <p><strong>MIME types defined:</strong>
             <code><a href="?mime=text/x-sql">text/x-sql</a></code>,
             <code><a href="?mime=text/x-mysql">text/x-mysql</a></code>,
             <code><a href="?mime=text/x-mariadb">text/x-mariadb</a></code>,
@@ -60,6 +60,7 @@ SELECT SQL_NO_CACHE DISTINCT
             <code><a href="?mime=text/x-pgsql">text/x-pgsql</a></code>,
             <code><a href="?mime=text/x-gql">text/x-gql</a></code>,
             <code><a href="?mime=text/x-gpsql">text/x-gpsql</a></code>.
+            <code><a href="?mime=text/x-esper">text/x-esper</a></code>.
         </p>
 <script>
 window.onload = function() {

--- a/mode/sql/sql.js
+++ b/mode/sql/sql.js
@@ -441,6 +441,19 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
     dateSQL: set("date time timestamp"),
     support: set("ODBCdotTable doubleQuote zerolessFloat")
   });
+
+  // Esper
+  CodeMirror.defineMIME("text/x-esper", {
+    name: "sql",
+    client: set("source"),
+    // http://www.espertech.com/esper/release-5.5.0/esper-reference/html/appendix_keywords.html
+    keywords: set("alter and as asc between by count create delete desc distinct drop from group having in insert into is join like not on or order select set table union update values where limit after all and as at asc avedev avg between by case cast coalesce count create current_timestamp day days delete define desc distinct else end escape events every exists false first from full group having hour hours in inner insert instanceof into irstream is istream join last lastweekday left limit like max match_recognize matches median measures metadatasql min minute minutes msec millisecond milliseconds not null offset on or order outer output partition pattern prev prior regexp retain-union retain-intersection right rstream sec second seconds select set some snapshot sql stddev sum then true unidirectional until update variable weekday when where window"),
+    builtin: {},
+    atoms: set("false true null"),
+    operatorChars: /^[*+\-%<>!=&|^\/#@?~]/,
+    dateSQL: set("time"),
+    support: set("decimallessFloat zerolessFloat binaryNumber hexNumber")
+  });
 }());
 
 });


### PR DESCRIPTION
Hi,

I see that you do no accept new modes, but is it possible to merge this addition to the sql-mode (x-esper)?

Esper is a language for complex event processing, but the language conforms to the SQL standard:

http://www.espertech.com/esper/faq_esper.php#how-does-it-work-overview

I hope you will consider this pull request as it will be a lot more work to create a separate package for this mode, since most of the logic is already included in sql.js.

best regards,

   Fredrik