### PR TITLE
[vim bindings] fix vim emulation ctrl-w behavior #4931

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -2034,7 +2034,8 @@
         vimGlobalState.registerController.pushText(
             args.registerName, 'delete', text,
             args.linewise, vim.visualBlock);
-        return clipCursorToContent(cm, finalHead);
+        var includeLineBreak = vim.insertMode
+        return clipCursorToContent(cm, finalHead, includeLineBreak);
       },
       indent: function(cm, args, ranges) {
         var vim = cm.state.vim;


### PR DESCRIPTION
Fixed `Ctrl-W` vim's keybinding.
`∎` - cursor
Line: `hello/world∎`

Before:
Pressing `Ctrl-W` in insert mode makes:
```
hello∎/
```

After:
Pressing `Ctrl-W` in insert mode makes:
```
hello/∎
```
