### PR TITLE
Documenting allowAtxHeaderWithoutSpace

### DIFF
--- a/mode/markdown/index.html
+++ b/mode/markdown/index.html
@@ -396,6 +396,12 @@ for (var i = 0; i < items.length; i++) {
           <dd>When you want ot override default token type names (e.g. <code>{code: "code"}</code>).</dd>
         </d1>
       </li>
+      <li>
+        <d1>
+          <dt><code>allowAtxHeaderWithoutSpace: Object</code></dt>
+          <dd>Allow lazy headers without whitespace between hashtag and text (default: <code>false</code>).</dd>
+        </d1>
+      </li>
     </ul>
 
     <p><strong>MIME types defined:</strong> <code>text/x-markdown</code>.</p>


### PR DESCRIPTION
Adding documentation for the `allowAtxHeaderWithoutSpace` configuration parameter.