### PR TITLE
Fixed wrong type for allowAtxHeaderWithoutSpace

### DIFF
--- a/mode/markdown/index.html
+++ b/mode/markdown/index.html
@@ -398,7 +398,7 @@ for (var i = 0; i < items.length; i++) {
       </li>
       <li>
         <d1>
-          <dt><code>allowAtxHeaderWithoutSpace: Object</code></dt>
+          <dt><code>allowAtxHeaderWithoutSpace: boolean</code></dt>
           <dd>Allow lazy headers without whitespace between hashtag and text (default: <code>false</code>).</dd>
         </d1>
       </li>


### PR DESCRIPTION
When submitting the previous commit, I had not noticed that the parameter allowAtxHeaderWithoutSpace had type Object instead of type boolean. I've fixed this now.