### PR TITLE
[continuelist addon] Don't continue list when cursor is before bullet

### DIFF
--- a/addon/edit/continuelist.js
+++ b/addon/edit/continuelist.js
@@ -25,7 +25,8 @@
       var inQuote = eolState.quote !== 0;
 
       var line = cm.getLine(pos.line), match = listRE.exec(line);
-      if (!ranges[i].empty() || (!inList && !inQuote) || !match) {
+      var cursorBeforeBullet = /^\s*$/.test(line.slice(0, pos.ch));
+      if (!ranges[i].empty() || (!inList && !inQuote) || !match || cursorBeforeBullet) {
         cm.execCommand("newlineAndIndent");
         return;
       }


### PR DESCRIPTION
Fixes this issue in continuelist addon:

![continuelist-issue](https://user-images.githubusercontent.com/7335302/30875068-86cefd88-a2f2-11e7-8592-6a4260d0133a.gif)
