### PR TITLE
[vim] Fix crash on exiting insert mode.

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -4798,7 +4798,8 @@
       // so as to update the ". register as expected in real vim.
       var text = [];
       if (!isPlaying) {
-        var selLength = lastChange.inVisualBlock ? vim.lastSelection.visualBlock.height : 1;
+        var selLength = lastChange.inVisualBlock && vim.lastSelection ?
+            vim.lastSelection.visualBlock.height : 1;
         var changes = lastChange.changes;
         var text = [];
         var i = 0;


### PR DESCRIPTION
Happened if you entered visual block mode in one editor and then tried to exit insert mode in another, since lastChange comes from vimGlobalState.