### PR TITLE
Remove `package` from Kotlin def keywords

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -591,7 +591,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     multiLineStrings: true,
     number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+\.?\d*|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
     blockKeywords: words("catch class do else finally for if where try while enum"),
-    defKeywords: words("class val var object package interface fun"),
+    defKeywords: words("class val var object interface fun"),
     atoms: words("true false null this"),
     hooks: {
       '"': function(stream, state) {


### PR DESCRIPTION
`package` should be treated like `import`, which is not a def keyword.

| Before | After |
| :-----: | :----: |
| ![before](https://user-images.githubusercontent.com/10191084/31000668-61bad7c8-a492-11e7-820f-5cbb31824cee.png) | ![after](https://user-images.githubusercontent.com/10191084/31000671-629177b0-a492-11e7-8866-0e0635cdc817.png) |

Note that the package at the top in the `After` image is correctly highlighted.
