### PR TITLE
Replace /** with /* disabling jsdoc for findWord

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -3245,8 +3245,7 @@
       return cur;
     }
 
-    /** @suppress {checkTypes} */
-    /**
+    /*
      * Returns the boundaries of the next word. If the cursor in the middle of
      * the word, then returns the boundaries of the current word, starting at
      * the cursor. If the cursor is at the start/end of a word, and we are going

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -3245,6 +3245,7 @@
       return cur;
     }
 
+    /** @suppress {checkTypes} */
     /**
      * Returns the boundaries of the next word. If the cursor in the middle of
      * the word, then returns the boundaries of the current word, starting at


### PR DESCRIPTION
This is to prevent the closure compiler from failing with

bazel-out/darwin_x86_64-fastbuild/bin/polygerrit-ui/app/gr-app.js:51233: ERROR - Bad type annotation. expected closing } See https://github.com/google/closure-compiler/wiki/Bad-Type-Annotation for more information.
     * @return {Object{from:number, to:number, line: number}} The boundaries of
                      ^
  ProTip: "JSC_TYPE_PARSE_ERROR" or "checkTypes" can be added to the `suppress` attribute of:
  //polygerrit-ui/app:polygerrit_ui_closure_lib
  Alternatively /** @suppress {checkTypes} */ can be added to the source file.

1 error(s), 1 warning(s)