### PR TITLE
Include CodeMirror.innerMode in node runmode

### DIFF
--- a/addon/runmode/runmode.node.js
+++ b/addon/runmode/runmode.node.js
@@ -163,6 +163,18 @@ exports.getMode = function(options, spec) {
 
   return modeObj;
 };
+
+exports.innerMode = function(mode, state) {
+  var info;
+  while (mode.innerMode) {
+    info = mode.innerMode(state);
+    if (!info || info.mode == mode) break;
+    state = info.state;
+    mode = info.mode;
+  }
+  return info || {mode: mode, state: state};
+}
+
 exports.registerHelper = exports.registerGlobalHelper = Math.min;
 
 exports.runMode = function(string, modespec, callback, options) {


### PR DESCRIPTION
The markdown mode [uses `CodeMirror.innerMode`](https://github.com/codemirror/CodeMirror/blob/master/mode/markdown/markdown.js#L268) which isn't defined in the stripped down node runmode.

Since markdown is the only mode (AFAICT) that uses it I'm not sure if it would make more sense to rewrite the mode to not use it but this seemed like the least risky option to me.