### PR TITLE
[FIX] wrong representation of table hinting in sql demo page html

### DIFF
--- a/mode/sql/index.html
+++ b/mode/sql/index.html
@@ -78,8 +78,8 @@ window.onload = function() {
     autofocus: true,
     extraKeys: {"Ctrl-Space": "autocomplete"},
     hintOptions: {tables: {
-      users: {name: null, score: null, birthDate: null},
-      countries: {name: null, population: null, size: null}
+      users: ["name", "score", "birthDate"],
+      countries: ["name", "population", "size"]
     }}
   });
 };


### PR DESCRIPTION
The current JS hint options for table hinting, raised errors. This was misleading for newcomers like me, as there's no documentation on that, other than the code. The proper format is like this:

```
hintOptions: {tables: {
      users: ["name", "score", "birthDate"],
      countries: ["name", "population", "size"]
    }}
```

