### PR TITLE
[continuelist addon] Fix bug where continuelist for unordered list is not working

### DIFF
--- a/addon/edit/continuelist.js
+++ b/addon/edit/continuelist.js
@@ -68,7 +68,7 @@
         var newNumber = (parseInt(startItem[3], 10) + lookAhead - skipCount);
         var nextNumber = (parseInt(nextItem[3], 10)), itemNumber = nextNumber;
 
-        if (startIndent === nextIndent) {
+        if (!isNaN(newNumber) && startIndent === nextIndent) {
           if (newNumber === nextNumber) itemNumber = nextNumber + 1;
           if (newNumber > nextNumber) itemNumber = newNumber + 1;
           cm.replaceRange(


### PR DESCRIPTION
You will get `NaNundefinedunordered` when inputted a return key in the unordered list.

Bug reproduce demo: https://continuelist-demo.netlify.com/demo/continuelist.html

This PR would fix it.