### PR TITLE
Fix OCaml syntax

### DIFF
--- a/mode/mllike/index.html
+++ b/mode/mllike/index.html
@@ -11,6 +11,7 @@
 <style type=text/css>
   .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
 </style>
+<link rel="stylesheet" href="http://farhadg.github.io/code-mirror-themes/themes/bespin.css"/>
 <div id=nav>
   <a href="http://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
 
@@ -143,6 +144,14 @@ let x = {|
 let b = 0b00110
 let h = 0x123abcd
 let e = 1e-10
+let i = 1.
+let x = 30_000
+let o = 0o1234
+
+[1; 2; 3] (* lists *)
+
+1 @ 2
+1. +. 2.
 </textarea>
 
 <h2>F# mode</h2>
@@ -176,7 +185,8 @@ type Color =
   var ocamlEditor = CodeMirror.fromTextArea(document.getElementById('ocamlCode'), {
     mode: 'text/x-ocaml',
     lineNumbers: true,
-    matchBrackets: true
+    matchBrackets: true,
+    theme: 'bespin'
   });
 
   var fsharpEditor = CodeMirror.fromTextArea(document.getElementById('fsharpCode'), {

--- a/mode/mllike/index.html
+++ b/mode/mllike/index.html
@@ -134,6 +134,8 @@ let () =
 (* OCaml page on Wikipedia - http://en.wikipedia.org/wiki/OCaml *)
 
 module type S = sig type t end
+
+let x = {| this is a long string |}
 </textarea>
 
 <h2>F# mode</h2>

--- a/mode/mllike/index.html
+++ b/mode/mllike/index.html
@@ -141,6 +141,7 @@ let x = {|
   |}
 
 let b = 0b00110
+let h = 0x123abcd
 </textarea>
 
 <h2>F# mode</h2>

--- a/mode/mllike/index.html
+++ b/mode/mllike/index.html
@@ -142,6 +142,7 @@ let x = {|
 
 let b = 0b00110
 let h = 0x123abcd
+let e = 1e-10
 </textarea>
 
 <h2>F# mode</h2>

--- a/mode/mllike/index.html
+++ b/mode/mllike/index.html
@@ -132,6 +132,8 @@ let () =
 
 (* A Hundred Lines of Caml - http://caml.inria.fr/about/taste.en.html *)
 (* OCaml page on Wikipedia - http://en.wikipedia.org/wiki/OCaml *)
+
+module type S = sig type t end
 </textarea>
 
 <h2>F# mode</h2>

--- a/mode/mllike/index.html
+++ b/mode/mllike/index.html
@@ -139,6 +139,8 @@ let x = {|
   this is a long string 
   with many lines and stuff
   |}
+
+let b = 0b00110
 </textarea>
 
 <h2>F# mode</h2>

--- a/mode/mllike/index.html
+++ b/mode/mllike/index.html
@@ -135,7 +135,10 @@ let () =
 
 module type S = sig type t end
 
-let x = {| this is a long string |}
+let x = {| 
+  this is a long string 
+  with many lines and stuff
+  |}
 </textarea>
 
 <h2>F# mode</h2>

--- a/mode/mllike/mllike.js
+++ b/mode/mllike/mllike.js
@@ -90,6 +90,9 @@ CodeMirror.defineMode('mllike', function(_config, parserConfig) {
         if (stream.eat('.')) {
           stream.eatWhile(/[\d]/);
         }
+        if (stream.eat(/[eE]/)) {
+          stream.eatWhile(/[\d\-+]/);
+        }
       }
       return 'number';
     }

--- a/mode/mllike/mllike.js
+++ b/mode/mllike/mllike.js
@@ -142,7 +142,9 @@ CodeMirror.defineMIME('text/x-ocaml', {
     'print_endline': 'builtin',
     'true': 'atom',
     'false': 'atom',
-    'raise': 'keyword'
+    'raise': 'keyword',
+    'module': 'keyword',
+    'sig': 'keyword'
   }
 });
 

--- a/mode/mllike/mllike.js
+++ b/mode/mllike/mllike.js
@@ -81,9 +81,13 @@ CodeMirror.defineMode('mllike', function(_config, parserConfig) {
       return 'comment';
     }
     if (/\d/.test(ch)) {
-      stream.eatWhile(/[\d]/);
-      if (stream.eat('.')) {
+      if (ch === '0' && stream.eat('b')) {
+        stream.eatWhile(/[01]/);
+      } else {
         stream.eatWhile(/[\d]/);
+        if (stream.eat('.')) {
+          stream.eatWhile(/[\d]/);
+        }
       }
       return 'number';
     }

--- a/mode/mllike/mllike.js
+++ b/mode/mllike/mllike.js
@@ -54,6 +54,13 @@ CodeMirror.defineMode('mllike', function(_config, parserConfig) {
       state.tokenize = tokenString;
       return state.tokenize(stream, state);
     }
+    if (ch === '{' && stream.eat('|')) {
+      if (stream.eatWhile(/[^(|})]/)) {
+        stream.eat('|');
+        stream.eat('}');
+      }
+      return 'string';
+    }
     if (ch === '(') {
       if (stream.eat('*')) {
         state.commentLevel++;

--- a/mode/mllike/mllike.js
+++ b/mode/mllike/mllike.js
@@ -81,8 +81,10 @@ CodeMirror.defineMode('mllike', function(_config, parserConfig) {
       return 'comment';
     }
     if (/\d/.test(ch)) {
-      if (ch === '0' && stream.eat('b')) {
+      if (ch === '0' && stream.eat(/[bB]/)) {
         stream.eatWhile(/[01]/);
+      } if (ch === '0' && stream.eat(/[xX]/)) {
+        stream.eatWhile(/[0-9a-dA-D]/)
       } else {
         stream.eatWhile(/[\d]/);
         if (stream.eat('.')) {

--- a/mode/mllike/mllike.js
+++ b/mode/mllike/mllike.js
@@ -84,9 +84,11 @@ CodeMirror.defineMode('mllike', function(_config, parserConfig) {
       if (ch === '0' && stream.eat(/[bB]/)) {
         stream.eatWhile(/[01]/);
       } if (ch === '0' && stream.eat(/[xX]/)) {
-        stream.eatWhile(/[0-9a-dA-D]/)
+        stream.eatWhile(/[0-9a-fA-F]/)
+      } if (ch === '0' && stream.eat(/[oO]/)) {
+        stream.eatWhile(/[0-7]/);
       } else {
-        stream.eatWhile(/[\d]/);
+        stream.eatWhile(/[\d_]/);
         if (stream.eat('.')) {
           stream.eatWhile(/[\d]/);
         }
@@ -96,7 +98,7 @@ CodeMirror.defineMode('mllike', function(_config, parserConfig) {
       }
       return 'number';
     }
-    if ( /[+\-*&%=<>!?|]/.test(ch)) {
+    if ( /[+\-*&%=<>!?|@]/.test(ch)) {
       return 'operator';
     }
     if (/[\w\xa1-\uffff]/.test(ch)) {


### PR DESCRIPTION
There were some issues with OCaml syntax:
 * First element in a list is not highlighted (when it is a number)
 * Binary number literal was not highlighted
 * Hexadecimal number literal was not highlighted
 * `module` and `sig` were not highlighted

This closes #5113 

I will suggest, if the OCaml syntax continue growing we should split it in a separate file to avoid issues with F# and other ML languages (for example, standard ML).