### PR TITLE
Fixing hotkeys for addCursorTo(Prev|Next)Line

### DIFF
--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -508,27 +508,6 @@
     cm.scrollTo(null, (pos.top + pos.bottom) / 2 - cm.getScrollInfo().clientHeight / 2);
   };
 
-  cmds.selectLinesUpward = function(cm) {
-    cm.operation(function() {
-      var ranges = cm.listSelections();
-      for (var i = 0; i < ranges.length; i++) {
-        var range = ranges[i];
-        if (range.head.line > cm.firstLine())
-          cm.addSelection(Pos(range.head.line - 1, range.head.ch));
-      }
-    });
-  };
-  cmds.selectLinesDownward = function(cm) {
-    cm.operation(function() {
-      var ranges = cm.listSelections();
-      for (var i = 0; i < ranges.length; i++) {
-        var range = ranges[i];
-        if (range.head.line < cm.lastLine())
-          cm.addSelection(Pos(range.head.line + 1, range.head.ch));
-      }
-    });
-  };
-
   function getTarget(cm) {
     var from = cm.getCursor("from"), to = cm.getCursor("to");
     if (CodeMirror.cmpPos(from, to) == 0) {
@@ -590,8 +569,6 @@
     "Cmd-Enter": "insertLineAfter",
     "Shift-Cmd-Enter": "insertLineBefore",
     "Cmd-D": "selectNextOccurrence",
-    "Shift-Cmd-Up": "addCursorToPrevLine",
-    "Shift-Cmd-Down": "addCursorToNextLine",
     "Shift-Cmd-Space": "selectScope",
     "Shift-Cmd-M": "selectBetweenBrackets",
     "Cmd-M": "goToBracket",
@@ -621,8 +598,8 @@
     "Cmd-K Cmd-Backspace": "delLineLeft",
     "Cmd-K Cmd-0": "unfoldAll",
     "Cmd-K Cmd-J": "unfoldAll",
-    "Ctrl-Shift-Up": "selectLinesUpward",
-    "Ctrl-Shift-Down": "selectLinesDownward",
+    "Ctrl-Shift-Up": "addCursorToPrevLine",
+    "Ctrl-Shift-Down": "addCursorToNextLine",
     "Cmd-F3": "findUnder",
     "Shift-Cmd-F3": "findUnderPrevious",
     "Alt-F3": "findAllUnder",
@@ -652,8 +629,6 @@
     "Ctrl-Enter": "insertLineAfter",
     "Shift-Ctrl-Enter": "insertLineBefore",
     "Ctrl-D": "selectNextOccurrence",
-    "Alt-CtrlUp": "addCursorToPrevLine",
-    "Alt-CtrlDown": "addCursorToNextLine",
     "Shift-Ctrl-Space": "selectScope",
     "Shift-Ctrl-M": "selectBetweenBrackets",
     "Ctrl-M": "goToBracket",
@@ -683,8 +658,8 @@
     "Ctrl-K Ctrl-Backspace": "delLineLeft",
     "Ctrl-K Ctrl-0": "unfoldAll",
     "Ctrl-K Ctrl-J": "unfoldAll",
-    "Ctrl-Alt-Up": "selectLinesUpward",
-    "Ctrl-Alt-Down": "selectLinesDownward",
+    "Ctrl-Alt-Up": "addCursorToPrevLine",
+    "Ctrl-Alt-Down": "addCursorToNextLine",
     "Ctrl-F3": "findUnder",
     "Shift-Ctrl-F3": "findUnderPrevious",
     "Alt-F3": "findAllUnder",

--- a/test/sublime_test.js
+++ b/test/sublime_test.js
@@ -219,31 +219,6 @@
                                                    2, 4, 2, 6,
                                                    2, 7, 2, 7));
 
-  stTest("addCursorToPrevLine", "123\n345\n789\n012",
-         setSel(0, 1, 0, 1,
-                1, 1, 1, 3,
-                2, 0, 2, 0,
-                3, 0, 3, 0),
-         "addCursorToPrevLine",
-         hasSel(0, 1, 0, 1,
-                0, 3, 0, 3,
-                1, 0, 1, 0,
-                1, 1, 1, 3,
-                2, 0, 2, 0,
-                3, 0, 3, 0));
-
-  stTest("addCursorToNextLine", "123\n345\n789\n012",
-         setSel(0, 1, 0, 1,
-                1, 1, 1, 3,
-                2, 0, 2, 0,
-                3, 0, 3, 0),
-         "addCursorToNextLine",
-         hasSel(0, 1, 0, 1,
-                1, 1, 1, 3,
-                2, 0, 2, 0,
-                2, 3, 2, 3,
-                3, 0, 3, 0));
-
   stTest("sortLines", "c\nb\na\nC\nB\nA",
          "sortLines", val("A\nB\nC\na\nb\nc"),
          "undo",

--- a/test/sublime_test.js
+++ b/test/sublime_test.js
@@ -219,12 +219,12 @@
                                                    2, 4, 2, 6,
                                                    2, 7, 2, 7));
 
-  stTest("selectLinesUpward", "123\n345\n789\n012",
+  stTest("addCursorToPrevLine", "123\n345\n789\n012",
          setSel(0, 1, 0, 1,
                 1, 1, 1, 3,
                 2, 0, 2, 0,
                 3, 0, 3, 0),
-         "selectLinesUpward",
+         "addCursorToPrevLine",
          hasSel(0, 1, 0, 1,
                 0, 3, 0, 3,
                 1, 0, 1, 0,
@@ -232,12 +232,12 @@
                 2, 0, 2, 0,
                 3, 0, 3, 0));
 
-  stTest("selectLinesDownward", "123\n345\n789\n012",
+  stTest("addCursorToNextLine", "123\n345\n789\n012",
          setSel(0, 1, 0, 1,
                 1, 1, 1, 3,
                 2, 0, 2, 0,
                 3, 0, 3, 0),
-         "selectLinesDownward",
+         "addCursorToNextLine",
          hasSel(0, 1, 0, 1,
                 1, 1, 1, 3,
                 2, 0, 2, 0,


### PR DESCRIPTION
#5109 This change fixes issue #5109. See details in issue thread.