### PR TITLE
Support expanding brackets selection in selectBetweenBrackets

### DIFF
--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -183,9 +183,15 @@
         var closing = cm.scanForBracket(pos, 1);
         if (!closing) return false;
         if (closing.ch == mirror.charAt(mirror.indexOf(opening.ch) + 1)) {
-          newRanges.push({anchor: Pos(opening.pos.line, opening.pos.ch + 1),
-                          head: closing.pos});
-          break;
+          var startPos = Pos(opening.pos.line, opening.pos.ch + 1);
+          if (CodeMirror.cmpPos(startPos, range.from()) == 0 &&
+              CodeMirror.cmpPos(closing.pos, range.to()) == 0) {
+            opening = cm.scanForBracket(opening.pos, -1);
+            if (!opening) return false;
+          } else {
+            newRanges.push({anchor: startPos, head: closing.pos});
+            break;
+          }
         }
         pos = Pos(closing.pos.line, closing.pos.ch + 1);
       }

--- a/test/sublime_test.js
+++ b/test/sublime_test.js
@@ -152,7 +152,9 @@
          Pos(0, 8), "selectScope", hasSel(0, 8, 2, 0),
          Pos(1, 2), "selectScope", hasSel(0, 8, 2, 0),
          Pos(1, 6), "selectScope", hasSel(1, 6, 1, 10),
-         Pos(1, 9), "selectScope", hasSel(1, 6, 1, 10));
+         Pos(1, 9), "selectScope", hasSel(1, 6, 1, 10),
+         "selectScope", hasSel(0, 8, 2, 0),
+         "selectScope", hasSel(0, 0, 2, 1));
 
   stTest("goToBracket", "foo(a) {\n  bar[1, 2];\n}",
          Pos(0, 0), "goToBracket", at(0, 0),


### PR DESCRIPTION
Pressing Ctrl+Shift+m (in sublime mode) more than once will expand the selection to the next brackets.