### PR TITLE
Adding an option to disable auto indenting when auto closing tag based on slash

### DIFF
--- a/addon/edit/closetag.js
+++ b/addon/edit/closetag.js
@@ -97,6 +97,8 @@
   function autoCloseCurrent(cm, typingSlash) {
     var ranges = cm.listSelections(), replacements = [];
     var head = typingSlash ? "/" : "</";
+    var opt = cm.getOption("autoCloseTags");
+    var dontIndentOnSlash = (typeof opt == "object" && opt.dontIndentOnSlash);
     for (var i = 0; i < ranges.length; i++) {
       if (!ranges[i].empty()) return CodeMirror.Pass;
       var pos = ranges[i].head, tok = cm.getTokenAt(pos);
@@ -127,7 +129,7 @@
     }
     cm.replaceSelections(replacements);
     ranges = cm.listSelections();
-    if (cm.getOption("autoCloseTagSlashIndent") == "true") {
+    if (!dontIndentOnSlash) {
         for (var i = 0; i < ranges.length; i++)
             if (i == ranges.length - 1 || ranges[i].head.line < ranges[i + 1].head.line)
                 cm.indentLine(ranges[i].head.line);

--- a/addon/edit/closetag.js
+++ b/addon/edit/closetag.js
@@ -90,8 +90,8 @@
       sel[i] = {head: info.newPos, anchor: info.newPos};
       cm.setSelections(sel);
       if (!dontIndentOnAutoClose && info.indent) {
-		cm.indentLine(info.newPos.line, null, true);
-		cm.indentLine(info.newPos.line + 1, null, true);
+        cm.indentLine(info.newPos.line, null, true);
+        cm.indentLine(info.newPos.line + 1, null, true);
       }
     }
   }

--- a/addon/edit/closetag.js
+++ b/addon/edit/closetag.js
@@ -53,13 +53,14 @@
   function autoCloseGT(cm) {
     if (cm.getOption("disableInput")) return CodeMirror.Pass;
     var ranges = cm.listSelections(), replacements = [];
+	var opt = cm.getOption("autoCloseTags");
     for (var i = 0; i < ranges.length; i++) {
       if (!ranges[i].empty()) return CodeMirror.Pass;
       var pos = ranges[i].head, tok = cm.getTokenAt(pos);
       var inner = CodeMirror.innerMode(cm.getMode(), tok.state), state = inner.state;
       if (inner.mode.name != "xml" || !state.tagName) return CodeMirror.Pass;
 
-      var opt = cm.getOption("autoCloseTags"), html = inner.mode.configuration == "html";
+      var html = inner.mode.configuration == "html";
       var dontCloseTags = (typeof opt == "object" && opt.dontCloseTags) || (html && htmlDontClose);
       var indentTags = (typeof opt == "object" && opt.indentTags) || (html && htmlIndent);
 
@@ -81,16 +82,17 @@
                          newPos: indent ? CodeMirror.Pos(pos.line + 1, 0) : CodeMirror.Pos(pos.line, pos.ch + 1)};
     }
 
+	var dontIndentOnAutoClose = (typeof opt == "object" && opt.dontIndentOnAutoClose);
     for (var i = ranges.length - 1; i >= 0; i--) {
       var info = replacements[i];
       cm.replaceRange(info.text, ranges[i].head, ranges[i].anchor, "+insert");
       var sel = cm.listSelections().slice(0);
       sel[i] = {head: info.newPos, anchor: info.newPos};
       cm.setSelections(sel);
-      if (info.indent) {
-        cm.indentLine(info.newPos.line, null, true);
-        cm.indentLine(info.newPos.line + 1, null, true);
-      }
+	  if (!dontIndentOnAutoClose && info.indent) {
+		cm.indentLine(info.newPos.line, null, true);
+		cm.indentLine(info.newPos.line + 1, null, true);
+	  }
     }
   }
 
@@ -98,7 +100,7 @@
     var ranges = cm.listSelections(), replacements = [];
     var head = typingSlash ? "/" : "</";
     var opt = cm.getOption("autoCloseTags");
-    var dontIndentOnSlash = (typeof opt == "object" && opt.dontIndentOnSlash);
+    var dontIndentOnAutoClose = (typeof opt == "object" && opt.dontIndentOnSlash);
     for (var i = 0; i < ranges.length; i++) {
       if (!ranges[i].empty()) return CodeMirror.Pass;
       var pos = ranges[i].head, tok = cm.getTokenAt(pos);
@@ -129,7 +131,7 @@
     }
     cm.replaceSelections(replacements);
     ranges = cm.listSelections();
-    if (!dontIndentOnSlash) {
+    if (!dontIndentOnAutoClose) {
         for (var i = 0; i < ranges.length; i++)
             if (i == ranges.length - 1 || ranges[i].head.line < ranges[i + 1].head.line)
                 cm.indentLine(ranges[i].head.line);

--- a/addon/edit/closetag.js
+++ b/addon/edit/closetag.js
@@ -82,7 +82,7 @@
                          newPos: indent ? CodeMirror.Pos(pos.line + 1, 0) : CodeMirror.Pos(pos.line, pos.ch + 1)};
     }
 
-	var dontIndentOnAutoClose = (typeof opt == "object" && opt.dontIndentOnAutoClose);
+    var dontIndentOnAutoClose = (typeof opt == "object" && opt.dontIndentOnAutoClose);
     for (var i = ranges.length - 1; i >= 0; i--) {
       var info = replacements[i];
       cm.replaceRange(info.text, ranges[i].head, ranges[i].anchor, "+insert");

--- a/addon/edit/closetag.js
+++ b/addon/edit/closetag.js
@@ -53,7 +53,7 @@
   function autoCloseGT(cm) {
     if (cm.getOption("disableInput")) return CodeMirror.Pass;
     var ranges = cm.listSelections(), replacements = [];
-	var opt = cm.getOption("autoCloseTags");
+    var opt = cm.getOption("autoCloseTags");
     for (var i = 0; i < ranges.length; i++) {
       if (!ranges[i].empty()) return CodeMirror.Pass;
       var pos = ranges[i].head, tok = cm.getTokenAt(pos);

--- a/addon/edit/closetag.js
+++ b/addon/edit/closetag.js
@@ -89,10 +89,10 @@
       var sel = cm.listSelections().slice(0);
       sel[i] = {head: info.newPos, anchor: info.newPos};
       cm.setSelections(sel);
-	  if (!dontIndentOnAutoClose && info.indent) {
+      if (!dontIndentOnAutoClose && info.indent) {
 		cm.indentLine(info.newPos.line, null, true);
 		cm.indentLine(info.newPos.line + 1, null, true);
-	  }
+      }
     }
   }
 

--- a/addon/edit/closetag.js
+++ b/addon/edit/closetag.js
@@ -133,7 +133,7 @@
         for (var i = 0; i < ranges.length; i++)
             if (i == ranges.length - 1 || ranges[i].head.line < ranges[i + 1].head.line)
                 cm.indentLine(ranges[i].head.line);
-     }
+    }
   }
 
   function autoCloseSlash(cm) {

--- a/addon/edit/closetag.js
+++ b/addon/edit/closetag.js
@@ -127,9 +127,11 @@
     }
     cm.replaceSelections(replacements);
     ranges = cm.listSelections();
-    for (var i = 0; i < ranges.length; i++)
-      if (i == ranges.length - 1 || ranges[i].head.line < ranges[i + 1].head.line)
-        cm.indentLine(ranges[i].head.line);
+    if (cm.getOption("autoCloseTagSlashIndent") == "true") {
+        for (var i = 0; i < ranges.length; i++)
+            if (i == ranges.length - 1 || ranges[i].head.line < ranges[i + 1].head.line)
+                cm.indentLine(ranges[i].head.line);
+     }
   }
 
   function autoCloseSlash(cm) {

--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -52,6 +52,7 @@ export function defineOptions(CodeMirror) {
     clearCaches(cm)
     regChange(cm)
   }, true)
+  option("autoCloseTagSlashIndent", true);
   option("lineSeparator", null, (cm, val) => {
     cm.doc.lineSep = val
     if (!val) return

--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -52,7 +52,7 @@ export function defineOptions(CodeMirror) {
     clearCaches(cm)
     regChange(cm)
   }, true)
-  option("autoCloseTagSlashIndent", true);
+    
   option("lineSeparator", null, (cm, val) => {
     cm.doc.lineSep = val
     if (!val) return

--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -52,7 +52,7 @@ export function defineOptions(CodeMirror) {
     clearCaches(cm)
     regChange(cm)
   }, true)
-    
+
   option("lineSeparator", null, (cm, val) => {
     cm.doc.lineSep = val
     if (!val) return


### PR DESCRIPTION
This PR is related to the issue #5129 

An option dontIndentOnAutoClose has been added which can be used to disable the code which indent the line when auto closing tags based on slash.
By default dontIndentOnAutoClose is false. This can be added as a property of "autoClosetags".