### PR TITLE
[stylus mode] parse CSS4 hex colors - #RGBA and #RRGGBBAA

### DIFF
--- a/mode/stylus/stylus.js
+++ b/mode/stylus/stylus.js
@@ -76,7 +76,7 @@
       if (ch == "#") {
         stream.next();
         // Hex color
-        if (stream.match(/^[0-9a-f]{6}|[0-9a-f]{3}/i)) {
+        if (stream.match(/^[0-9a-f]{3}([0-9a-f]([0-9a-f]{2}){0,2})?\b/i)) {
           return ["atom", "atom"];
         }
         // ID selector


### PR DESCRIPTION
Instead of alternation groups that match in descending lengths I've used `\b` and progressive matching.