### PR TITLE
Recognize ScrollLock and Pause with Ctrl modifier

### DIFF
--- a/src/input/keymap.js
+++ b/src/input/keymap.js
@@ -137,6 +137,9 @@ export function keyName(event, noShift) {
   if (presto && event.keyCode == 34 && event["char"]) return false
   let name = keyNames[event.keyCode]
   if (name == null || event.altGraphKey) return false
+  // Ctrl-ScrollLock has keyCode 3, same as Ctrl-Pause,
+  // so we'll use event.code when available (Chrome 48+, FF 38+, Safari 10.1+)
+  if (event.keyCode == 3 && event.code) name = event.code
   return addModifierNames(name, event, noShift)
 }
 

--- a/src/input/keynames.js
+++ b/src/input/keynames.js
@@ -1,9 +1,9 @@
 export let keyNames = {
-  3: "Enter", 8: "Backspace", 9: "Tab", 13: "Enter", 16: "Shift", 17: "Ctrl", 18: "Alt",
+  3: "Pause", 8: "Backspace", 9: "Tab", 13: "Enter", 16: "Shift", 17: "Ctrl", 18: "Alt",
   19: "Pause", 20: "CapsLock", 27: "Esc", 32: "Space", 33: "PageUp", 34: "PageDown", 35: "End",
   36: "Home", 37: "Left", 38: "Up", 39: "Right", 40: "Down", 44: "PrintScrn", 45: "Insert",
   46: "Delete", 59: ";", 61: "=", 91: "Mod", 92: "Mod", 93: "Mod",
-  106: "*", 107: "=", 109: "-", 110: ".", 111: "/", 127: "Delete",
+  106: "*", 107: "=", 109: "-", 110: ".", 111: "/", 127: "Delete", 145: "ScrollLock",
   173: "-", 186: ";", 187: "=", 188: ",", 189: "-", 190: ".", 191: "/", 192: "`", 219: "[", 220: "\\",
   221: "]", 222: "'", 63232: "Up", 63233: "Down", 63234: "Left", 63235: "Right", 63272: "Delete",
   63273: "Home", 63275: "End", 63276: "PageUp", 63277: "PageDown", 63302: "Insert"


### PR DESCRIPTION
* Changed: keyCode `3` -> <kbd>Pause</kbd>

  <kbd>Pause</kbd> with <kbd>Ctrl</kbd> modifier produces keyCode `3`, which was set to `Enter` (why?). See also [MDN](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
):

  >"Pause" key with Control causes 0x03 (3).

* Added: keyCode `145` -> <kbd>ScrollLock</kbd>

  Note: Ctrl-ScrollLock has keyCode 3, same as Ctrl-Pause, so I use event.code when available (Chrome 48+, FF 38+, Safari 10.1+)
