### PR TITLE
Support for the official mimetype

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -856,6 +856,6 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   return mode;
 }, "xml");
 
-CodeMirror.defineMIME("text/x-markdown", "markdown");
+CodeMirror.defineMIME("text/markdown", "text/x-markdown", "markdown");
 
 });

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -856,6 +856,8 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   return mode;
 }, "xml");
 
-CodeMirror.defineMIME("text/markdown", "text/x-markdown", "markdown");
+CodeMirror.defineMIME("text/markdown", "markdown");
+  
+CodeMirror.defineMIME("text/x-markdown", "markdown");
 
 });


### PR DESCRIPTION
tl;dr: `text/markdown` since March 2016
---

In March 2016, `text/markdown` was registered as [RFC7763 at IETF](https://tools.ietf.org/html/rfc7763).

Previously, it should have been `text/x-markdown`. The text below describes the situation before March 2016, when RFC7763 was still a draft.

---

There is no official recommendation on [Gruber’s definition](http://daringfireball.net/projects/markdown/), but the topic was discussed quite heavily on the [official mailing-list](http://six.pairlist.net/pipermail/markdown-discuss/2007-June/thread.html#640), and reached the choice of `text/x-markdown`.

This conclusion was [challenged later](http://six.pairlist.net/pipermail/markdown-discuss/2008-February/000960.html), has been confirmed and can be, IMO, considered consensus.

This is the only logical conclusion in the lack of an official mime type: `text/` will provide proper default almost everywhere, `x-` because we're not using an official type, `markdown` and not `gruber.` or whatever because the type is now so common.

There are still [unknowns](http://six.pairlist.net/pipermail/markdown-discuss/2007-June/000652.html) regarding the different “flavors” of Markdown, though. I guess someone should register an official type, which is supposedly [easy](http://tools.ietf.org/html/rfc4288#section-3.4), but I doubt anyone dares do it beyond John Gruber, as he very recently [proved](http://blog.codinghorror.com/standard-markdown-is-now-common-markdown/) his attachment to Markdown.

There is a [draft](https://datatracker.ietf.org/doc/draft-ietf-appsawg-text-markdown/) on the IETF for `text/markdown`, but the contents do not seem to describe Markdown at all, so I wouldn't use it until it gets more complete.