### PR TITLE
Add Arduino file extension (C/C++)

### DIFF
--- a/mode/meta.js
+++ b/mode/meta.js
@@ -12,6 +12,7 @@
   "use strict";
 
   CodeMirror.modeInfo = [
+    {name: "Arduino", mime: "text/x-csrc", mode: "clike", ext: ["ino"]},
     {name: "APL", mime: "text/apl", mode: "apl", ext: ["dyalog", "apl"]},
     {name: "PGP", mimes: ["application/pgp", "application/pgp-encrypted", "application/pgp-keys", "application/pgp-signature"], mode: "asciiarmor", ext: ["asc", "pgp", "sig"]},
     {name: "ASN.1", mime: "text/x-ttcn-asn", mode: "asn.1", ext: ["asn", "asn1"]},

--- a/mode/meta.js
+++ b/mode/meta.js
@@ -12,13 +12,12 @@
   "use strict";
 
   CodeMirror.modeInfo = [
-    {name: "Arduino", mime: "text/x-csrc", mode: "clike", ext: ["ino"]},
     {name: "APL", mime: "text/apl", mode: "apl", ext: ["dyalog", "apl"]},
     {name: "PGP", mimes: ["application/pgp", "application/pgp-encrypted", "application/pgp-keys", "application/pgp-signature"], mode: "asciiarmor", ext: ["asc", "pgp", "sig"]},
     {name: "ASN.1", mime: "text/x-ttcn-asn", mode: "asn.1", ext: ["asn", "asn1"]},
     {name: "Asterisk", mime: "text/x-asterisk", mode: "asterisk", file: /^extensions\.conf$/i},
     {name: "Brainfuck", mime: "text/x-brainfuck", mode: "brainfuck", ext: ["b", "bf"]},
-    {name: "C", mime: "text/x-csrc", mode: "clike", ext: ["c", "h"]},
+    {name: "C", mime: "text/x-csrc", mode: "clike", ext: ["c", "h", "ino"]},
     {name: "C++", mime: "text/x-c++src", mode: "clike", ext: ["cpp", "c++", "cc", "cxx", "hpp", "h++", "hh", "hxx"], alias: ["cpp"]},
     {name: "Cobol", mime: "text/x-cobol", mode: "cobol", ext: ["cob", "cpy"]},
     {name: "C#", mime: "text/x-csharp", mode: "clike", ext: ["cs"], alias: ["csharp"]},


### PR DESCRIPTION
I noticed that gogs wasn't recognizing the syntax of my Arduino sketches because of the `.ino` file extension, since Arduino code is essentially C/C++, this fixes it.