### PR TITLE
[Markdown] Adding more thorough clearing for styles across list items and paragraph breaks

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -166,6 +166,10 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
         }
         if (state.list !== false) {
           state.indentationDiff = lineIndentation - state.listStack[state.listStack.length - 1]
+          state.em = false;
+          state.strong = false;
+          state.code = false;
+          state.strikethrough = false;
         }
       }
     }

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -862,6 +862,8 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   return mode;
 }, "xml");
 
+CodeMirror.defineMIME("text/markdown", "markdown");
+
 CodeMirror.defineMIME("text/x-markdown", "markdown");
 
 });

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -113,6 +113,8 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   function blankLine(state) {
     // Reset linkTitle state
     state.linkTitle = false;
+    state.linkHref = false;
+    state.linkText = false;
     // Reset EM state
     state.em = false;
     // Reset STRONG state

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -151,6 +151,12 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     if (state.indentationDiff === null) {
       state.indentationDiff = state.indentation;
       if (prevLineIsList) {
+        // Reset inline styles which shouldn't propagate aross list items
+        state.em = false;
+        state.strong = false;
+        state.code = false;
+        state.strikethrough = false;
+
         state.list = null;
         // While this list item's marker's indentation is less than the deepest
         //  list item's content's indentation,pop the deepest list item
@@ -166,10 +172,6 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
         }
         if (state.list !== false) {
           state.indentationDiff = lineIndentation - state.listStack[state.listStack.length - 1]
-          state.em = false;
-          state.strong = false;
-          state.code = false;
-          state.strikethrough = false;
         }
       }
     }
@@ -859,8 +861,6 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   };
   return mode;
 }, "xml");
-
-CodeMirror.defineMIME("text/markdown", "markdown");
 
 CodeMirror.defineMIME("text/x-markdown", "markdown");
 


### PR DESCRIPTION
Most Markdown parsers cut off the inline styles with new list items, but the Markdown mode in CodeMirror keeps them open. This means the preview in CodeMirror usually doesn't match the rendered output. I've made an example [here](http://jsbin.com/dosisudusu/edit?html,output). 

I don't 100% understand exactly how the tokenizer is working here, so this might not be the exact right spot to make the change. It worked in my tests, though. 
  
  