### PR TITLE
[Markdown] linkHref status should get copied along with the rest of the state.

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -777,6 +777,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
         formatting: false,
         linkText: s.linkText,
         linkTitle: s.linkTitle,
+        linkHref: s.linkHref,
         code: s.code,
         em: s.em,
         strong: s.strong,


### PR DESCRIPTION
The `linkHref` data wasn't getting copied through when the state was copied, so no tokens were ever carrying it. 