### PR TITLE
Switch order of SQL hints

### DIFF
--- a/addon/hint/sql-hint.js
+++ b/addon/hint/sql-hint.js
@@ -273,8 +273,8 @@
     if (search.charAt(0) == "." || search.charAt(0) == identifierQuote) {
       start = nameCompletion(cur, token, result, editor);
     } else {
-      addMatches(result, search, tables, function(w) {return w;});
       addMatches(result, search, defaultTable, function(w) {return w;});
+      addMatches(result, search, tables, function(w) {return w;});
       if (!disableKeywords)
         addMatches(result, search, keywords, function(w) {return w.toUpperCase();});
     }


### PR DESCRIPTION
I propose to show column hints (if a defaultTable is set) above table hints, since you are far more often in clauses where you need those.