### PR TITLE
[javascript-lint addon] Fix incorrect severity

### DIFF
--- a/addon/lint/javascript-lint.js
+++ b/addon/lint/javascript-lint.js
@@ -51,13 +51,13 @@
   }
 
   function fixWith(error, forcedErrorCodes, replacements) {
-    var errorCode, description, fix, find, replace, found;
+    var errorCode, description, i, fix, find, replace, found;
 
     errorCode = error.code;
     description = error.description;
 
     if (error.severity !== "error") {
-      for (var i = 0; i < forcedErrorCodes.length; i++) {
+      for (i = 0; i < forcedErrorCodes.length; i++) {
         if (errorCode === forcedErrorCodes[i]) {
           error.severity = "error";
           break;

--- a/addon/lint/javascript-lint.js
+++ b/addon/lint/javascript-lint.js
@@ -68,11 +68,12 @@
     for (i = 0; i < replacements.length; i++) {
       fix = replacements[i];
       find = fix[0];
-      replace = fix[1];
       found = description.indexOf(find) !== -1;
 
       if (found) {
+        replace = fix[1];
         error.description = replace;
+        break;
       }
     }
   }

--- a/addon/lint/javascript-lint.js
+++ b/addon/lint/javascript-lint.js
@@ -14,12 +14,20 @@
 
   var bogus = [ "Dangerous comment" ];
 
-  var warnings = [ [ "Expected '{'",
+  var replacements = [ [ "Expected '{'",
                      "Statement body should be inside '{ }' braces." ] ];
 
-  var errors = [ "Missing semicolon", "Extra comma", "Missing property name",
-                 "Unmatched ", " and instead saw", " is not defined",
-                 "Unclosed string", "Stopping, unable to continue" ];
+  var forcedErrorCodes = [
+    "W033", // Missing semicolon.
+    "W070", // Extra comma. (it breaks older versions of IE)
+    "W112", // Unclosed string.
+    "W117", // '{a}' is not defined.
+    "W023", // Expected an identifier in an assignment and instead saw a function invocation.
+    "W024", // Expected an identifier and instead saw '{a}' (a reserved word).
+    "W030", // Expected an assignment or function call and instead saw an expression.
+    "W084", // Expected a conditional expression and instead saw an assignment.
+    "W095" // Expected a string and instead saw {a}.
+  ];
 
   function validator(text, options) {
     if (!window.JSHINT) {
@@ -37,28 +45,33 @@
   CodeMirror.registerHelper("lint", "javascript", validator);
 
   function cleanup(error) {
-    // All problems are warnings by default
-    fixWith(error, warnings, "warning", true);
-    fixWith(error, errors, "error");
+    fixWith(error, forcedErrorCodes, replacements);
 
     return isBogus(error) ? null : error;
   }
 
-  function fixWith(error, fixes, severity, force) {
-    var description, fix, find, replace, found;
+  function fixWith(error, forcedErrorCodes, replacements) {
+    var errorCode, description, fix, find, replace, found;
 
+    errorCode = error.code;
     description = error.description;
 
-    for ( var i = 0; i < fixes.length; i++) {
-      fix = fixes[i];
-      find = (typeof fix === "string" ? fix : fix[0]);
-      replace = (typeof fix === "string" ? null : fix[1]);
+    if (error.severity !== "error") {
+      for (var i = 0; i < forcedErrorCodes.length; i++) {
+        if (errorCode === forcedErrorCodes[i]) {
+          error.severity = "error";
+          break;
+        }
+      }
+    }
+
+    for (i = 0; i < replacements.length; i++) {
+      fix = replacements[i];
+      find = fix[0];
+      replace = fix[1];
       found = description.indexOf(find) !== -1;
 
-      if (force || found) {
-        error.severity = severity;
-      }
-      if (found && replace) {
+      if (found) {
         error.description = replace;
       }
     }
@@ -128,6 +141,7 @@
         error.description = error.reason;// + "(jshint)";
         error.start = error.character;
         error.end = end;
+        error.severity = error.code.startsWith('W') ? "warning" : "error";
         error = cleanup(error);
 
         if (error)


### PR DESCRIPTION
When enabling strict equality checks via `lint: {options: {eqeqeq: true}}` ([see](http://jshint.com/docs/options/#eqeqeq)), found problems showed up as errors instead of warnings.
To fix it, the `fixWith()` logic had to be changed since simply adding the phrase to the warnings array would not have worked. This is because both the warnings and errors array matched this exact error and therefore the severity could never be "warning" (errors were checked after warnings).

I didn't include "Missing property name" and "Unmatched " in the new error array since they already are errors with the new logic.
"Stopping, unable to continue" also got removed since it didn't appear anywhere in the current jshint.js.

For now I've implemented everything to not break previous behavior/hinting, except the strict equality hint severity. Although I want to suggest removing the following codes from the new error array (so they can stay warnings):
- W033 (Missing semicolon) - since erroneous missing semicolons have their own code: E058
- W084 (Expected a conditional expression and instead saw an assignment) - since something like `switch (var2 = var1 + 42)` is valid js code, though not recommendable
- maybe W023/24/30/95, since there are many more " and instead saw an" hints that are already errors with their own codes, so I think they should be pretty accurate. Unfortunately I couldn't force these warnings so I couldn't check.