### PR TITLE
[lint demo] Added JS error

### DIFF
--- a/demo/lint.html
+++ b/demo/lint.html
@@ -39,7 +39,7 @@
     <p><textarea id="code-js">var widgets = []
 function updateHints() {
   editor.operation(function(){
-    for (var i = 0; i < widgets.length; ++i)
+    for (var i = 0; i < widgets.length.; ++i)
       editor.removeLineWidget(widgets[i]);
     widgets.length = 0;
 


### PR DESCRIPTION
As of 1d5c828f8348b7384cb38568f0d12075fd41917e the missing js semicolon is a warning and not an error anymore, therefore I added an error elsewhere.