### PR TITLE
[mode/meta] Add handlebars extensions to htmlmixed

### DIFF
--- a/mode/meta.js
+++ b/mode/meta.js
@@ -64,7 +64,7 @@
     {name: "Haxe", mime: "text/x-haxe", mode: "haxe", ext: ["hx"]},
     {name: "HXML", mime: "text/x-hxml", mode: "haxe", ext: ["hxml"]},
     {name: "ASP.NET", mime: "application/x-aspx", mode: "htmlembedded", ext: ["aspx"], alias: ["asp", "aspx"]},
-    {name: "HTML", mime: "text/html", mode: "htmlmixed", ext: ["html", "htm"], alias: ["xhtml"]},
+    {name: "HTML", mime: "text/html", mode: "htmlmixed", ext: ["html", "htm", "handlebars", "hbs"], alias: ["xhtml"]},
     {name: "HTTP", mime: "message/http", mode: "http"},
     {name: "IDL", mime: "text/x-idl", mode: "idl", ext: ["pro"]},
     {name: "Pug", mime: "text/x-pug", mode: "pug", ext: ["jade", "pug"], alias: ["jade"]},


### PR DESCRIPTION
[Handlebars](http://handlebarsjs.com/) is a template language primarily used for HTML which renders pretty well in `htmlmixed` mode, so I added its extensions to the `htmlmixed` mode.