### PR TITLE
Doc constructor can now accept another Doc object

### DIFF
--- a/src/model/Doc.js
+++ b/src/model/Doc.js
@@ -25,6 +25,28 @@ let Doc = function(text, mode, firstLine, lineSep, direction) {
   if (firstLine == null) firstLine = 0
 
   BranchChunk.call(this, [new LeafChunk([new Line("", null)])])
+
+  let history = new History(null)
+
+  if (text instanceof Doc) {
+    const options = mode || {}
+    const other = text
+
+    let from = other.first, to = other.first + other.size
+    if (options.from != null && options.from > from) from = options.from
+    if (options.to != null && options.to < to) to = options.to
+    ;(other.linked || (other.linked = [])).push({doc: this, sharedHist: options.sharedHist})
+    this.linked = [{doc: other, isParent: true, sharedHist: options.sharedHist}]
+    copySharedMarkers(this, findSharedMarkers(other))
+
+    if(options.sharedHist) history = other.history
+    firstLine = from
+    lineSep = other.lineSep
+    mode = options.mode || other.modeOption
+    direction = other.direction
+    text = getLines(other, from, to)
+  }
+
   this.first = firstLine
   this.scrollTop = this.scrollLeft = 0
   this.cantEdit = false
@@ -32,7 +54,7 @@ let Doc = function(text, mode, firstLine, lineSep, direction) {
   this.modeFrontier = this.highlightFrontier = firstLine
   let start = Pos(firstLine, 0)
   this.sel = simpleSelection(start)
-  this.history = new History(null)
+  this.history = history
   this.id = ++nextDocId
   this.modeOption = mode
   this.lineSep = lineSep


### PR DESCRIPTION
Before, extending base `Doc` class had serious limitation, that if sub-class(say for example `DocPlus`)
required itself to be linked to another `DocPlus`, which also meant to  have their respective bases(`Doc`)
in sync, that wouldn't have worked, as `DocPlus` constructor needs to call `super()` before anything else.

Thus not being able to have a synced/linked base `Doc`(which originally, only possible by using `linkedDoc`)

This patch will allow developers to have:

```javascript
import { Doc } from 'codemirror';

class DocPlus extends Doc {
	constructor(contents) {
		super(contents, (contents instanceof Doc) ? { sharedHist: true } : 'javascript');
	}

	writeToDisk(path) {
		// ...
	}
}

const doc = new DocPlus('cool');
const synced = new DocPlus(doc);

doc.replaceRange('really ', { line: 0, ch: 0 });
console.log(synced.getValue());
// > really cool

synced.undo();
console.log(doc.getValue());
// > cool

```

So, `Doc` constructor now has following signatures:

```javascript
const newDoc = new Doc(text, [mode, firstLine, lineSep, direction])
const linkedDoc = new Doc(doc, [linkingOptions])
```