### PR TITLE
[sublime keymap] In addCursorToNextLine, skip lines that are too short to keep the cursor's position

### DIFF
--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -156,11 +156,23 @@
     var ranges = cm.listSelections(), newRanges = [];
     for (var i = 0; i < ranges.length; i++) {
       var range = ranges[i];
-      var newAnchor = cm.findPosV(range.anchor, dir, "line");
-      var newHead = cm.findPosV(range.head, dir, "line");
-      var newRange = {anchor: newAnchor, head: newHead};
+      var newAnchor;
+      var newHead;
+      var amount = 1;
+      do {
+        newAnchor = cm.findPosV(range.anchor, dir * amount, "line");
+        newHead = cm.findPosV(range.head, dir * amount, "line");
+        if (newAnchor.hitSide || newHead.hitSide) {
+          break;
+        }
+        amount++;
+      } while (newAnchor.xRel > 3 || newHead.xRel > 3);
+
       newRanges.push(range);
-      newRanges.push(newRange);
+      if (!newAnchor.hitSide && !newHead.hitSide) {
+        var newRange = {anchor: newAnchor, head: newHead};
+        newRanges.push(newRange);
+      }
     }
     cm.setSelections(newRanges);
   }


### PR DESCRIPTION
The current behavior of addCursorToNextLine is to select the next line even if it has less characters than the cursor's column. This creates the following effect (# is the cursor's position):

```
 int main() {
    #int x = 0;
    #int y = 0;
#
#    return 0;
#}
```

Instead, this change skips short lines (in this case the empty line) and keeps the cursor's column:

```
 int main() {
    #int x = 0;
    #int y = 0;

    #return 0;
}
```