### PR TITLE
Update regex in text/x-kotlin for parsing numbers in code

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -617,7 +617,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     intendSwitch: false,
     indentStatements: false,
     multiLineStrings: true,
-    number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+\.?\d*|\.\d+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
+    number: /^(?:0x[a-f\d_]+|0b[01_]+|(?:[\d_]+\.?[^\.\D]+|\.\d+|[\d_]+)(?:e[-+]?[\d_]+)?)(u|ll?|l|f)?/i,
     blockKeywords: words("catch class do else finally for if where try while enum"),
     defKeywords: words("class val var object interface fun"),
     atoms: words("true false null this"),


### PR DESCRIPTION
Now we have a problem with drawing dots in range in Kotlin code.
For instance:
now `1..5` => **1.**(green) **.**(black) **5**(green) 
expected `1..5` => **1**(green) **..**(both black) **5**(green).

What i did? 
1) replaced existing alternative  `\d* => [^\.\D]+`
We want to see NO dot after dot and NO any symbols except numbers `/D`
2) added 1 more alternative `[\d_]+ `
Just only for writting plain digitals in code like **"1"**, **"11"**, **"12345"**