### PR TITLE
Add condition on addLineWidget function

### DIFF
--- a/src/model/line_widget.js
+++ b/src/model/line_widget.js
@@ -73,6 +73,8 @@ export function addLineWidget(doc, handle, node, options) {
     }
     return true
   })
-  signalLater(cm, "lineWidgetAdded", cm, widget, typeof handle == "number" ? handle : lineNo(handle))
+  if (cm !== undefined) {
+    signalLater(cm, "lineWidgetAdded", cm, widget, typeof handle == "number" ? handle : lineNo(handle));
+  }
   return widget
 }


### PR DESCRIPTION
Hello! 
Unfortunately we've used an old version of CodeMirror(~2016), but recently updated on version 5.34.0.
And get one problem with `addLineWidget` function.
In this function we can see the `signalLater` function.
`signalLater(cm, "lineWidgetAdded", cm, widget, typeof handle == "number" ? handle : lineNo(handle))` 
FYI: `signalLater` was added ~02.2017 but `addLineWidge` ~2016. 
In my case I always get exception in this function in `getHandlers`, because  `var cm = doc.cm;` always undefined and then in  `getHandlers` => `cm._handlers` => exception.

Probably It will be nice to add one condition on undefined before calling `signalLater` function.

Thanks.
