### PR TITLE
[sublime keymap] Fix addCursorToSelection.

### DIFF
--- a/keymap/sublime.js
+++ b/keymap/sublime.js
@@ -156,8 +156,14 @@
     var ranges = cm.listSelections(), newRanges = [];
     for (var i = 0; i < ranges.length; i++) {
       var range = ranges[i];
-      var newAnchor = cm.findPosV(range.anchor, dir, "line");
-      var newHead = cm.findPosV(range.head, dir, "line");
+      var newAnchor = cm.findPosV(
+          range.anchor, dir, "line", range.anchor.goalColumn);
+      var newHead = cm.findPosV(
+          range.head, dir, "line", range.head.goalColumn);
+      newAnchor.goalColumn = range.anchor.goalColumn != null ?
+          range.anchor.goalColumn : cm.cursorCoords(range.anchor, "div").left;
+      newHead.goalColumn = range.head.goalColumn != null ?
+          range.head.goalColumn : cm.cursorCoords(range.head, "div").left;
       var newRange = {anchor: newAnchor, head: newHead};
       newRanges.push(range);
       newRanges.push(newRange);


### PR DESCRIPTION
In addCursorToSelection, keep the cursor's position after short lines. For example (# is the cursor's position):

```
 int main() {
    #int x = 0;   // <--- Start with a cursor here.
    #int y = 0;
#
    #return 0;
}
```

instead of the current behavior:
```
 int main() {
    #int x = 0;   // <--- Start with a cursor here.
    #int y = 0;
#
#    return 0;
}
```

This is similar to [this pull request](https://github.com/codemirror/CodeMirror/pull/5207), but the behavior is more similar to Sublime's behavior.

