### PR TITLE
[stex mode] LaTeX-style inline math delimiters \( \)

### DIFF
--- a/mode/stex/stex.js
+++ b/mode/stex/stex.js
@@ -117,6 +117,10 @@
         setState(state, function(source, state){ return inMathMode(source, state, "\\]"); });
         return "keyword";
       }
+      if (source.match("\\(")) {
+        setState(state, function(source, state){ return inMathMode(source, state, "\\)"); });
+        return "keyword";
+      }
       if (source.match("$$")) {
         setState(state, function(source, state){ return inMathMode(source, state, "$$"); });
         return "keyword";

--- a/mode/stex/test.js
+++ b/mode/stex/test.js
@@ -111,6 +111,9 @@
   MT("inlineMath",
      "[keyword $][number 3][variable-2 x][tag ^][number 2.45]-[tag \\sqrt][bracket {][tag \\$\\alpha][bracket }] = [number 2][keyword $] other text");
 
+  MT("inlineMathLatexStyle",
+     "[keyword \\(][number 3][variable-2 x][tag ^][number 2.45]-[tag \\sqrt][bracket {][tag \\$\\alpha][bracket }] = [number 2][keyword \\)] other text");
+
   MT("displayMath",
      "More [keyword $$]\t[variable-2 S][tag ^][variable-2 n][tag \\sum] [variable-2 i][keyword $$] other text");
 


### PR DESCRIPTION
Add support for inline math in LaTeX-style:
```tex
This is an equation \( E=mc^2 \), named after Einstein.
```