### PR TITLE
[stex mode] Added some tags whose arguments are atom

### DIFF
--- a/mode/stex/stex.js
+++ b/mode/stex/stex.js
@@ -78,6 +78,14 @@
     plugins["begin"] = addPluginPattern("begin", "tag", ["atom"]);
     plugins["end"] = addPluginPattern("end", "tag", ["atom"]);
 
+    plugins["label"    ] = addPluginPattern("label"    , "tag", ["atom"]);
+    plugins["ref"      ] = addPluginPattern("ref"      , "tag", ["atom"]);
+    plugins["eqref"    ] = addPluginPattern("eqref"    , "tag", ["atom"]);
+    plugins["cite"     ] = addPluginPattern("cite"     , "tag", ["atom"]);
+    plugins["bibitem"  ] = addPluginPattern("bibitem"  , "tag", ["atom"]);
+    plugins["Bibitem"  ] = addPluginPattern("Bibitem"  , "tag", ["atom"]);
+    plugins["RBibitem" ] = addPluginPattern("RBibitem" , "tag", ["atom"]);
+
     plugins["DEFAULT"] = function () {
       this.name = "DEFAULT";
       this.style = "tag";

--- a/mode/stex/test.js
+++ b/mode/stex/test.js
@@ -117,6 +117,12 @@
   MT("displayMath",
      "More [keyword $$]\t[variable-2 S][tag ^][variable-2 n][tag \\sum] [variable-2 i][keyword $$] other text");
 
+  MT("displayMath environment",
+     "[tag \\begin][bracket {][atom equation][bracket }] x [tag \\end][bracket {][atom equation][bracket }] other text");
+
+  MT("displayMath environment with label",
+     "[tag \\begin][bracket {][atom equation][bracket }][tag \\label][bracket {][atom eq1][bracket }] x [tag \\end][bracket {][atom equation][bracket }] other text~[tag \\ref][bracket {][atom eq1][bracket }]");
+
   MT("mathWithComment",
      "[keyword $][variable-2 x] [comment % $]",
      "[variable-2 y][keyword $] other text");


### PR DESCRIPTION
If you declare a `\label` and then want to make a `\ref` to it, you must literally repeat the argument of `\label` tag as the argument of `\ref` tag. So, the arguments are always `atom`s, even if they contain digits, underscores, colons etc.