### PR TITLE
CodeMirror.hasMode

### DIFF
--- a/addon/runmode/runmode-standalone.js
+++ b/addon/runmode/runmode-standalone.js
@@ -90,9 +90,15 @@ CodeMirror.resolveMode = function(spec) {
   if (typeof spec == "string") return {name: spec};
   else return spec || {name: "null"};
 };
+function getModeFactory(spec) {
+  var modeName = CodeMirror.resolveMode(spec).name;
+  return modes[modeName];
+}
+CodeMirror.hasMode = function (spec) {
+  return typeof getModeFactory(spec) === "function";
+};
 CodeMirror.getMode = function (options, spec) {
-  spec = CodeMirror.resolveMode(spec);
-  var mfactory = modes[spec.name];
+  var mfactory = getModeFactory(spec);
   if (!mfactory) throw new Error("Unknown mode: " + spec);
   return mfactory(options, spec);
 };

--- a/addon/runmode/runmode-standalone.js
+++ b/addon/runmode/runmode-standalone.js
@@ -90,15 +90,16 @@ CodeMirror.resolveMode = function(spec) {
   if (typeof spec == "string") return {name: spec};
   else return spec || {name: "null"};
 };
-function getModeFactory(spec) {
-  var modeName = CodeMirror.resolveMode(spec).name;
+function getModeFactory(spec, isResolved) {
+  var modeName = isResolved ? spec.name : CodeMirror.resolveMode(spec).name;
   return modes[modeName];
 }
 CodeMirror.hasMode = function (spec) {
   return typeof getModeFactory(spec) === "function";
 };
 CodeMirror.getMode = function (options, spec) {
-  var mfactory = getModeFactory(spec);
+  spec = CodeMirror.resolveMode(spec);
+  var mfactory = getModeFactory(spec, true);
   if (!mfactory) throw new Error("Unknown mode: " + spec);
   return mfactory(options, spec);
 };

--- a/src/edit/legacy.js
+++ b/src/edit/legacy.js
@@ -36,6 +36,7 @@ export function addLegacyProps(CodeMirror) {
   CodeMirror.modes = modes
   CodeMirror.mimeModes = mimeModes
   CodeMirror.resolveMode = resolveMode
+  CodeMirror.hasMode = hasMode
   CodeMirror.getMode = getMode
   CodeMirror.modeExtensions = modeExtensions
   CodeMirror.extendMode = extendMode

--- a/src/modes.js
+++ b/src/modes.js
@@ -35,11 +35,20 @@ export function resolveMode(spec) {
   else return spec || {name: "null"}
 }
 
+export function getModeFactory(spec, isResolved) {
+  var modeName = isResolved ? spec.name : resolveMode(spec).name
+  return modes[modeName]
+}
+
+export function hasMode(spec) {
+  return typeof getModeFactory(spec) === "function"
+}
+
 // Given a mode spec (anything that resolveMode accepts), find and
 // initialize an actual mode object.
 export function getMode(options, spec) {
   spec = resolveMode(spec)
-  let mfactory = modes[spec.name]
+  let mfactory = getModeFactory(spec, true)
   if (!mfactory) return getMode(options, "text/plain")
   let modeObj = mfactory(options, spec)
   if (modeExtensions.hasOwnProperty(spec.name)) {


### PR DESCRIPTION
I created a `hasMode(spec)` function, to check if a given spec resolves to an existing mode. I needed this for dynamic mode creations via overlay.js, so I don't end up creating the same mode over and over again.
Thought it could be useful to others.