### PR TITLE
Add support for dynamic import operator to JavaScript mode

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -400,6 +400,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (type == "{") return contCommasep(objprop, "}", null, maybeop);
     if (type == "quasi") return pass(quasi, maybeop);
     if (type == "new") return cont(maybeTarget(noComma));
+    if (type == "import") return cont(expression);
     return cont();
   }
   function maybeexpression(type) {
@@ -726,6 +727,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   }
   function afterImport(type) {
     if (type == "string") return cont();
+    if (type == "(") return pass(expression);
     return pass(importSpec, maybeMoreImports, maybeFrom);
   }
   function importSpec(type, value) {

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -66,6 +66,9 @@
   MT("import_dynamic",
      "[keyword import]([string 'baz']).[property then]")
 
+  MT("import_dynamic",
+     "[keyword const] [def t] [operator =] [keyword import]([string 'baz']).[property then]")
+
   MT("const",
      "[keyword function] [def f]() {",
      "  [keyword const] [[ [def a], [def b] ]] [operator =] [[ [number 1], [number 2] ]];",

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -63,6 +63,9 @@
   MT("import_trailing_comma",
      "[keyword import] {[def foo], [def bar],} [keyword from] [string 'baz']")
 
+  MT("import_dynamic",
+     "[keyword import]([string 'baz']).[property then]")
+
   MT("const",
      "[keyword function] [def f]() {",
      "  [keyword const] [[ [def a], [def b] ]] [operator =] [[ [number 1], [number 2] ]];",


### PR DESCRIPTION
Adds support for dynamic import syntax to the JavaScript mode. Currently this isn't handled, so, for instance, property access from dynamic imports - like

```js
import('foo').then(() => {});
```

Highlights `then` as a `variable`, not a `property`.

This PR allows for dynamic imports at the top level by detecting `(`, and handles imports in expressions by just continuing to the expression mode when they're detected.