### PR TITLE
[javascript-lint] JSHINT backward compatibility (#5260)

### DIFF
--- a/addon/lint/javascript-lint.js
+++ b/addon/lint/javascript-lint.js
@@ -51,7 +51,7 @@
         // Convert to format expected by validation service
         var hint = {
           message: error.reason,
-          severity: error.code.startsWith('W') ? "warning" : "error",
+          severity: error.code ? (error.code.startsWith('W') ? "warning" : "error") : "error",
           from: CodeMirror.Pos(error.line - 1, start),
           to: CodeMirror.Pos(error.line - 1, end)
         };


### PR DESCRIPTION
Setting error severity to "error" by default when there is no error.code property (#5260)