### PR TITLE
Support for await syntax in JavaScript mode

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -638,7 +638,8 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   function maybeelse(type, value) {
     if (type == "keyword b" && value == "else") return cont(pushlex("form", "else"), statement, poplex);
   }
-  function forspec(type) {
+  function forspec(type, value) {
+    if (value == "await") return cont(forspec);
     if (type == "(") return cont(pushlex(")"), forspec1, expect(")"), poplex);
   }
   function forspec1(type) {

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -77,6 +77,9 @@
   MT("for/of",
      "[keyword for]([keyword let] [def of] [keyword of] [variable something]) {}");
 
+  MT("for await",
+     "[keyword for] [keyword await]([keyword let] [def of] [keyword of] [variable something]) {}");
+
   MT("generator",
      "[keyword function*] [def repeat]([def n]) {",
      "  [keyword for]([keyword var] [def i] [operator =] [number 0]; [variable-2 i] [operator <] [variable-2 n]; [operator ++][variable-2 i])",


### PR DESCRIPTION
[asynchronous iteration](http://2ality.com/2016/10/asynchronous-iteration.html) is a stage 4 ("finished") feature in ES2018, and its additional syntax - for await loops - don't require too much change in CodeMirror's JavaScript mode for support. All this PR does is it tolerates an `await` keyword between `for` and `(` - previously the await would cause the mode to drop out of `forspec` and fail to highlight the def/check/increment correctly.