### PR TITLE
Support regex special characters in match highlighting addon (#5265)

### DIFF
--- a/addon/search/match-highlighter.js
+++ b/addon/search/match-highlighter.js
@@ -87,12 +87,20 @@
   }
 
   function addOverlay(cm, query, hasBoundary, style) {
+    function filter(cm, match) {
+      return boundariesAroundString(cm.getLine(match.from.line),
+                                    match.from.ch,
+                                    match.to.ch,
+                                    hasBoundary);
+    }
     var state = cm.state.matchHighlighter;
     cm.addOverlay(state.overlay = makeOverlay(query, hasBoundary, style));
     if (state.options.annotateScrollbar && cm.showMatchesOnScrollbar) {
-      var searchFor = hasBoundary ? new RegExp("\\b" + query + "\\b") : query;
-      state.matchesonscroll = cm.showMatchesOnScrollbar(searchFor, false,
-        {className: "CodeMirror-selection-highlight-scrollbar"});
+      state.matchesonscroll = cm.showMatchesOnScrollbar(query, false,
+        {
+          className: "CodeMirror-selection-highlight-scrollbar",
+          filter: hasBoundary ? filter : undefined
+        });
     }
   }
 
@@ -148,9 +156,13 @@
     } else return false;
   }
 
+  function boundariesAroundString(text, from, to, re) {
+    return (!from || !re.test(text.charAt(from - 1))) &&
+      (to == text.length || !re.test(text.charAt(to)));
+  }
+
   function boundariesAround(stream, re) {
-    return (!stream.start || !re.test(stream.string.charAt(stream.start - 1))) &&
-      (stream.pos == stream.string.length || !re.test(stream.string.charAt(stream.pos)));
+    return boundariesAroundString(stream.string, stream.start, stream.pos, re);
   }
 
   function makeOverlay(query, hasBoundary, style) {

--- a/addon/search/matchesonscrollbar.js
+++ b/addon/search/matchesonscrollbar.js
@@ -51,7 +51,9 @@
     while (cursor.findNext()) {
       var match = {from: cursor.from(), to: cursor.to()};
       if (match.from.line >= this.gap.to) break;
-      this.matches.splice(i++, 0, match);
+      if (!this.options.filter || this.options.filter(this.cm, match)) {
+        this.matches.splice(i++, 0, match);
+      }
       if (this.matches.length > maxMatches) break;
     }
     this.gap = null;


### PR DESCRIPTION
showMatchesOnScrollbar now accepts an additional option named 'filter'.
If set it must be a function that will receive a CodeMirror handle
and a match position and return a boolean result. Only matches for
which the filter returned 'true' will be highlighted.

This new mechanism has been used to check for boundaries when
annotating the scrollbar in the match highlighter. This should resolve 
issue #5265.