### PR TITLE
Add ECMAScript 2015 keywords to JavaScript hint addon

### DIFF
--- a/addon/hint/javascript-hint.js
+++ b/addon/hint/javascript-hint.js
@@ -92,8 +92,8 @@
   var arrayProps = ("length concat join splice push pop shift unshift slice reverse sort indexOf " +
                     "lastIndexOf every some filter forEach map reduce reduceRight ").split(" ");
   var funcProps = "prototype apply call bind".split(" ");
-  var javascriptKeywords = ("break case catch continue debugger default delete do else false finally for function " +
-                  "if in instanceof new null return switch throw true try typeof var void while with").split(" ");
+  var javascriptKeywords = ("break case catch class const continue debugger default delete do else export extends false finally for function " +
+                  "if in import instanceof new null return super switch this throw true try typeof var void while with yield").split(" ");
   var coffeescriptKeywords = ("and break catch class continue delete do else extends false finally for " +
                   "if in instanceof isnt new no not null of off on or return switch then throw true try typeof until void while with yes").split(" ");
 


### PR DESCRIPTION
This explicitly adds keywords that are already syntax-highlighted
and correctly parsed by CodeMirror already in the JavaScript mode.