### PR TITLE
[BUGFIX] Velocity variables with dash are not well highlighted #5287

### DIFF
--- a/mode/velocity/velocity.js
+++ b/mode/velocity/velocity.js
@@ -82,7 +82,7 @@ CodeMirror.defineMode("velocity", function() {
         }
         // variable?
         else if (ch == "$") {
-            stream.eatWhile(/[\w\d\$_\.{}]/);
+            stream.eatWhile(/[\w\d\$_\.{}-]/);
             // is it one of the specials?
             if (specials && specials.propertyIsEnumerable(stream.current())) {
                 return "keyword";


### PR DESCRIPTION
It is introduced dash in regexp for variables
#5287 