### PR TITLE
Implement binding types for var/let/const variables.

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -302,8 +302,13 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   function popcontext() {
     if (cx.state.context.block) {
       var newVars = {name: "this", next: {name: "arguments"}};
+      // drop block-scoped variables
       for (var v = cx.state.localVars; v; v = v.next) {
         if (!v.block) newVars = { name: v.name, scope: v.scope, next: newVars };
+      }
+      // inherit from previous scope
+      for (v = cx.state.context.vars; v; v = v.next) {
+        newVars = { name: v.name, scope: v.scope, next: newVars };
       }
       cx.state.localVars = newVars;
     } else {
@@ -376,8 +381,8 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
         return cont(pushlex("stat"), maybelabel);
       }
     }
-    if (type == "switch") return cont(pushlex("form"), parenExpr, expect("{"), pushlex("}", "switch"),
-                                      block, poplex, poplex);
+    if (type == "switch") return cont(pushblockcontext, pushlex("form"), parenExpr, expect("{"), pushlex("}", "switch"),
+                                      block, poplex, poplex, popcontext);
     if (type == "case") return cont(expression, expect(":"));
     if (type == "default") return cont(expect(":"));
     if (type == "catch") return cont(pushlex("form"), pushcontext, maybeCatchBinding, statement, poplex, popcontext);

--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -7,7 +7,7 @@
   else if (typeof define == "function" && define.amd) // AMD
     define(["../../lib/codemirror"], mod);
   else // Plain browser env
-     mod(CodeMirror);
+    mod(CodeMirror);
 })(function(CodeMirror) {
 "use strict";
 
@@ -268,7 +268,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   function register(varname) {
     function inList(list, block) {
       for (var v = list; v; v = v.next)
-        if (v.name == varname && (block === undefined || v.block == block)) return true;
+        if (v.name == varname && (block === undefined || v.block === block)) return true;
       return false;
     }
     var state = cx.state;
@@ -292,7 +292,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
 
   var defaultVars = {name: "this", next: {name: "arguments"}};
   function pushcontext() {
-    cx.state.context = {prev: cx.state.context, vars: cx.state.localVars };
+    cx.state.context = {prev: cx.state.context, vars: cx.state.localVars};
     cx.state.localVars = defaultVars;
   }
   function pushblockcontext() {
@@ -347,7 +347,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (type == "keyword b") return cont(pushlex("form"), statement, poplex);
     if (type == "keyword d") return cx.stream.match(/^\s*$/, false) ? cont() : cont(pushlex("stat"), maybeexpression, expect(";"), poplex);
     if (type == "debugger") return cont(expect(";"));
-    if (type == "{") return cont(pushlex("}"), pushblockcontext, block, popcontext, poplex);
+    if (type == "{") return cont(pushlex("}"), block, poplex);
     if (type == ";") return cont();
     if (type == "if") {
       if (cx.state.lexical.info == "else" && cx.state.cc[cx.state.cc.length - 1] == poplex)
@@ -557,7 +557,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   }
   function block(type) {
     if (type == "}") return cont();
-    return pass(statement, block);
+    return pass(pushblockcontext, statement, block, popcontext);
   }
   function maybetype(type, value) {
     if (isTS) {

--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -274,7 +274,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     var state = cx.state;
     cx.marked = "def";
     if (state.context) {
-      var block = !(cx.state.lexical.info && cx.state.lexical.info.scope == "var");
+      var block = !(cx.state.lexical.info && cx.state.lexical.info.scope === "var");
       if (inList(state.localVars, block)) return;
       state.localVars = {name: varname, block: block, next: state.localVars};
     } else {
@@ -302,7 +302,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   function popcontext() {
     if (cx.state.context.block) {
       var newVars = {name: "this", next: {name: "arguments"}};
-      for (var v = cx.state.context.vars; v; v = v.next) {
+      for (var v = cx.state.localVars; v; v = v.next) {
         if (!v.block) newVars = { name: v.name, scope: v.scope, next: newVars };
       }
       cx.state.localVars = newVars;

--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -347,7 +347,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (type == "keyword b") return cont(pushlex("form"), statement, poplex);
     if (type == "keyword d") return cx.stream.match(/^\s*$/, false) ? cont() : cont(pushlex("stat"), maybeexpression, expect(";"), poplex);
     if (type == "debugger") return cont(expect(";"));
-    if (type == "{") return cont(pushlex("}"), block, poplex);
+    if (type == "{") return cont(pushlex("}"), pushblockcontext, block, poplex, popcontext);
     if (type == ";") return cont();
     if (type == "if") {
       if (cx.state.lexical.info == "else" && cx.state.cc[cx.state.cc.length - 1] == poplex)
@@ -557,7 +557,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   }
   function block(type) {
     if (type == "}") return cont();
-    return pass(pushblockcontext, statement, block, popcontext);
+    return pass(statement, block);
   }
   function maybetype(type, value) {
     if (isTS) {

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -86,6 +86,12 @@
      "    [keyword yield] [variable-2 i];",
      "}");
 
+  MT("scoping",
+     "[keyword function] [def scoped]([def n]) {",
+     "  { [keyword var] [def i]; } [variable-2 i];",
+     "  { [keyword let] [def j]; } [variable j];",
+     "}");
+
   MT("quotedStringAddition",
      "[keyword let] [def f] [operator =] [variable a] [operator +] [string 'fatarrow'] [operator +] [variable c];");
 

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -90,7 +90,7 @@
      "[keyword function] [def scoped]([def n]) {",
      "  { [keyword var] [def i]; } [variable-2 i];",
      "  { [keyword let] [def j]; } [variable j];",
-     "  if (true) { [keyword const] [def k]; [variable-2 k]; } [variable k];",
+     "  if ([atom true]) { [keyword const] [def k]; [variable-2 k]; } [variable k];",
      "}");
 
   MT("quotedStringAddition",

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -89,9 +89,17 @@
   MT("let_scoping",
      "[keyword function] [def scoped]([def n]) {",
      "  { [keyword var] [def i]; } [variable-2 i];",
-     "  { [keyword let] [def j]; } [variable j];",
-     "  if ([atom true]) { [keyword const] [def k]; [variable-2 k]; } [variable k];",
+     "  { [keyword let] [def j]; [variable-2 j]; } [variable j];",
+     "  [keyword if] ([atom true]) { [keyword const] [def k]; [variable-2 k]; } [variable k];",
      "}");
+
+  MT("switch_scoping",
+     "[keyword switch] ([variable x]) {",
+     "  [keyword default]:",
+     "    [keyword let] [def j];",
+     "    [keyword return] [variable-2 j]",
+     "}",
+     "[variable j];")
 
   MT("quotedStringAddition",
      "[keyword let] [def f] [operator =] [variable a] [operator +] [string 'fatarrow'] [operator +] [variable c];");

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -86,10 +86,11 @@
      "    [keyword yield] [variable-2 i];",
      "}");
 
-  MT("scoping",
+  MT("let_scoping",
      "[keyword function] [def scoped]([def n]) {",
      "  { [keyword var] [def i]; } [variable-2 i];",
      "  { [keyword let] [def j]; } [variable j];",
+     "  if (true) { [keyword const] [def k]; [variable-2 k]; } [variable k];",
      "}");
 
   MT("quotedStringAddition",


### PR DESCRIPTION
Work in progress! This doesn't pass the full test suite yet, and I'm not sure why yet. This aims to fix #5138 - it makes the register() method in the JavaScript highlighting mode aware of the type of binding it is in, and also adds block context that contains block-scoped definitions. Review + hints for how to get to the finish line much appreciated!