### PR TITLE
Fix bug with indentation in multiplex.js

### DIFF
--- a/addon/mode/multiplex.js
+++ b/addon/mode/multiplex.js
@@ -50,7 +50,15 @@ CodeMirror.multiplexingMode = function(outer /*, others */) {
           if (found == stream.pos) {
             if (!other.parseDelimiters) stream.match(other.open);
             state.innerActive = other;
-            state.inner = CodeMirror.startState(other.mode, outer.indent ? outer.indent(state.outer, "") : 0);
+
+            // Get the outer indent, making sure to handle CodeMirror.Pass
+            let outerIndent = 0;
+            if (outer.indent) {
+              let possibleOuterIndent = outer.indent(state.outer, "");
+              if (possibleOuterIndent !== CodeMirror.Pass) outerIndent = possibleOuterIndent;
+            }
+
+            state.inner = CodeMirror.startState(other.mode, outerIndent);
             return other.delimStyle && (other.delimStyle + " " + other.delimStyle + "-open");
           } else if (found != -1 && found < cutOff) {
             cutOff = found;

--- a/addon/mode/multiplex.js
+++ b/addon/mode/multiplex.js
@@ -52,9 +52,9 @@ CodeMirror.multiplexingMode = function(outer /*, others */) {
             state.innerActive = other;
 
             // Get the outer indent, making sure to handle CodeMirror.Pass
-            let outerIndent = 0;
+            var outerIndent = 0;
             if (outer.indent) {
-              let possibleOuterIndent = outer.indent(state.outer, "");
+              var possibleOuterIndent = outer.indent(state.outer, "");
               if (possibleOuterIndent !== CodeMirror.Pass) outerIndent = possibleOuterIndent;
             }
 


### PR DESCRIPTION
Some modes may return `CodeMirror.Pass` from their `indent` methods, which in the current code can get fed into the start state of another mode and mess things up. Fixed to check for this case.