### PR TITLE
Add password as an inputStyle to avoid whacky mobile keyboard hijinks

### DIFF
--- a/src/edit/main.js
+++ b/src/edit/main.js
@@ -29,7 +29,8 @@ eventMixin(Doc)
 
 import ContentEditableInput from "../input/ContentEditableInput.js"
 import TextareaInput from "../input/TextareaInput.js"
-CodeMirror.inputStyles = {"textarea": TextareaInput, "contenteditable": ContentEditableInput}
+import PasswordInput from "../input/PasswordInput.js"
+CodeMirror.inputStyles = {"textarea": TextareaInput, "contenteditable": ContentEditableInput, "password": PasswordInput}
 
 // MODE DEFINITION AND QUERYING
 

--- a/src/input/PasswordInput.js
+++ b/src/input/PasswordInput.js
@@ -1,0 +1,8 @@
+import TextareaInput from "./TextareaInput"
+import { hiddenPassword } from "./input"
+
+export default class PasswordInput extends TextareaInput {
+  _getHiddenInput() {
+    return hiddenPassword()
+  }
+}

--- a/src/input/TextareaInput.js
+++ b/src/input/TextareaInput.js
@@ -30,11 +30,15 @@ export default class TextareaInput {
     this.composing = null
   }
 
+  _getHiddenInput() {
+    return hiddenTextarea()
+  }
+
   init(display) {
     let input = this, cm = this.cm
 
     // Wraps and hides input textarea
-    let div = this.wrapper = hiddenTextarea()
+    let div = this.wrapper = this._getHiddenInput()
     // The semihidden textarea that is focused when the editor is
     // focused, and receives input.
     let te = this.textarea = div.firstChild

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -133,3 +133,17 @@ export function hiddenTextarea() {
   disableBrowserMagic(te)
   return div
 }
+
+export function hiddenPassword() {
+  let te = elt("input", null, null, "position: absolute; bottom: -1em; padding: 0; width: 1px; height: 1em; outline: none")
+  te.setAttribute("type", "password")
+  let div = elt("div", [te], null, "overflow: hidden; position: relative; width: 3px; height: 0px;")
+  // The textarea is kept positioned near the cursor to prevent the
+  // fact that it'll be scrolled into view on input from scrolling
+  // our fake cursor out of view. On webkit, when wrap=off, paste is
+  // very slow. So make the area wide instead.
+  if (webkit) te.style.width = "1000px"
+  // If border: 0; -- iOS fails to open keyboard (issue #1287)
+  if (ios) te.style.border = "1px solid black"
+  return div
+}


### PR DESCRIPTION
Greetings!

**TL;DR** It _looks_ like using a password input as a backing field rather than a textarea or contenteditable solves some mobile issues.

I have a project with a live playground, wherein users can compose code jsFiddle-style and share in chats and issues to demonstrate bugs, get help with concepts, etc. This works fine on desktop, but I'm usually on my phone when I get a chance to look at them. As far as editors on mobile go, CodeMirror is one of the best behaved, but there are still weird issues that crop up when GBoard (and probably others) decides that it wants to help you complete a word or autocorrect that `forEach` for you.

After poking around at how to stop Chrome on Android from trying to do _anything_ related to autocorrect or suggestions, I found that CodeMirror already does its best to make the bad things stop in textarea mode, but Chrome is pretty insistent on mucking about with things you type. The _only_ field that I could think of that doesn't get abused by GBoard in Chrome is the password input, so I gave it a go. It seems to work nicely.

### Implementation

This just adds a new `inputStyle`, `password`, that when set, calls a new input `PasswordInput`, which is just a subclass of `TextareaInput` that has an override to get the backing node. I don't know if that was the best way to accomplish this, but it seemed better to have an override-able method on the class than to duplicate a whole bunch of code. It might make sense to use the `TextareaInput` for both cases, but just have it check the options during `init`, since it seems `inputStyle` can't be changed after init.

The default for mobile remains `contenteditable`.

### Potential issues?

There may be a few side-effects to using a password input:

* Chrome is pretty insistent on trying to save passwords when you submit a form. There are a few ways around that, mostly by throwing out some empty decoy password fields, but I'll cross that bridge if this looks like it's a useful PR.
* All of the input I tried worked well. You can't use the slide-on-the-spacebar-to-move-the-cursor trick, but that also tends to delete characters at random in contenteditable mode anyway, so I'll call that a draw. There may be some corner cases that I didn't stumble across.
* You get no blue teardrop cursor moving handle thing. The contenteditable mode does, but it doesn't seem to get the more useful double teardrop selection editor. It seems that select all still works, and honestly, I'm ok with poking at the place I need to drop the cursor a time or three if my input isn't randomly futzed.
* On GBoard, you get no emoji button for password fields, so you can no longer have happy, crying, or pile-of-poo comments/variables.
* More things that I haven't thought of? This is my first foray into editing code editor code. I also have no idea how to go about writing tests for actual functionality here.

Bonus effects:

* The suggestions bar on the top of the keyboard doesn't pop up to soak up another ~30px of precious tiny screen.

### Related issues

It _looks_ like this would resolve a handful of the open issues about whackiness with autocomplete and suggestions when using mobile keyboards. One issue that I specifically checked was autocomplete plugin triggering, and I verified that `<` still doesn't trigger the popup for the xmlcomplete demo.

### It's finally over

Thanks for reading my wall of text! If this looks like a useful PR, I'm more than happy to adjust it in whatever ways are required.