### PR TITLE
Move field creation in TextareaInput to an overridable method

### DIFF
--- a/src/input/TextareaInput.js
+++ b/src/input/TextareaInput.js
@@ -32,13 +32,10 @@ export default class TextareaInput {
 
   init(display) {
     let input = this, cm = this.cm
+    this.createField(display)
+    const te = this.textarea
 
-    // Wraps and hides input textarea
-    let div = this.wrapper = hiddenTextarea()
-    // The semihidden textarea that is focused when the editor is
-    // focused, and receives input.
-    let te = this.textarea = div.firstChild
-    display.wrapper.insertBefore(div, display.wrapper.firstChild)
+    display.wrapper.insertBefore(this.wrapper, display.wrapper.firstChild)
 
     // Needed to hide big blue blinking cursor on Mobile Safari (doesn't seem to work in iOS 8 anymore)
     if (ios) te.style.width = "0px"
@@ -103,6 +100,14 @@ export default class TextareaInput {
         input.composing = null
       }
     })
+  }
+
+  createField(_display) {
+    // Wraps and hides input textarea
+    this.wrapper = hiddenTextarea()
+    // The semihidden textarea that is focused when the editor is
+    // focused, and receives input.
+    this.textarea = this.wrapper.firstChild
   }
 
   prepareSelection() {


### PR DESCRIPTION
This allows third-party code to subclass TextareaInput to use a non-textarea field as a backing field, notably `input[type=password]`, which has some pros and cons vs contenteditable on Chrome for Android. I've tested the following and verified that it does indeed work as desired:

```js
var TextareaInput = CodeMirror.inputStyles.textarea;
function PasswordInput(cm) {
  TextareaInput.call(this, cm);
}
var proto = PasswordInput.prototype = Object.create(TextareaInput.prototype);
proto.constructor = PasswordInput;
proto.createField = function() {
  var input = document.createElement('input');
  input.setAttribute('type', 'password');
  input.setAttribute(
    'style', 
    'position: absolute; bottom: -1em; padding: 0; width: 1000px; height: 1em; outline: none'
  );
  var div = document.createElement('div');
  div.setAttribute('style', 'overflow: hidden; position: relative; width: 3px; height: 0px;');
  div.appendChild(input);
  this.wrapper = div;
  this.textarea = input;
}

CodeMirror.inputStyles.password = PasswordInput;
```

See #5303