### PR TITLE
Fix for some mouse events being sent to the wrong document

### DIFF
--- a/src/edit/mouse_events.js
+++ b/src/edit/mouse_events.js
@@ -149,8 +149,8 @@ function leftButtonStartDrag(cm, event, pos, behavior) {
   let dragEnd = operation(cm, e => {
     if (webkit) display.scroller.draggable = false
     cm.state.draggingText = false
-    off(document, "mouseup", dragEnd)
-    off(document, "mousemove", mouseMove)
+    off(display.wrapper.ownerDocument, "mouseup", dragEnd)
+    off(display.wrapper.ownerDocument, "mousemove", mouseMove)
     off(display.scroller, "dragstart", dragStart)
     off(display.scroller, "drop", dragEnd)
     if (!moved) {
@@ -159,7 +159,7 @@ function leftButtonStartDrag(cm, event, pos, behavior) {
         extendSelection(cm.doc, pos, null, null, behavior.extend)
       // Work around unexplainable focus problem in IE9 (#2127) and Chrome (#3081)
       if (webkit || ie && ie_version == 9)
-        setTimeout(() => {document.body.focus(); display.input.focus()}, 20)
+        setTimeout(() => {display.wrapper.ownerDocument.body.focus(); display.input.focus()}, 20)
       else
         display.input.focus()
     }
@@ -174,8 +174,8 @@ function leftButtonStartDrag(cm, event, pos, behavior) {
   dragEnd.copy = !behavior.moveOnDrag
   // IE's approach to draggable
   if (display.scroller.dragDrop) display.scroller.dragDrop()
-  on(document, "mouseup", dragEnd)
-  on(document, "mousemove", mouseMove)
+  on(display.wrapper.ownerDocument, "mouseup", dragEnd)
+  on(display.wrapper.ownerDocument, "mousemove", mouseMove)
   on(display.scroller, "dragstart", dragStart)
   on(display.scroller, "drop", dragEnd)
 
@@ -307,8 +307,8 @@ function leftButtonSelect(cm, event, start, behavior) {
     counter = Infinity
     e_preventDefault(e)
     display.input.focus()
-    off(document, "mousemove", move)
-    off(document, "mouseup", up)
+    off(display.wrapper.ownerDocument, "mousemove", move)
+    off(display.wrapper.ownerDocument, "mouseup", up)
     doc.history.lastSelOrigin = null
   }
 
@@ -318,8 +318,8 @@ function leftButtonSelect(cm, event, start, behavior) {
   })
   let up = operation(cm, done)
   cm.state.selectingText = up
-  on(document, "mousemove", move)
-  on(document, "mouseup", up)
+  on(display.wrapper.ownerDocument, "mousemove", move)
+  on(display.wrapper.ownerDocument, "mouseup", up)
 }
 
 // Used when mouse-selecting to adjust the anchor to the proper side


### PR DESCRIPTION
If the CodeMirror script is being run in a different document than the CodeMirror instance itself, some mouse events will be sent to the wrong document. In particular mouse move is sent to `document` rather than the editor's document, which causes selection to break.

This pull request fixes that issue allowing instances of CodeMirror to be run in different documents than the script itself. 

To get code mirror to run in different documents you need to do something like:
```javascript
var editor = CodeMirror.fromTextArea(window.frames["iframe"].document.getElementById("code"), {
    lineNumbers: true,
    lineWrapping: true
  });
```

We're specifically using this technique for some upcoming changes to our [RunKit Embeds](https://runkit.com/docs/embed). We load our main app in a background frame, which then can render to any number of additional iframes without paying the price of additional loads.