### PR TITLE
[show-hint addon] fixed fromList didn't show all completions if the cursor was inside the token

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -400,7 +400,8 @@
     var cur = cm.getCursor(), token = cm.getTokenAt(cur);
     var to = CodeMirror.Pos(cur.line, token.end);
     if (token.string && /\w/.test(token.string[token.string.length - 1])) {
-      var term = token.string, from = CodeMirror.Pos(cur.line, token.start);
+      var length = token.string.length - (token.end - cur.ch);
+      var term = token.string.substr(0, length), from = CodeMirror.Pos(cur.line, token.start);
     } else {
       var term = "", from = to;
     }


### PR DESCRIPTION
The hint logic of the `fromList` command did not respect the cursor position inside the token.
Now it will list all matching completions for the substring up to the cursor, instead of only the ones matching the complete token. The behavior is now the same as for the regular autocompletion.