### PR TITLE
[javascript-hint addon] Disable completion in json mode

### DIFF
--- a/addon/hint/javascript-hint.js
+++ b/addon/hint/javascript-hint.js
@@ -32,7 +32,9 @@
     // Find the token at the cursor
     var cur = editor.getCursor(), token = getToken(editor, cur);
     if (/\b(?:string|comment)\b/.test(token.type)) return;
-    token.state = CodeMirror.innerMode(editor.getMode(), token.state).state;
+    var innerMode = CodeMirror.innerMode(editor.getMode(), token.state);
+    if (innerMode.mode.helperType === "json") return;
+    token.state = innerMode.state;
 
     // If it's not a 'word-style' token, ignore the token.
     if (!/^[\w$_]*$/.test(token.string)) {


### PR DESCRIPTION
When using the editor in "application/json" mode, the standard javascript autocompletion would show up once triggered. Although it's deactivated by default and doesn't make sense to enable autocompletion in JSON mode on its own, this change fixes incorrect completions once you combine the default completion with your own custom logic.