### PR TITLE
[merge addon] edge case arising when diff'ing two empty strings

### DIFF
--- a/addon/merge/merge.js
+++ b/addon/merge/merge.js
@@ -664,6 +664,7 @@
 
   function getChunks(diff) {
     var chunks = [];
+    if (!diff.length) return chunks;
     var startEdit = 0, startOrig = 0;
     var edit = Pos(0, 0), orig = Pos(0, 0);
     for (var i = 0; i < diff.length; ++i) {


### PR DESCRIPTION
The merge view will incorrectly show a "Revert chunk" arrow when the text on both sides of the view are the empty string.

The getChunks() helper is not prepared to deal with an empty diff array.

The getDiff() helper returns an empty diff array when both strings to compare are empty, as the only diff item returned by diff_match_patch, `[0, ""]`, is removed as a result of the diff entry containing an empty string.

The chosen (trivial) fix is to simply check for the empty diff array case at the top of getChunks().

You can save the following HTML code in an `index.html` file to see the issue -- there are three MergeViews, the top one is the one showing the issue:

    <!DOCTYPE html>
    <html>
    <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <title></title>
    <link rel="stylesheet" type="text/css" href="https://codemirror.net/lib/codemirror.css">
    <link rel="stylesheet" type="text/css" href="https://codemirror.net/addon/merge/merge.css">
    </head>
    <body>
    <p>&quot;&quot; and &quot;&quot; -- there is a &quot;Revert chunk&quot; arrow (incorrect):
        <div id="mergeContainer1" style="height:20vh;overflow:hidden;"></div>
    <p>&quot;&nbsp;&quot; and &quot;&nbsp;&quot; -- there is no &quot;Revert chunk&quot; arrow (correct):
        <div id="mergeContainer2" style="height:20vh;overflow:hidden;"></div>
    <p>&quot;&quot; and &quot;&nbsp;&quot; -- there is a &quot;Revert chunk&quot; arrow (correct):
        <div id="mergeContainer3" style="height:20vh;overflow:hidden;"></div>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/diff_match_patch/20121119/diff_match_patch.js"></script>
    <script src="https://codemirror.net/lib/codemirror.js"></script>
    <script src="https://codemirror.net/addon/merge/merge.js"></script>
    <script>
    CodeMirror.MergeView(document.getElementById('mergeContainer1'), {
        value: '', origLeft: '',
        lineNumbers: true
    });
    CodeMirror.MergeView(document.getElementById('mergeContainer2'), {
        value: ' ', origLeft: ' ',
        lineNumbers: true
    });
    CodeMirror.MergeView(document.getElementById('mergeContainer3'), {
        value: ' ', origLeft: '',
        lineNumbers: true
    });
    </script>
    </body>
    </html>
