### PR TITLE
404 on languages modes page

### DIFF
--- a/mode/index.html
+++ b/mode/index.html
@@ -80,7 +80,7 @@ option.</p>
       <li><a href="javascript/index.html">JavaScript</a> (<a href="jsx/index.html">JSX</a>)</li>
       <li><a href="jinja2/index.html">Jinja2</a></li>
       <li><a href="julia/index.html">Julia</a></li>
-      <li><a href="kotlin/index.html">Kotlin</a></li>
+      <li><a href="clike/index.html">Kotlin</a></li>
       <li><a href="css/less.html">LESS</a></li>
       <li><a href="livescript/index.html">LiveScript</a></li>
       <li><a href="lua/index.html">Lua</a></li>


### PR DESCRIPTION
Currently I see 404 on [Language modes](https://codemirror.net/mode/index.html) when I click on [kotlin](https://codemirror.net/mode/kotlin/index.html)