### PR TITLE
[python mode] Highlight expressions inside python f-strings

### DIFF
--- a/mode/python/index.html
+++ b/mode/python/index.html
@@ -126,6 +126,15 @@ class ExampleClass(ParentClass):
     def __init__(self, mixin = 'Hello'):
         self.mixin = mixin
 
+# Python 3.6 f-strings (https://www.python.org/dev/peps/pep-0498/)
+f'My name is {name}, my age next year is {age+1}, my anniversary is {anniversary:%A, %B %d, %Y}.'
+f'He said his name is {name!r}.'
+f"""He said his name is {name!r}."""
+f'{"quoted string"}'
+f'{{ {4*10} }}'
+f'This is an error }'
+f'This is ok }}'
+fr'x={4*10}\n'
 </textarea></div>
 
 

--- a/mode/python/index.html
+++ b/mode/python/index.html
@@ -132,6 +132,7 @@ f'He said his name is {name!r}.'
 f"""He said his name is {name!r}."""
 f'{"quoted string"}'
 f'{{ {4*10} }}'
+f'{ f"{nested f-string}" is treated as "normal string" }'
 f'This is an error }'
 f'This is ok }}'
 fr'x={4*10}\n'

--- a/mode/python/index.html
+++ b/mode/python/index.html
@@ -132,7 +132,7 @@ f'He said his name is {name!r}.'
 f"""He said his name is {name!r}."""
 f'{"quoted string"}'
 f'{{ {4*10} }}'
-f'{ f"{nested f-string}" is treated as "normal string" }'
+f'{ "Nested f-string " + f"{2**100}" + " is treated as normal string" }'
 f'This is an error }'
 f'This is ok }}'
 fr'x={4*10}\n'

--- a/mode/python/python.js
+++ b/mode/python/python.js
@@ -142,7 +142,7 @@
 
       // Handle Strings
       if (stream.match(stringPrefixes)) {
-        var isFmtString = stream.current().toLowerCase().includes('f');
+        var isFmtString = stream.current().toLowerCase().indexOf('f') !== -1;
         if (!isFmtString || state.fstr_state !== null) {
           // if this is a nested format string (e.g. f' {   f"{10*10}" + "a" }' )
           // we do not format the nested expression and treat the nested format

--- a/mode/python/python.js
+++ b/mode/python/python.js
@@ -147,9 +147,6 @@
           // if this is a nested format string (e.g. f' {   f"{10*10}" + "a" }' )
           // we do not format the nested expression and treat the nested format
           // string as regular string
-          if (state.fstr_state) {
-            console.log(`This is nested ${stream.peek()}`)
-          }
           state.tokenize = tokenStringFactory(stream.current());
           return state.tokenize(stream, state);
         } else {

--- a/mode/python/python.js
+++ b/mode/python/python.js
@@ -62,7 +62,7 @@
       var identifiers = parserConf.identifiers|| /^[_A-Za-z\u00A1-\uFFFF][_A-Za-z0-9\u00A1-\uFFFF]*/;
       myKeywords = myKeywords.concat(["nonlocal", "False", "True", "None", "async", "await"]);
       myBuiltins = myBuiltins.concat(["ascii", "bytes", "exec", "print"]);
-      var stringPrefixes = new RegExp("^(([rbuf]|(br))?('{3}|\"{3}|['\"]))", "i");
+      var stringPrefixes = new RegExp("^(([rbuf]|(br)|(fr))?('{3}|\"{3}|['\"]))", "i");
     } else {
       var identifiers = parserConf.identifiers|| /^[_A-Za-z][_A-Za-z0-9]*/;
       myKeywords = myKeywords.concat(["exec", "print"]);
@@ -142,8 +142,21 @@
 
       // Handle Strings
       if (stream.match(stringPrefixes)) {
-        state.tokenize = tokenStringFactory(stream.current());
-        return state.tokenize(stream, state);
+        var isFmtString = stream.current().toLowerCase().includes('f');
+        if (!isFmtString || state.fstr_state !== null) {
+          // if this is a nested format string (e.g. f' {   f"{10*10}" + "a" }' )
+          // we do not format the nested expression and treat the nested format
+          // string as regular string
+          if (state.fstr_state) {
+            console.log(`This is nested ${stream.peek()}`)
+          }
+          state.tokenize = tokenStringFactory(stream.current());
+          return state.tokenize(stream, state);
+        } else {
+          // need to do something more sophisticated
+          state.tokenize = formatStringFactory(stream.current());
+          return state.tokenize(stream, state);
+        }
       }
 
       for (var i = 0; i < operators.length; i++)
@@ -172,6 +185,76 @@
       // Handle non-detected items
       stream.next();
       return ERRORCLASS;
+    }
+
+    function formatStringFactory(delimiter) {
+      while ("rubf".indexOf(delimiter.charAt(0).toLowerCase()) >= 0)
+        delimiter = delimiter.substr(1);
+
+      var singleline = delimiter.length == 1;
+      var OUTCLASS = "string";
+
+      function tokenString(stream, state) {
+        if (state.fstr_state) {
+          // inside f-str Expression
+          if (stream.match(delimiter)) {
+            // expression ends pre-maturally, but very common in editing
+            // Could show error to remind users to close brace here
+            state.fstr_state = null;
+            return OUTCLASS;
+          } else if (stream.match('{')) {
+            // starting brace, if not eaten below
+            return "punctuation";
+          } else if (stream.match('}')) {
+            // return to regular inside string state
+            state.fstr_state = null;
+            return "punctuation";
+          } else {
+            // use tokenBaseInner to parse the expression
+            return tokenBaseInner(stream, state.fstr_state);
+          }
+        }
+        while (!stream.eol()) {
+          stream.eatWhile(/[^'"\{\}\\]/);
+          if (stream.eat("\\")) {
+            stream.next();
+            if (singleline && stream.eol())
+              return OUTCLASS;
+          } else if (stream.match(delimiter)) {
+            state.tokenize = tokenBase;
+            return OUTCLASS;
+          } else if (stream.match('{{')) {
+            // ignore {{ in f-str
+            return OUTCLASS;
+          } else if (stream.match('{', false)) {
+            // switch to nested mode
+            state.fstr_state = {};
+            if (stream.current()) {
+              return OUTCLASS;
+            } else {
+              // need to return something, so eat the starting {
+              stream.next();
+              return "punctuation";
+            }
+          } else if (stream.match('}}')) {
+            return OUTCLASS;
+          } else if (stream.match('}')) {
+            // single } in f-string is an error
+            return ERRORCLASS;
+          } else {
+            stream.eat(/['"]/);
+          }
+        }
+        if (singleline) {
+          if (parserConf.singleLineStringErrors)
+            return ERRORCLASS;
+          else
+            state.tokenize = tokenBase;
+        }
+        return OUTCLASS;
+      }
+      tokenString.isString = true;
+      return tokenString;
     }
 
     function tokenStringFactory(delimiter) {
@@ -276,6 +359,7 @@
         return {
           tokenize: tokenBase,
           scopes: [{offset: basecolumn || 0, type: "py", align: null}],
+          fstr_state: null,
           indent: basecolumn || 0,
           lastToken: null,
           lambda: false,

--- a/mode/python/test.js
+++ b/mode/python/test.js
@@ -30,6 +30,8 @@
     MT("before_equal_sign_" + c, "[variable a] [operator " + c + "=] [variable b]");
   }
 
-  MT("fValidStringPrefix", "[string f'this is a {formatted} string']");
+  MT("fValidStringPrefix", "[string f'this is a]{[variable formatted]}[string string']");
+  MT("fValidExpressioninFString", "[string f'expression ]{[number 100][operator *][number 5]}[string string']");
+  MT("fInvalidFString", "[error f'this is wrong}]");
   MT("uValidStringPrefix", "[string u'this is an unicode string']");
 })();


### PR DESCRIPTION
This patch enables syntax highlighting of [python f-string](https://www.python.org/dev/peps/pep-0498/). As shown by [added examples](https://github.com/BoPeng/CodeMirror/blob/f-string/mode/python/index.html#L130)

![image](https://user-images.githubusercontent.com/9889312/38164729-4041f5be-34ce-11e8-9f84-959236469443.png)

CodeMirror now goes inside of f-strings and highlights expressions inside braces as regular python expressions.

Format strings are handled by a [formatStringFactory](https://github.com/BoPeng/CodeMirror/blob/f-string/mode/python/python.js#L190) which is extended (copied) from [tokenStringFactory ](https://github.com/BoPeng/CodeMirror/blob/f-string/mode/python/python.js#L260) with an added [state for f-string](https://github.com/BoPeng/CodeMirror/blob/f-string/mode/python/python.js#L198). Inside the f-string expression, a regular [tokenBaseInner](https://github.com/BoPeng/CodeMirror/blob/f-string/mode/python/python.js#L214) is used to parse the string until `}` or end of string is encountered.

The patch seems to work but has **not** been thoroughly tested because I would like to know if this is useful/acceptable to the community and if my implementation is technically sound.