### PR TITLE
Add semantic classes to different types of SQL hints.

### DIFF
--- a/addon/hint/sql-hint.js
+++ b/addon/hint/sql-hint.js
@@ -276,7 +276,18 @@
       start = nameCompletion(cur, token, result, editor);
     } else {
       addMatches(result, search, defaultTable, function(w) {return {text:w, className: "CodeMirror-hint-table CodeMirror-hint-default-table"};});
-      addMatches(result, search, tables, function(w) {return {text:w, className: "CodeMirror-hint-table"};});
+      addMatches(
+          result,
+          search,
+          tables,
+          function(w) {
+              if (w.text) {
+                  w = w.text;
+              }
+
+              return {text: w, className: "CodeMirror-hint-table"};
+          }
+      );
       if (!disableKeywords)
         addMatches(result, search, keywords, function(w) {return {text: w.toUpperCase(), className: "CodeMirror-hint-keyword"};});
     }

--- a/addon/hint/sql-hint.js
+++ b/addon/hint/sql-hint.js
@@ -275,10 +275,10 @@
     if (search.charAt(0) == "." || search.charAt(0) == identifierQuote) {
       start = nameCompletion(cur, token, result, editor);
     } else {
-      addMatches(result, search, defaultTable, function(w) {return w;});
-      addMatches(result, search, tables, function(w) {return w;});
+      addMatches(result, search, defaultTable, function(w) {return {text:w, className: "CodeMirror-hint-table CodeMirror-hint-default-table"};});
+      addMatches(result, search, tables, function(w) {return {text:w, className: "CodeMirror-hint-table"};});
       if (!disableKeywords)
-        addMatches(result, search, keywords, function(w) {return w.toUpperCase();});
+        addMatches(result, search, keywords, function(w) {return {text: w.toUpperCase(), className: "CodeMirror-hint-keyword"};});
     }
 
     return {list: result, from: Pos(cur.line, start), to: Pos(cur.line, end)};

--- a/addon/hint/sql-hint.js
+++ b/addon/hint/sql-hint.js
@@ -281,11 +281,13 @@
           search,
           tables,
           function(w) {
-              if (w.text) {
-                  w = w.text;
+              if (typeof w === 'object') {
+                  w.className =  "CodeMirror-hint-table";
+              } else {
+                  w = {text: w, className: "CodeMirror-hint-table"};
               }
 
-              return {text: w, className: "CodeMirror-hint-table"};
+              return w;
           }
       );
       if (!disableKeywords)

--- a/test/sql-hint-test.js
+++ b/test/sql-hint-test.js
@@ -41,7 +41,7 @@
   test("keywords", {
     value: "SEL",
     cursor: Pos(0, 3),
-    list: ["SELECT"],
+    list: [{"text":"SELECT","className":"CodeMirror-hint-keyword"}],
     from: Pos(0, 0),
     to: Pos(0, 3)
   });
@@ -49,7 +49,7 @@
   test("from", {
     value: "SELECT * fr",
     cursor: Pos(0, 11),
-    list: ["FROM"],
+    list: [{"text":"FROM","className":"CodeMirror-hint-keyword"}],
     from: Pos(0, 9),
     to: Pos(0, 11)
   });
@@ -58,7 +58,7 @@
     value: "SELECT xc",
     cursor: Pos(0, 9),
     tables: simpleTables,
-    list: ["xcountries"],
+    list: [{"text":"xcountries","className":"CodeMirror-hint-table"}],
     from: Pos(0, 7),
     to: Pos(0, 9)
   });
@@ -123,8 +123,11 @@
     value: "SELECT schem",
     cursor: Pos(0, 12),
     tables: schemaTables,
-    list: ["schema.users", "schema.countries",
-           "SCHEMA", "SCHEMA_NAME", "SCHEMAS"],
+    list: [{"text":"schema.users","className":"CodeMirror-hint-table"},
+        {"text":"schema.countries","className":"CodeMirror-hint-table"},
+        {"text":"SCHEMA","className":"CodeMirror-hint-keyword"},
+        {"text":"SCHEMA_NAME","className":"CodeMirror-hint-keyword"},
+        {"text":"SCHEMAS","className":"CodeMirror-hint-keyword"}],
     from: Pos(0, 7),
     to: Pos(0, 12)
   });
@@ -186,7 +189,7 @@
     value: "SELECT myt",
     cursor: Pos(0, 10),
     tables: displayTextTables,
-    list: [{text: "mytable", displayText: "mytable | The main table",}],
+    list: [{text: "mytable", displayText: "mytable | The main table", "className":"CodeMirror-hint-table"}],
     from: Pos(0, 7),
     to: Pos(0, 10)
   });


### PR DESCRIPTION
By adding classes that clearly define when a hint is a table or a keyword, it gives developers easy control if they wish to style hints differently. For example, you may wish to style table hints in a different colour to keywords (to make them easier to distinguish).