### PR TITLE
Fix space key clearing composition with Korean IME in contenteditable mode

### DIFF
--- a/src/input/ContentEditableInput.js
+++ b/src/input/ContentEditableInput.js
@@ -355,7 +355,7 @@ export default class ContentEditableInput {
   }
 
   onKeyPress(e) {
-    if (e.charCode == 0) return
+    if (e.charCode == 0 || this.composing) return
     e.preventDefault()
     if (!this.cm.isReadOnly())
       operation(this.cm, applyTextInput)(this.cm, String.fromCharCode(e.charCode == null ? e.keyCode : e.charCode), 0)


### PR DESCRIPTION
There is a problem with Korean IME in the contenteditable mode, where `space` key will clear the current composition. As demonstrated here: (Key strokes: 'g', 'k', 's', 'r', 'm', 'f', SPACE in Qwerty layout)

![](https://cl.ly/2V2p3j0x3C1A/Screen%20Recording%202018-04-10%20at%2003.14%20PM.gif)

This is caused by the `keypress` event. `keypress` should not happen during IME composition ([as spec](https://www.w3.org/TR/uievents/#keys-IME) + [ref](https://lists.w3.org/Archives/Public/www-dom/2011JulSep/0132.html)), but it does on Windows and Ubuntu for Korean IMEs, not for Chinese and Japanese IME, or anything on Mac. 

This PR fixes it by returning the keypress event if composing. Fixed behavior:

![](https://cl.ly/0F0w2S0W2f2q/Screen%20Recording%202018-04-10%20at%2003.13%20PM.gif)