### PR TITLE
Adds support for options.finishInit to CodeMirror.fromTextArea

### DIFF
--- a/src/edit/fromTextArea.js
+++ b/src/edit/fromTextArea.js
@@ -38,6 +38,11 @@ export function fromTextArea(textarea, options) {
     }
   }
 
+  let _finishInit
+  if (typeof options.finishInit === 'function') {
+    _finishInit = options.finishInit
+  }
+
   options.finishInit = cm => {
     cm.save = save
     cm.getTextArea = () => textarea
@@ -51,6 +56,10 @@ export function fromTextArea(textarea, options) {
         if (typeof textarea.form.submit == "function")
           textarea.form.submit = realSubmit
       }
+    }
+
+    if (typeof options.finishInit === 'function') {
+      _finishInit(cm)
     }
   }
 


### PR DESCRIPTION
This allows `options.finishInit` to work in a more consistent manner, even when running `CodeMirror.fromTextArea()`

Although this is an undocumented feature, it's quite useful and it would be good to know that this works consistently.