### PR TITLE
For jsonlint package, make lint addon look at parser property of jsonlint.

### DIFF
--- a/addon/lint/json-lint.js
+++ b/addon/lint/json-lint.js
@@ -23,6 +23,12 @@ CodeMirror.registerHelper("lint", "json", function(text) {
     }
     return found;
   }
+  
+  // for jsonlint's web dist jsonlint is exported as an object with a single property parser, of which parseError
+  // is a subproperty
+  if (window.jsonlint.parser) {
+    var jsonlint = window.jsonlint.parser;   
+  }
   jsonlint.parseError = function(str, hash) {
     var loc = hash.loc;
     found.push({from: CodeMirror.Pos(loc.first_line - 1, loc.first_column),

--- a/addon/lint/json-lint.js
+++ b/addon/lint/json-lint.js
@@ -23,7 +23,6 @@ CodeMirror.registerHelper("lint", "json", function(text) {
     }
     return found;
   }
-  
   // for jsonlint's web dist jsonlint is exported as an object with a single property parser, of which parseError
   // is a subproperty
   if (window.jsonlint.parser) {

--- a/addon/lint/json-lint.js
+++ b/addon/lint/json-lint.js
@@ -27,7 +27,7 @@ CodeMirror.registerHelper("lint", "json", function(text) {
   // for jsonlint's web dist jsonlint is exported as an object with a single property parser, of which parseError
   // is a subproperty
   if (window.jsonlint.parser) {
-    var jsonlint = window.jsonlint.parser;   
+    var jsonlint = window.jsonlint.parser;
   }
   jsonlint.parseError = function(str, hash) {
     var loc = hash.loc;


### PR DESCRIPTION
Jsonlint exports in two different ways ->

One way is as an object of which parseError is a property, and another in which jsonlint = { parser: { ... parse, parseError }}

This should fix the issue s.t. people can require directly from jsonlint as a package.