### PR TITLE
Fix nbsp (for space splitting) getting added as real spaces (contentEdtiable mode)

### DIFF
--- a/src/input/ContentEditableInput.js
+++ b/src/input/ContentEditableInput.js
@@ -431,7 +431,7 @@ function domTextBetween(cm, from, to, fromLine, toLine) {
         walk(node.childNodes[i])
       if (isBlock) closing = true
     } else if (node.nodeType == 3) {
-      addText(node.nodeValue)
+      addText(node.nodeValue.replace(/\u00a0/g, " "))
     }
   }
   for (;;) {


### PR DESCRIPTION
 ## Problem

When using IME in `lineWrapping` + `contentEdtiable` mode, typing CJK characters puts the cursor at the wrong position. Steps to reproduce:

1. With existing text like:
  ```
  - 123
     - 456
```
2. Type Chinese characters at the end of Line 1 `123` with an IME (example: "台灣" with Zhuyin that is `w` `9` `6` `j` `0` `(space)`, `(enter)`)
3. See the cursor is put on the next line (after a `&nbsp;`). 

### GIF

![](https://cl.ly/2z3k0Q05192N/Screen%20Recording%202018-04-25%20at%2005.45%20PM.gif)

## Cause

This problem only exist when the next line has `&nbsp;` created by `splitSpaces`

https://github.com/codemirror/CodeMirror/blob/9ed217d5b46f98581b7b751758686c5a70ad05d1/src/line/line_data.js#L192-L203

After composition ends & `pollContent`, the `&nbsp;` created to split spaces becomes real content, which I believe causes miscalculation of the cursor position.
## Solution

This PR replaces nbsp with regular spaces in `pollContent`.

![](https://cl.ly/282L332i2B0X/Screen%20Recording%202018-04-25%20at%2005.44%20PM.gif)

Before the fix

```javascript
$ editor.getValue()
> "- 123台灣
  - 321
"
$ editor.getValue().match(/\u00A0/)
> [" ", index: 9, input: "- 123台灣↵  - 321↵", groups: undefined]
```

After the fix

```javascript
$ editor.getValue()
> "- 123台灣
  - 321
"
$ editor.getValue().match(/\u00A0/)
> null
```

---

@marijnh Honestly I don't have enough context to be 100% sure if this is the right fix. It also doesn't seem like there's a reliable way to test for this problem.

It could be worth noting that this problem also goes away with the removal of https://github.com/codemirror/CodeMirror/blob/9ed217d5b46f98581b7b751758686c5a70ad05d1/src/input/ContentEditableInput.js#L261-L262 But I think we do need them. Ref: #4307.

Since you have more context here perhaps you'd know if there's a better fix. 🙏🏻