### PR TITLE
Fix line break disappearing with pasted text in IE11 under contentEditable mode

### DIFF
--- a/src/input/ContentEditableInput.js
+++ b/src/input/ContentEditableInput.js
@@ -396,12 +396,13 @@ function isInGutter(node) {
 function badPos(pos, bad) { if (bad) pos.bad = true; return pos }
 
 function domTextBetween(cm, from, to, fromLine, toLine) {
-  let text = "", closing = false, lineSep = cm.doc.lineSeparator()
+  let text = "", closing = false, lineSep = cm.doc.lineSeparator(), extraLinebreak = false
   function recognizeMarker(id) { return marker => marker.id == id }
   function close() {
     if (closing) {
       text += lineSep
-      closing = false
+      if (extraLinebreak) text += lineSep
+      closing = extraLinebreak = false
     }
   }
   function addText(str) {
@@ -431,9 +432,11 @@ function domTextBetween(cm, from, to, fromLine, toLine) {
       if (isBlock) close()
       for (let i = 0; i < node.childNodes.length; i++)
         walk(node.childNodes[i])
+
+      if (/^(pre|p)$/i.test(node.nodeName)) extraLinebreak = true
       if (isBlock) closing = true
     } else if (node.nodeType == 3) {
-      addText(node.nodeValue.replace(/\u00a0/g, " ").replace(/\u200b/g, ""))
+      addText(node.nodeValue.replace(/\u200b/g, "").replace(/\u00a0/g, " "))
     }
   }
   for (;;) {

--- a/src/input/ContentEditableInput.js
+++ b/src/input/ContentEditableInput.js
@@ -443,6 +443,7 @@ function domTextBetween(cm, from, to, fromLine, toLine) {
     walk(from)
     if (from == to) break
     from = from.nextSibling
+    extraLinebreak = false
   }
   return text
 }

--- a/src/input/ContentEditableInput.js
+++ b/src/input/ContentEditableInput.js
@@ -413,8 +413,8 @@ function domTextBetween(cm, from, to, fromLine, toLine) {
   function walk(node) {
     if (node.nodeType == 1) {
       let cmText = node.getAttribute("cm-text")
-      if (cmText != null) {
-        addText(cmText || node.textContent.replace(/\u200b/g, ""))
+      if (cmText) {
+        addText(cmText)
         return
       }
       let markerID = node.getAttribute("cm-marker"), range
@@ -425,13 +425,15 @@ function domTextBetween(cm, from, to, fromLine, toLine) {
         return
       }
       if (node.getAttribute("contenteditable") == "false") return
-      let isBlock = /^(pre|div|p)$/i.test(node.nodeName)
+      let isBlock = /^(pre|div|p|li|table|br)$/i.test(node.nodeName)
+      if (!/^br$/i.test(node.nodeName) && node.textContent.length == 0) return
+
       if (isBlock) close()
       for (let i = 0; i < node.childNodes.length; i++)
         walk(node.childNodes[i])
       if (isBlock) closing = true
     } else if (node.nodeType == 3) {
-      addText(node.nodeValue.replace(/\u00a0/g, " "))
+      addText(node.nodeValue.replace(/\u00a0/g, " ").replace(/\u200b/g, ""))
     }
   }
   for (;;) {


### PR DESCRIPTION
 ## Problem

Line breaks disappear when pasting plain text from nodepad/textarea/command prompt in IE11 in `contentEditable` mode.

Specifically, this is because in `domTextBetween` a `fromNode` like`<span cm-text="">1<br>2<br>3<br>4<br>5</span>` is handled with `addText(node.textContent); return`, ignoring the `<br>`s inside.

This PR does a few things:

- only `addText` & `return` if `cm-text` has value
- otherwise walk the child nodes
- treat `br` along with `table`, `li` as blocks
- ignore empty elements (except for `br` which should be empty) to avoid unnecessary line breaks
- add extra line breaks for `p` and `pre`

FWIW this issue reportedly is also on archlinux/debian in Firefox 52/58, but I have yet been able to reproduce them.

---

As far as I can see changes to this method effects IME input in modern browsers and IE11 plus pasting in IE11. I've manually tested for the IME issues I sent PR for previously (#5379, #5354) and they're still OK.

## Before (IE11)

Text flashes, line breaks disappear.

![](https://cl.ly/1W1E2R1c1T1M/Screen%20Recording%202018-04-26%20at%2005.17%20PM.gif)

## Expected behavior (Chrome)

![](https://cl.ly/460K193r0S1s/Screen%20Recording%202018-04-26%20at%2005.14%20PM.gif)

## After (IE11)

Line breaks preserved. 

![](https://cl.ly/0M420W091808/Screen%20Recording%202018-04-26%20at%2005.16%20PM.gif)
