### PR TITLE
[show-hint addon] Add option to change active hint on mouseover

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -279,6 +279,15 @@
       hints.style.left = (left + startScroll.left - curScroll.left) + "px";
     });
 
+    if (completion.options.changeActiveOnMouseover) {
+      CodeMirror.on(hints, "mouseover", function(e) {
+        var t = getHintElement(hints, e.target || e.srcElement);
+        if (t && t.hintId != null) {
+          widget.changeActive(t.hintId);
+        }
+      });
+    }
+
     CodeMirror.on(hints, "dblclick", function(e) {
       var t = getHintElement(hints, e.target || e.srcElement);
       if (t && t.hintId != null) {widget.changeActive(t.hintId); widget.pick();}
@@ -426,7 +435,8 @@
     completeOnSingleClick: true,
     container: null,
     customKeys: null,
-    extraKeys: null
+    extraKeys: null,
+    changeActiveOnMouseover: false
   };
 
   CodeMirror.defineOption("hintOptions", null);


### PR DESCRIPTION
Adds an bool option, `changeActiveOnMouseover` (disabled by default), which updates the selected hint index for mouseover events. Using the selected hint variable to maintain the index of the active hint allows the `ACTIVE_HINT_ELEMENT_CLASS` to be consistently applied when the user uses a combination of mouse selections and keyboard while deciding the hint to choose.