### PR TITLE
adding prepend in dialog.js instead of append

### DIFF
--- a/addon/dialog/dialog.js
+++ b/addon/dialog/dialog.js
@@ -14,7 +14,7 @@
   function dialogDiv(cm, template, bottom) {
     var wrap = cm.getWrapperElement();
     var dialog;
-    dialog = wrap.appendChild(document.createElement("div"));
+    dialog = document.createElement("div");
     if (bottom)
       dialog.className = "CodeMirror-dialog CodeMirror-dialog-bottom";
     else
@@ -25,6 +25,7 @@
     } else { // Assuming it's a detached DOM element.
       dialog.appendChild(template);
     }
+    wrap.prepend(dialog);
     return dialog;
   }
 


### PR DESCRIPTION
I was trying to find a way to style the search dialog so that it did not cover up the first few lines of text in the editor. I want to be able to use a sibling selector something like this to move the editor content down accounting for the height of the dialog.

```
.CodeMirror-dialog ~ .CodeMirror-scroll {
    margin-top: 50px;
}
```

This is not accomplishable with the current implementation as it adds the dialog as the last child, which does not allow for selecting the CodeMirror-scroll class as a sibling of the dialog.