### PR TITLE
'dialog-opened' class when dialog is triggered

### DIFF
--- a/addon/dialog/dialog.js
+++ b/addon/dialog/dialog.js
@@ -25,7 +25,7 @@
     } else { // Assuming it's a detached DOM element.
       dialog.appendChild(template);
     }
-    wrap.classList.add('dialog-opened');
+    CodeMirror.addClass(wrap, 'dialog-opened');
     return dialog;
   }
 
@@ -48,7 +48,7 @@
       } else {
         if (closed) return;
         closed = true;
-        dialog.parentNode.classList.remove('dialog-opened');
+        CodeMirror.rmClass(dialog.parentNode, 'dialog-opened');
         dialog.parentNode.removeChild(dialog);
         me.focus();
 
@@ -104,7 +104,7 @@
     function close() {
       if (closed) return;
       closed = true;
-      dialog.parentNode.classList.remove('dialog-opened');
+      CodeMirror.rmClass(dialog.parentNode, 'dialog-opened');
       dialog.parentNode.removeChild(dialog);
       me.focus();
     }
@@ -144,7 +144,7 @@
       if (closed) return;
       closed = true;
       clearTimeout(doneTimer);
-      dialog.parentNode.classList.remove('dialog-opened');
+      CodeMirror.rmClass(dialog.parentNode, 'dialog-opened');
       dialog.parentNode.removeChild(dialog);
     }
 

--- a/addon/dialog/dialog.js
+++ b/addon/dialog/dialog.js
@@ -25,6 +25,7 @@
     } else { // Assuming it's a detached DOM element.
       dialog.appendChild(template);
     }
+    wrap.classList.add('dialog-opened');
     return dialog;
   }
 
@@ -47,6 +48,7 @@
       } else {
         if (closed) return;
         closed = true;
+        dialog.parentNode.classList.remove('dialog-opened');
         dialog.parentNode.removeChild(dialog);
         me.focus();
 
@@ -102,6 +104,7 @@
     function close() {
       if (closed) return;
       closed = true;
+      dialog.parentNode.classList.remove('dialog-opened');
       dialog.parentNode.removeChild(dialog);
       me.focus();
     }
@@ -141,6 +144,7 @@
       if (closed) return;
       closed = true;
       clearTimeout(doneTimer);
+      dialog.parentNode.classList.remove('dialog-opened');
       dialog.parentNode.removeChild(dialog);
     }
 


### PR DESCRIPTION
Thanks for considering my other PR about adding insertBefore to the dialog. I think this approach is less invasive to the existing dom structure and allows for styling like this to avoid the dialog covering up the first few lines of text in the editor.
```
.dialog-opened .CodeMirror-scroll {
	margin-top: 40px;
}
```

An advantage I see with this is it gives the application an indication of when a dialog is opened, allowing for many styling opportunities.