### PR TITLE
Replace stream.match(/ +$/, false) with a more efficient regex

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -619,7 +619,9 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     }
 
     if (ch === ' ') {
-      if (stream.match(/ +$/, false)) {
+
+      if (matchTrailingSpaces(stream.string, stream.pos)) {
+      // if (matchTrailingSpaces(stream.string, stream.pos)) {
         state.trailingSpace++;
       } else if (state.trailingSpace) {
         state.trailingSpaceNewLine = true;
@@ -627,6 +629,34 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     }
 
     return getType(state);
+  }
+
+  /**
+   * Matches the behavior of stream.match(/ \s+/, false) for
+   * this one case but is vastly faster.
+   * @param {string} string 
+   * @param {number} startPos 
+   */
+  function matchTrailingSpaces(string, startPos) {
+    var hasMatch = false;
+    var matchIndex = -1;
+    var currentIndex = string.length - 1;
+
+    while (currentIndex >= 0 && currentIndex >= startPos && string.charAt(currentIndex) === ' ') {
+      matchIndex = currentIndex;
+      currentIndex--;
+      hasMatch = true;
+    }
+
+    matchIndex -= startPos;
+
+    if (hasMatch && matchIndex > 0) {
+      return null;
+    } else if (hasMatch && matchIndex === 0) {
+      return true;
+    } else {
+      return null;
+    }
   }
 
   function linkInline(stream, state) {

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -619,8 +619,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     }
 
     if (ch === ' ') {
-
-      if (stream.matchTrailing(" ")) {
+      if (stream.match(/^ +$/, false)) {
         state.trailingSpace++;
       } else if (state.trailingSpace) {
         state.trailingSpaceNewLine = true;

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -621,7 +621,6 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     if (ch === ' ') {
 
       if (matchTrailingSpaces(stream.string, stream.pos)) {
-      // if (matchTrailingSpaces(stream.string, stream.pos)) {
         state.trailingSpace++;
       } else if (state.trailingSpace) {
         state.trailingSpaceNewLine = true;

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -620,7 +620,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
     if (ch === ' ') {
 
-      if (matchTrailingSpaces(stream.string, stream.pos)) {
+      if (stream.matchTrailing(" ")) {
         state.trailingSpace++;
       } else if (state.trailingSpace) {
         state.trailingSpaceNewLine = true;
@@ -628,34 +628,6 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     }
 
     return getType(state);
-  }
-
-  /**
-   * Matches the behavior of stream.match(/ \s+/, false) for
-   * this one case but is vastly faster.
-   * @param {string} string 
-   * @param {number} startPos 
-   */
-  function matchTrailingSpaces(string, startPos) {
-    var hasMatch = false;
-    var matchIndex = -1;
-    var currentIndex = string.length - 1;
-
-    while (currentIndex >= 0 && currentIndex >= startPos && string.charAt(currentIndex) === ' ') {
-      matchIndex = currentIndex;
-      currentIndex--;
-      hasMatch = true;
-    }
-
-    matchIndex -= startPos;
-
-    if (hasMatch && matchIndex > 0) {
-      return null;
-    } else if (hasMatch && matchIndex === 0) {
-      return true;
-    } else {
-      return null;
-    }
   }
 
   function linkInline(stream, state) {

--- a/src/util/StringStream.js
+++ b/src/util/StringStream.js
@@ -72,28 +72,6 @@ class StringStream {
     }
   }
 
-  matchTrailing(character) {
-    let hasMatch = false
-    let matchIndex = -1
-    let currentIndex = this.string.length - 1
-
-    while (currentIndex >= 0 && currentIndex >= this.pos && this.string.charAt(currentIndex) === character) {
-      matchIndex = currentIndex
-      currentIndex--
-      hasMatch = true
-    }
-
-    matchIndex -= this.pos
-
-    if (hasMatch && matchIndex > 0) {
-      return null
-    } else if (hasMatch && matchIndex === 0) {
-      return true
-    } else {
-      return null
-    }
-  }
-
   current(){return this.string.slice(this.start, this.pos)}
   hideFirstChars(n, inner) {
     this.lineStart += n

--- a/src/util/StringStream.js
+++ b/src/util/StringStream.js
@@ -71,6 +71,29 @@ class StringStream {
       return match
     }
   }
+
+  matchTrailing(character) {
+    let hasMatch = false
+    let matchIndex = -1
+    let currentIndex = this.string.length - 1
+
+    while (currentIndex >= 0 && currentIndex >= this.pos && this.string.charAt(currentIndex) === character) {
+      matchIndex = currentIndex
+      currentIndex--
+      hasMatch = true
+    }
+
+    matchIndex -= this.pos
+
+    if (hasMatch && matchIndex > 0) {
+      return null
+    } else if (hasMatch && matchIndex === 0) {
+      return true
+    } else {
+      return null
+    }
+  }
+
   current(){return this.string.slice(this.start, this.pos)}
   hideFirstChars(n, inner) {
     this.lineStart += n

--- a/src/util/StringStream.js
+++ b/src/util/StringStream.js
@@ -71,7 +71,6 @@ class StringStream {
       return match
     }
   }
-
   current(){return this.string.slice(this.start, this.pos)}
   hideFirstChars(n, inner) {
     this.lineStart += n


### PR DESCRIPTION
With some inputs, especially when they contain long lines with many whitespace characters, `stream.match(/ +$/, false)` in the Markdown mode gets terribly slow. In our case, it could lock up the editor for 10s of seconds.

~~As a quick fix, I added a method `StringStream.matchTrailing(character)` which replicates the behavior of `StringStream.match()` for the special case of checking for specific trailing characters.~~

I changed the regex to `^ +$` which improves the performance a lot.

* All tests pass
* No complaints from `bin/lint`