### PR TITLE
Support BigInt literals in JavaScript

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -77,12 +77,15 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
       return ret("=>", "operator");
     } else if (ch == "0" && stream.eat(/x/i)) {
       stream.eatWhile(/[\da-f]/i);
+      stream.eat(/n/);
       return ret("number", "number");
     } else if (ch == "0" && stream.eat(/o/i)) {
       stream.eatWhile(/[0-7]/i);
+      stream.eat(/n/);
       return ret("number", "number");
     } else if (ch == "0" && stream.eat(/b/i)) {
       stream.eatWhile(/[01]/i);
+      stream.eat(/n/);
       return ret("number", "number");
     } else if (/\d/.test(ch)) {
       stream.match(/^\d*(n|(?:\.\d*)?(?:[eE][+\-]?\d+)?)?/);

--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -85,7 +85,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
       stream.eatWhile(/[01]/i);
       return ret("number", "number");
     } else if (/\d/.test(ch)) {
-      stream.match(/^\d*(?:\.\d*)?(?:[eE][+\-]?\d+)?/);
+      stream.match(/^\d*(n|(?:\.\d*)?(?:[eE][+\-]?\d+)?)?/);
       return ret("number", "number");
     } else if (ch == "/") {
       if (stream.eat("*")) {

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -239,6 +239,8 @@
      "[keyword const] [def async] [operator =] {[property a]: [number 1]};",
      "[keyword const] [def foo] [operator =] [string-2 `bar ${][variable async].[property a][string-2 }`];")
 
+  MT("bigint", "[number 1n]};")
+
   MT("async_comment",
      "[keyword async] [comment /**/] [keyword function] [def foo]([def args]) { [keyword return] [atom true]; }");
 

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -239,7 +239,7 @@
      "[keyword const] [def async] [operator =] {[property a]: [number 1]};",
      "[keyword const] [def foo] [operator =] [string-2 `bar ${][variable async].[property a][string-2 }`];")
 
-  MT("bigint", "[number 1n]};")
+  MT("bigint", "[number 1n] [operator +] [number 0x1afn] [operator +] [number 0o064n] [operator +] [number 0b100n];")
 
   MT("async_comment",
      "[keyword async] [comment /**/] [keyword function] [def foo]([def args]) { [keyword return] [atom true]; }");


### PR DESCRIPTION
This adds support for BigInt literal syntax: `10n` is highlighted as `[number 10n]` instead of `[number 10][variable n]`. Not sure what the policy on 'when is soon enough' to implement language features - this one's quite fresh: it's a stage 3 proposal, shipped in Chrome Canary. The BigInt interface is implemented in JSC and SpiderMonkey, but afaict, the literal syntax isn't yet.

Todo:

- [x] Support binary, octal, and hexadecimal syntax

References:

- Google Chrome announcement post: https://developers.google.com/web/updates/2018/05/bigint
- tc39 proposal: https://github.com/tc39/proposal-bigint