### PR TITLE
[monokai] Reduce the saturation of colors within doccomments

### DIFF
--- a/theme/monokai.css
+++ b/theme/monokai.css
@@ -14,6 +14,11 @@
 .cm-s-monokai span.cm-atom { color: #ae81ff; }
 .cm-s-monokai span.cm-number { color: #ae81ff; }
 
+.cm-s-monokai span.cm-comment.cm-attribute { color: #97b757; }
+.cm-s-monokai span.cm-comment.cm-def { color: #bc9262; }
+.cm-s-monokai span.cm-comment.cm-tag { color: #bc6283; }
+.cm-s-monokai span.cm-comment.cm-type { color: #89c1cd; }
+
 .cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute { color: #a6e22e; }
 .cm-s-monokai span.cm-keyword { color: #f92672; }
 .cm-s-monokai span.cm-builtin { color: #66d9ef; }

--- a/theme/monokai.css
+++ b/theme/monokai.css
@@ -17,7 +17,7 @@
 .cm-s-monokai span.cm-comment.cm-attribute { color: #97b757; }
 .cm-s-monokai span.cm-comment.cm-def { color: #bc9262; }
 .cm-s-monokai span.cm-comment.cm-tag { color: #bc6283; }
-.cm-s-monokai span.cm-comment.cm-type { color: #89c1cd; }
+.cm-s-monokai span.cm-comment.cm-type { color: #5998a6; }
 
 .cm-s-monokai span.cm-property, .cm-s-monokai span.cm-attribute { color: #a6e22e; }
 .cm-s-monokai span.cm-keyword { color: #f92672; }


### PR DESCRIPTION
This makes the brightness of the tokens within the comment more similar to the rest of the comment block.