### PR TITLE
Add Papyrus mode

### DIFF
--- a/mode/index.html
+++ b/mode/index.html
@@ -98,6 +98,7 @@ option.</p>
       <li><a href="mllike/index.html">OCaml</a></li>
       <li><a href="octave/index.html">Octave</a> (MATLAB)</li>
       <li><a href="oz/index.html">Oz</a></li>
+      <li><a href="papyrus/index.html">Papyrus</a></li>
       <li><a href="pascal/index.html">Pascal</a></li>
       <li><a href="pegjs/index.html">PEG.js</a></li>
       <li><a href="perl/index.html">Perl</a></li>

--- a/mode/papyrus/index.html
+++ b/mode/papyrus/index.html
@@ -1,0 +1,59 @@
+<!doctype html>
+
+<title>CodeMirror: Papyrus mode</title>
+<meta charset="utf-8"/>
+<link rel=stylesheet href="../../doc/docs.css">
+
+<link rel="stylesheet" href="../../lib/codemirror.css">
+<script src="../../lib/codemirror.js"></script>
+<script src="papyrus.js"></script>
+<style type="text/css">.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
+<div id=nav>
+  <a href="http://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+
+  <ul>
+    <li><a href="../../index.html">Home</a>
+    <li><a href="../../doc/manual.html">Manual</a>
+    <li><a href="https://github.com/codemirror/codemirror">Code</a>
+  </ul>
+  <ul>
+    <li><a href="../index.html">Language modes</a>
+    <li><a class=active href="#">Papyrus</a>
+  </ul>
+</div>
+
+<article>
+<h2>Papyrus mode</h2>
+<div><textarea id="code" name="code">
+; Papyrus demo.
+
+Potion Property FoodSweetroll Auto
+
+Event OnEffectStart(Actor akTarget, Actor akCaster)
+    RollDice()
+EndEvent
+
+Function RollDice()
+    random = Utility.RandomInt(1, 3)
+
+    if random == 1
+        Debug.Notification("Try again.")
+    elseif random == 2
+        Debug.Notification("Better luck next time.")
+    elseif random == 3
+        Game.GetPlayer().AddItem(FoodSweetroll, 1)
+    endif
+EndFunction
+</textarea></div>
+
+    <script>
+      var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
+        lineNumbers: true,
+        lineWrapping: true,
+        indentUnit: 4,
+        mode: "papyrus"
+      });
+    </script>
+
+    <p><strong>MIME types defined:</strong> <code>text/x-papyrus</code>.</p>
+  </article>

--- a/mode/papyrus/papyrus.js
+++ b/mode/papyrus/papyrus.js
@@ -1,0 +1,131 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  "use strict";
+
+  CodeMirror.defineMode("papyrus", function(config) {
+
+    /* Papyrus keywords are all case insensitive. */
+    function wordsRE(words) {
+      return new RegExp("^(?:" + words.join("|") + ")$", "i");
+    }
+
+    var indentUnit = config.indentUnit;
+
+    var indentKeywords = [ "Else", "ElseIf", "Event", "Function", "If", "While" ];
+    var dedentKeywords = [ "EndEvent", "EndFunction", "EndIf", "EndWhile" ];
+
+    var standardKeywords = [ "Auto", "Conditional", "Extends", "Property" ];
+    var keywords = wordsRE(standardKeywords.concat(indentKeywords, dedentKeywords));
+    var builtins = wordsRE([ "Scriptname", "ScriptName" ]);
+    var types = wordsRE([ "Bool", "Int", "String" ])
+
+    var indentTokens = wordsRE(indentKeywords);
+    var dedentTokens = wordsRE(dedentKeywords);
+    var dedentPartial = wordsRE(dedentKeywords);
+
+    function normal(stream, state) {
+      var ch = stream.next();
+
+      if(ch == ';') {
+        stream.skipToEnd();
+        return "comment";
+      }
+      if (ch == "\"" || ch == "'")
+        return (state.cur = string(ch))(stream, state);
+      if (ch == "{")
+        return (state.cur = bracketed("comment"))(stream, state);
+      if (/\d/.test(ch)) {
+        stream.eatWhile(/[\w.%]/);
+        return "number";
+      }
+      if (/[\w_]/.test(ch)) {
+        stream.eatWhile(/[\w\\\-_.]/);
+        return "variable";
+      }
+      return null;
+    }
+
+    /* Multi-line comment block. */
+    function bracketed(style) {
+      return function(stream, state) {
+        var ch;
+        while ((ch = stream.next()) != null) {
+          if (ch == "}") {
+            state.cur = normal;
+            break;
+          }
+        }
+        return style;
+      };
+    }
+
+    function string(quote) {
+      return function(stream, state) {
+        var escaped = false,
+          ch;
+        while ((ch = stream.next()) != null) {
+          if (ch == quote && !escaped)
+            break;
+          escaped = !escaped && ch == "\\";
+        }
+        if (!escaped)
+          state.cur = normal;
+        return "string";
+      };
+    }
+
+    return {
+      startState: function(basecol) {
+        return { basecol: basecol || 0, indentDepth: 0, cur: normal };
+      },
+
+      token: function(stream, state) {
+        if (stream.eatSpace())
+          return null;
+
+        var style = state.cur(stream, state);
+        var word = stream.current();
+
+        if (style == "variable") {
+          if (keywords.test(word))
+            style = "keyword";
+          else if (builtins.test(word))
+            style = "builtin";
+          else if (types.test(word))
+            style = "type";
+        }
+
+        if ((style != "comment") && (style != "string")) {
+          if (indentTokens.test(word))
+            ++state.indentDepth;
+          else if (dedentTokens.test(word))
+            --state.indentDepth;
+        }
+
+        return style;
+      },
+
+      indent: function(state, textAfter) {
+        var closing = dedentPartial.test(textAfter);
+
+        return state.basecol + indentUnit * (state.indentDepth - (closing ? 1 : 0));
+      },
+
+      electricInput: new RegExp("\\b" + dedentKeywords.join("|") + "\\b", "gi"),
+      lineComment: ";",
+      blockCommentStart: "{",
+      blockCommentEnd: "}"
+    };
+  });
+
+  CodeMirror.defineMIME("text/x-papyrus", "papyrus");
+});


### PR DESCRIPTION
Adds a highlighting mode for Papyrus, a scripting language by Bethesda
for video games mods (Skyrim and the Fallout series).

Documentation on the syntax is bit all over the place, but the
CreationKit wiki has lots of examples scattered around:

https://www.creationkit.com/index.php?title=Arrays_(Papyrus)
https://www.creationkit.com/index.php?title=Literals_Reference

Credit to the authors of the Lua mode, which acted as a good base to
work up from.