### PR TITLE
Change cursor color in darcula theme to be visible

### DIFF
--- a/theme/darcula.css
+++ b/theme/darcula.css
@@ -25,6 +25,7 @@
 .cm-s-darcula.CodeMirror { background: #2B2B2B; color: #A9B7C6; }
 
 
+.cm-s-darcula .CodeMirror-cursor { border-left: 1px solid #dddddd; }
 .cm-s-darcula .CodeMirror-activeline-background { background: #3A3A3A; }
 .cm-s-darcula div.CodeMirror-selected { background: #085a9c; }
 .cm-s-darcula .CodeMirror-gutters { background: rgb(72, 72, 72); border-right: 1px solid grey; color: #606366 }


### PR DESCRIPTION
The "darcula" theme added in version 5.38.0 is missing a CSS rule for coloring the cursor, so it falls back to the default black. This makes it difficult to see with its dark gray background. This commit adds a rule that makes the cursor a light gray for better contrast.