### PR TITLE
Add `inMathMode` configuration option to `sTeX` mode

### DIFF
--- a/mode/stex/index.html
+++ b/mode/stex/index.html
@@ -103,6 +103,12 @@
       var editor = CodeMirror.fromTextArea(document.getElementById("code"), {});
     </script>
 
+    <p>sTeX mode supports this option:</p>
+    <d1>
+      <dt><code>inMathMode: boolean</code></dt>
+      <dd>Whether to start parsing in math mode (default: <code>false</code>).</dd>
+    </d1>
+
     <p><strong>MIME types defined:</strong> <code>text/x-stex</code>.</p>
 
     <p><strong>Parsing/Highlighting Tests:</strong> <a href="../../test/index.html#stex_*">normal</a>,  <a href="../../test/index.html#verbose,stex_*">verbose</a>.</p>

--- a/mode/stex/stex.js
+++ b/mode/stex/stex.js
@@ -16,7 +16,7 @@
 })(function(CodeMirror) {
   "use strict";
 
-  CodeMirror.defineMode("stex", function() {
+  CodeMirror.defineMode("stex", function(_config, parserConfig) {
     "use strict";
 
     function pushCommand(state, command) {
@@ -173,7 +173,7 @@
       if (source.eatSpace()) {
         return null;
       }
-      if (source.match(endModeSeq)) {
+      if (endModeSeq && source.match(endModeSeq)) {
         setState(state, normal);
         return "keyword";
       }
@@ -235,9 +235,10 @@
 
     return {
       startState: function() {
+        var f = parserConfig.inMathMode ? function(source, state){ return inMathMode(source, state); } : normal;
         return {
           cmdState: [],
-          f: normal
+          f: f
         };
       },
       copyState: function(s) {


### PR DESCRIPTION
Nowadays TeX is often used to encode mathematical expressions within other markup languages (Markdown or HTML for example).
The natural way to highlight such kind of documents inside CodeMirror is using `multiplex` addon.
However sTeX mode always starts parsing in text mode, so, when the `multiplex` parser switches from the outer to sTeX mode, it assumes to be in text mode whereas in fact it should be in math mode.
As a consequence, the mathematical expression is parsed as normal TeX text.

This image shows how a display equation embedded in Markdown is highlighted using `multiplex` addon:

![ex1](https://user-images.githubusercontent.com/1220427/40632365-6e6c702c-62e6-11e8-93c6-de8f8a1085cd.png)

The same equation inside a TeX document:

![ex2](https://user-images.githubusercontent.com/1220427/40632370-9810c07c-62e6-11e8-8651-c56dfc18b51e.png)

This issue is fixed by this PR adding a configuration option to sTeX mode:

```
inMathMode: boolean
```  

When it is `true` (default is `false`) the parser starts in math mode instead of text mode.