### PR TITLE
[markdown] improve for HTMLs

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -125,9 +125,10 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     state.quote = 0;
     // Reset state.indentedCode
     state.indentedCode = false;
-    if (state.f == htmlBlock) {
+    if (state.f == htmlBlock && (!state.htmlState.tokenize || !state.htmlState.tokenize.isInBlock)) {
       state.f = inlineNormal;
       state.block = blockNormal;
+      state.htmlState = null;
     }
     // Reset state.trailingSpace
     state.trailingSpace = 0;
@@ -534,7 +535,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       return type + tokenTypes.linkEmail;
     }
 
-    if (modeCfg.xml && ch === '<' && stream.match(/^(!--|[a-z][a-z0-9-]*(?:\s+[a-z_:.\-]+(?:\s*=\s*[^>]+)?)*\s*>)/i, false)) {
+    if (modeCfg.xml && ch === '<' && stream.match(/^(!--|\?|!\[CDATA\[|[a-z][a-z0-9-]*(?:\s+[a-z_:.\-]+(?:\s*=\s*[^>]+)?)*\s*(?:>|$))/i, false)) {
       var end = stream.string.indexOf(">", stream.pos);
       if (end != -1) {
         var atts = stream.string.substring(stream.start, end);

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -125,10 +125,14 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     state.quote = 0;
     // Reset state.indentedCode
     state.indentedCode = false;
-    if (state.f == htmlBlock && (!state.htmlState.tokenize || !state.htmlState.tokenize.isInBlock)) {
-      state.f = inlineNormal;
-      state.block = blockNormal;
-      state.htmlState = null;
+    if (state.f == htmlBlock) {
+      var htmlState = state.htmlState;
+      while ('htmlState' in htmlState) htmlState = htmlState.htmlState; // htmlmixed -> xml
+      if (!htmlState || !htmlState.tokenize || !htmlState.tokenize.isInBlock) {
+        state.f = inlineNormal;
+        state.block = blockNormal;
+        state.htmlState = null;
+      }
     }
     // Reset state.trailingSpace
     state.trailingSpace = 0;

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -1283,6 +1283,25 @@
      "[tag&bracket <][tag div][tag&bracket >]",
      "[tag&bracket </][tag div][tag&bracket >]");
 
+  MT("xmlModeLineBreakInTags",
+     "[tag&bracket <][tag div] [attribute id]=[string \"1\"]",
+     "     [attribute class]=[string \"sth\"][tag&bracket >]xxx",
+     "[tag&bracket </][tag div][tag&bracket >]");
+
+  MT("xmlModeCommentWithBlankLine",
+     "[comment <!-- Hello]",
+     "",
+     "[comment World -->]");
+
+  MT("xmlModeCDATA",
+     "[atom <![CDATA[ Hello]",
+     "",
+     "[atom FooBar]",
+     "[atom Test ]]]]>]");
+
+  MT("xmlModePreprocessor",
+     "[meta <?php] [meta echo '1234'; ?>]");
+
   MT_noXml("xmlHighlightDisabled",
      "<div>foo</div>");
 

--- a/mode/xml/xml.js
+++ b/mode/xml/xml.js
@@ -154,7 +154,7 @@ CodeMirror.defineMode("xml", function(editorConf, config_) {
   }
 
   function inBlock(style, terminator) {
-    return function(stream, state) {
+    var closure = function(stream, state) {
       while (!stream.eol()) {
         if (stream.match(terminator)) {
           state.tokenize = inText;
@@ -164,7 +164,10 @@ CodeMirror.defineMode("xml", function(editorConf, config_) {
       }
       return style;
     };
+    closure.isInBlock = true;
+    return closure;
   }
+
   function doctype(depth) {
     return function(stream, state) {
       var ch;


### PR DESCRIPTION
## Commits

[markdown] support line-breaks in tags
[markdown] support multi-line blocks (eg. CDATA and comments)
[markdown] clear unused htmlState

## Example

```
<!-- Comments may contain

blank lines -->

<?php echo "good"; ?>

<![CDATA[ Support CDATA ]]>

<div id="xxx"
class="yyy">
    ↑ line-breaks are accepted between attributes
</div>
```

See:

- https://spec.commonmark.org/0.28/#example-146
- https://spec.commonmark.org/0.28/#example-147
- https://spec.commonmark.org/0.28/#example-149
- https://spec.commonmark.org/0.28/#example-614


## BTW, introducing ... [HyperMD](https://laobubu.net/HyperMD/)

**WYSIWYG Markdown editor** based on CodeMirror.
(Yes, it's *"What You See Is What You Get"*)

 [Demo](https://laobubu.net/HyperMD/)
