### PR TITLE
Fix hint not closing correctly when at beginning of line

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -98,7 +98,7 @@
       var pos = this.cm.getCursor(), line = this.cm.getLine(pos.line);
       if (pos.line != this.startPos.line || line.length - pos.ch != this.startLen - this.startPos.ch ||
           pos.ch < this.startPos.ch || this.cm.somethingSelected() ||
-          (pos.ch && this.options.closeCharacters.test(line.charAt(pos.ch - 1)))) {
+          (pos.ch != undefined && this.options.closeCharacters.test(line.charAt(pos.ch - 1)))) {
         this.close();
       } else {
         var self = this;

--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -98,7 +98,7 @@
       var pos = this.cm.getCursor(), line = this.cm.getLine(pos.line);
       if (pos.line != this.startPos.line || line.length - pos.ch != this.startLen - this.startPos.ch ||
           pos.ch < this.startPos.ch || this.cm.somethingSelected() ||
-          (pos.ch != undefined && this.options.closeCharacters.test(line.charAt(pos.ch - 1)))) {
+          (!pos.ch || this.options.closeCharacters.test(line.charAt(pos.ch - 1)))) {
         this.close();
       } else {
         var self = this;


### PR DESCRIPTION
Fixes a bug where opening the hint widget at the beginning of a line would not close correctly after deleting. It's somewhat hard to explain, so I've created a small repro case [here](http://jsbin.com/becuselate/edit?html,js,output).

If the cursor started at the beginning of a line and show hint was triggered, deleting a character would not close the hint correctly. I think the issue here is that `pos.ch` is checked for existence but falsy 0 wasn't considered.