### PR TITLE
Document `direction` option

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -292,6 +292,17 @@
       character. By default, a red dot (<span style="color: red">•</span>)
       is shown, with a title tooltip to indicate the character code.</dd>
 
+      <dt id="option_direction"><code><strong>direction</strong>: "ltr" | "rtl"</code></dt>
+      <dd>Flips overall layout and selects base paragraph direction to
+      be left-to-right or right-to-left.  Default is "ltr".
+      CodeMirror applies the Unicode Bidirectional Algorithm to each
+      line, but does not autodetect base direction — it's set to the
+      editor direction for all lines.  The resulting order is
+      sometimes wrong when base direction doesn't match user intent
+      (for example, leading and trailing punctuation jumps to the
+      wrong side of the line).  Therefore, it's helpful for
+      multilingual input to let users toggle this option.
+
       <dt id="option_rtlMoveVisually"><code><strong>rtlMoveVisually</strong>: boolean</code></dt>
       <dd>Determines whether horizontal cursor movement through
       right-to-left (Arabic, Hebrew) text is visual (pressing the left


### PR DESCRIPTION
Exists since #4624 but wasn't documented in manual, only in demo.
(BTW thanks for the hard work it took to land that :heart:)

I tried to make the description useful to someone not familiar with bidi coding for multi-lingual users.  Not sure if too "preachy", but IMHO as long as CodeMirror doesn't autodetect per-line direction, it's good advice — editing with oppossite direction is significantly awkward, and letting users flip the whole editor is the best mitigation currently possible.

- I thought I should also clarify how `rtlMoveVisually` affects Home/End keys, and how it interacts with `direction` — but turns out it doesn't (at least not as I expected) :grin:  I need to study it better before proposing/implementing any improvement there...
  Meanwhile, current description `rtlMoveVisually` seems precise.