### PR TITLE
[jinja2 mode] add file extensions for jinja2 mode

### DIFF
--- a/mode/meta.js
+++ b/mode/meta.js
@@ -75,7 +75,7 @@
     {name: "JSON", mimes: ["application/json", "application/x-json"], mode: "javascript", ext: ["json", "map"], alias: ["json5"]},
     {name: "JSON-LD", mime: "application/ld+json", mode: "javascript", ext: ["jsonld"], alias: ["jsonld"]},
     {name: "JSX", mime: "text/jsx", mode: "jsx", ext: ["jsx"]},
-    {name: "Jinja2", mime: "null", mode: "jinja2"},
+    {name: "Jinja2", mime: "null", mode: "jinja2", ext: ["j2", "jinja", "jinja2"]},
     {name: "Julia", mime: "text/x-julia", mode: "julia", ext: ["jl"]},
     {name: "Kotlin", mime: "text/x-kotlin", mode: "clike", ext: ["kt"]},
     {name: "LESS", mime: "text/x-less", mode: "css", ext: ["less"]},


### PR DESCRIPTION
Does what it says on the box. Had someone ask about why our system wasn't automatically highlighting jinja2 files and noticed there were no extensions mapped for this mode. From [what I could find](https://stackoverflow.com/questions/29590931/is-there-an-idiomatic-file-extension-for-jinja-templates) there [isn't an explicit file extension that is deemed the official one](https://github.com/pallets/jinja/issues/547). It seems that `j2` is the favoured extension for [Ansible projects](https://docs.ansible.com/ansible/latest/user_guide/playbooks_best_practices.html#directory-layout), and I think it makes sense to include `jinja` and `jinja2` as well.