### PR TITLE
the shorthand if else is causing ReferenceError b is not defined when…

### DIFF
--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -94,8 +94,12 @@
   }
 
   function getMaxSeverity(a, b) {
-    if (a == "error") return a;
-    else return b;
+    if (a == "error") {
+      return a;
+    }
+    else {
+      return b
+    };
   }
 
   function groupByLine(annotations) {


### PR DESCRIPTION
the shorthand if else is causing ReferenceError b is not defined when using babel-loader