### PR TITLE
Add HTML commenting to markdown.js.

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -869,6 +869,8 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
 
     getType: getType,
 
+    blockCommentStart: "<!--",
+    blockCommentEnd: "-->",
     closeBrackets: "()[]{}''\"\"``",
     fold: "markdown"
   };


### PR DESCRIPTION
Adds HTML comment support to the Markdown mode.

HTML comments are generally permissible in Markdown, per https://spec.commonmark.org/0.28/.