### PR TITLE
Fix centered column as not emoji

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -620,7 +620,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       }
     }
 
-    if (modeCfg.emoji && ch === ":" && stream.match(/^[a-z_\d+-]+:/)) {
+    if (modeCfg.emoji && ch === ":" && stream.match(/^(?:[a-z_\d+][a-z_\d+-]*|\-[a-z_\d+][a-z_\d+-]*):/)) {
       state.emoji = true;
       if (modeCfg.highlightFormatting) state.formatting = "emoji";
       var retType = getType(state);

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -45,6 +45,8 @@
       "formatting" : "override-formatting"
   }});
   function FormatTokenTypeOverrideTest(name) { test.mode(name, modeFormattingOverride, Array.prototype.slice.call(arguments, 1)); }
+  var modeET = CodeMirror.getMode(config, {name: "markdown", emoji: true});
+  function ET(name) { test.mode(name, modeET, Array.prototype.slice.call(arguments, 1)); }
 
 
   FT("formatting_emAsterisk",
@@ -1305,4 +1307,11 @@
   MT_noXml("xmlHighlightDisabled",
      "<div>foo</div>");
 
+  // Tests Emojis
+
+  ET("emojiDefault",
+    "[builtin :foobar:]");
+
+  ET("emojiTable",
+    " :--:");
 })();


### PR DESCRIPTION
This change fixes the centered column of a table to be not recognized as an emoji.

```
| Left-aligned | Center-aligned | Right-aligned |
| :---         |     :---:      |          ---: |
| git status   | git status     | git status    |
| git diff     | git diff       | git diff      |
```
` :---:` shouldn't be marked as an emoji. [GFM reference](https://help.github.com/articles/organizing-information-with-tables/)