### PR TITLE
[javascript mode] allow default values in array destructuring

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -644,7 +644,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (isTS && isModifier(value)) { cx.marked = "keyword"; return cont(pattern) }
     if (type == "variable") { register(value); return cont(); }
     if (type == "spread") return cont(pattern);
-    if (type == "[") return contCommasep(pattern, "]");
+    if (type == "[") return contCommasep(elempattern, "]");
     if (type == "{") return contCommasep(proppattern, "}");
   }
   function proppattern(type, value) {
@@ -656,6 +656,10 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (type == "spread") return cont(pattern);
     if (type == "}") return pass();
     return cont(expect(":"), pattern, maybeAssign);
+  }
+  function elempattern(type, value) {
+    if (type == "variable") { register(value); return cont(maybeAssign); }
+    return cont(pattern);
   }
   function maybeAssign(_type, value) {
     if (value == "=") return cont(expressionNoComma);

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -12,7 +12,7 @@
      "[keyword function](){ [keyword var] [def x] [operator =] [number 1] [operator +] [number 2], [def y]; }");
 
   MT("destructuring",
-     "([keyword function]([def a], [[[def b], [def c] ]]) {",
+     "([keyword function]([def a], [[[def b] [operator =] [number 10], [def c] ]]) {",
      "  [keyword let] {[def d], [property foo]: [def c][operator =][number 10], [def x]} [operator =] [variable foo]([variable-2 a]);",
      "  [[[variable-2 c], [variable y] ]] [operator =] [variable-2 c];",
      "})();");


### PR DESCRIPTION
This permits default assignments in array destructuring patterns, so:

```js
let [a = 10, b] = [];
function z([a = 10, b]) { return [a, b]; }
let y([a = 10, b]) => { return [a, b]; }
```

Currently the parser bails out after an assignment like `a = 10` in this example, which means that any other parameters (like `b`) are not registered.