### PR TITLE
[clojure mode] Add tests.

### DIFF
--- a/mode/clojure/clojure.js
+++ b/mode/clojure/clojure.js
@@ -33,17 +33,17 @@ CodeMirror.defineMode("clojure", function (options) {
         "defstruct", "deftype", "defprotocol", "defrecord", "defproject", "deftest", "slice", "defalias",
         "defhinted", "defmacro-", "defn-memo", "defnk", "defonce-", "defunbound", "defunbound-",
         "defvar", "defvar-", "let", "letfn", "do", "case", "cond", "condp", "for", "loop", "recur", "when",
-        "when-not", "when-let", "when-first", "if", "if-let", "if-not", ".", "..", "->", "->>", "doto",
+        "when-not", "when-let", "when-first", "when-some", "if", "if-let", "if-not", ".", "..", "->", "->>", "doto",
         "and", "or", "dosync", "doseq", "dotimes", "dorun", "doall", "load", "import", "unimport", "ns",
         "in-ns", "refer", "try", "catch", "finally", "throw", "with-open", "with-local-vars", "binding",
-        "gen-class", "gen-and-load-class", "gen-and-save-class", "handler-case", "handle"];
+        "gen-class", "gen-and-load-class", "gen-and-save-class", "handler-case", "handle", "new"];
     var commonBuiltins = ["*", "*'", "*1", "*2", "*3", "*agent*", "*allow-unresolved-vars*", "*assert*",
         "*clojure-version*", "*command-line-args*", "*compile-files*", "*compile-path*", "*compiler-options*",
         "*data-readers*", "*default-data-reader-fn*", "*e", "*err*", "*file*", "*flush-on-newline*", "*fn-loader*",
         "*in*", "*math-context*", "*ns*", "*out*", "*print-dup*", "*print-length*", "*print-level*", "*print-meta*",
         "*print-namespace-maps*", "*print-readably*", "*read-eval*", "*reader-resolver*", "*source-path*",
         "*suppress-read*", "*unchecked-math*", "*use-context-classloader*", "*verbose-defrecords*",
-        "*warn-on-reflection*'", "-", "-'", "->", "->>", "->ArrayChunk", "->Eduction", "->Vec", "->VecNode",
+        "*warn-on-reflection*", "+", "+'", "-", "-'", "->", "->>", "->ArrayChunk", "->Eduction", "->Vec", "->VecNode",
         "->VecSeq", "-cache-protocol-fn", "-reset-methods", "..", "/", "<", "<=", "=", "==", ">", ">=",
         "EMPTY-NODE", "Inst", "StackTraceElement->vec", "Throwable->map", "accessor", "aclone", "add-classpath",
         "add-watch", "agent", "agent-error", "agent-errors", "aget", "alength", "alias", "all-ns", "alter",
@@ -115,7 +115,7 @@ CodeMirror.defineMode("clojure", function (options) {
         "zipmap"];
     var commonIndentKeys = [
         // Built-ins
-        "ns", "fn", "def", "defn", "defmethod", "bound-fn", "if", "if-not", "case", "condp", "when", "while", "when-not", "when-first", "do", "future", "comment", "doto",
+        "ns", "fn", "def", "defn", "defmethod", "bound-fn", "if", "if-not", "case", "condp", "when", "while", "when-not", "when-first", "when-some", "do", "future", "comment", "doto",
         "locking", "proxy", "with-open", "with-precision", "reify", "deftype", "defrecord", "defprotocol", "extend", "extend-protocol", "extend-type",
         "try", "catch",
         // Binding forms
@@ -136,12 +136,11 @@ CodeMirror.defineMode("clojure", function (options) {
 
     var tests = {
         digit: /\d/,
-        digit_or_colon: /[\d:]/,
         hex: /[0-9a-f]/i,
         sign: /[+-]/,
         exponent: /e/i,
-        keyword_char: /[^\s\(\[\;\)\]]/,
-        symbol: /[\w*+!\-\._?:<>\/\xa1-\uffff]/,
+        keyword_char: /[^\s;()\[\]{}]/,
+        symbol: /[\w*+!\-._?:<>\/'\xa1-\uffff]/,
         block_indent: /^(?:def|with)[^\/]+$|\/(?:def|with)/
     };
 
@@ -252,7 +251,7 @@ CodeMirror.defineMode("clojure", function (options) {
                     } else if (ch == "\\") {
                         eatCharacter(stream);
                         returnType = CHARACTER;
-                    } else if (ch == "'" && !( tests.digit_or_colon.test(stream.peek()) )) {
+                    } else if (ch == "'") {
                         returnType = ATOM;
                     } else if (ch == ";") { // comment
                         stream.skipToEnd(); // rest of the line is a comment

--- a/mode/clojure/index.html
+++ b/mode/clojure/index.html
@@ -6,6 +6,8 @@
 
 <link rel="stylesheet" href="../../lib/codemirror.css">
 <script src="../../lib/codemirror.js"></script>
+<script src="../../addon/edit/closebrackets.js"></script>
+<script src="../../addon/edit/matchbrackets.js"></script>
 <script src="clojure.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
@@ -83,7 +85,12 @@
 
 </textarea></form>
     <script>
-      var editor = CodeMirror.fromTextArea(document.getElementById("code"), {});
+      var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
+          autoCloseBrackets: true,
+          lineNumbers: true,
+          matchBrackets: true,
+          mode: 'text/x-clojure'
+      });
     </script>
 
     <p><strong>MIME types defined:</strong> <code>text/x-clojure</code>.</p>

--- a/test/index.html
+++ b/test/index.html
@@ -22,6 +22,7 @@
 <script src="../mode/css/css.js"></script>
 <script src="../mode/clike/clike.js"></script>
 <!-- clike must be after css or vim and sublime tests will fail -->
+<script src="../mode/clojure/clojure.js"></script>
 <script src="../mode/cypher/cypher.js"></script>
 <script src="../mode/d/d.js"></script>
 <script src="../mode/dockerfile/dockerfile.js"></script>
@@ -114,6 +115,7 @@
     <script src="mode_test.js"></script>
 
     <script src="../mode/clike/test.js"></script>
+    <script src="../mode/clojure/test.js"></script>
     <script src="../mode/css/test.js"></script>
     <script src="../mode/css/gss_test.js"></script>
     <script src="../mode/css/scss_test.js"></script>


### PR DESCRIPTION
Besides adding tests, this PR also fixes a few minor issues revealed by the tests:
- Keywords or numbers following a single quote (`'`) were being styled as `variable` instead of `atom` or `number`, respectively.
- Single quote (`'`) was missing on the list of valid symbol characters. Such symbols include `+'`, `*'` and, `-'`.
- `new` and `when-some` were missing on the keyword list. There are a few other symbols (e.g., `as->`, `cond->`, `condp->`, `some->` etc.) that are also missing on the list which I plan to add soon.
- `tests.keyword_char` and `tests.symbol` had redundant characters in them.
- `+` and `+'` were missing on the core symbols list as a regression introduced by commit 74fca7c .

Please note that there are some `FIXME`es in the tests. I'm planning to fix them soon once this PR is accepted.