### PR TITLE
Do not autoclose single quotes in scala mode

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -573,7 +573,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
         return state.tokenize(stream, state)
       }
     },
-    modeProps: {closeBrackets: {triples: '"'}}
+    modeProps: {closeBrackets: {pairs: '()[]{}""', triples: '"'}}
   });
 
   function tokenKotlinString(tripleString){


### PR DESCRIPTION
A single quote in scala indicates the start of a symbol literal (like 'x), not a string, so should not be paired with a closing single quote.

See https://www.scala-lang.org/files/archive/spec/2.12/01-lexical-syntax.html#string-literals and https://www.scala-lang.org/files/archive/spec/2.12/01-lexical-syntax.html#symbol-literals for more information.