### PR TITLE
[clojure mode] Refactoring.

### DIFF
--- a/mode/clojure/clojure.js
+++ b/mode/clojure/clojure.js
@@ -12,10 +12,10 @@
 "use strict";
 
 CodeMirror.defineMode("clojure", function (options) {
-  var commonAtoms = ["false", "nil", "true"];
-  var commonSpecialForms = [".", "catch", "def", "do", "if", "monitor-enter",
+  var atoms = ["false", "nil", "true"];
+  var specialForms = [".", "catch", "def", "do", "if", "monitor-enter",
       "monitor-exit", "new", "quote", "recur", "set!", "throw", "try", "var"];
-  var commonCoreSymbols = ["*", "*'", "*1", "*2", "*3", "*agent*",
+  var coreSymbols = ["*", "*'", "*1", "*2", "*3", "*agent*",
       "*allow-unresolved-vars*", "*assert*", "*clojure-version*",
       "*command-line-args*", "*compile-files*", "*compile-path*",
       "*compiler-options*", "*data-readers*", "*default-data-reader-fn*", "*e",
@@ -137,23 +137,22 @@ CodeMirror.defineMode("clojure", function (options) {
       "with-local-vars", "with-meta", "with-open", "with-out-str",
       "with-precision", "with-redefs", "with-redefs-fn", "xml-seq", "zero?",
       "zipmap"];
-  var commonIndentSymbols = [
+  var formsThatHaveBodyParameter = [
       "assoc", "binding", "bound-fn", "case", "catch", "comment", "cond",
-      "condp", "def", "defmethod", "defn", "defprotocol", "defrecord",
-      "defstruct", "deftype", "do", "doseq", "dotimes", "doto", "extend",
-      "extend-protocol", "extend-type", "fn", "for", "future", "if", "if-let",
-      "if-not", "let", "letfn", "locking", "loop", "ns", "proxy", "reify",
-      "struct-map", "try", "when", "when-first", "when-let", "when-not",
-      "when-some", "while", "with-open", "with-precision"];
+      "condp", "def", "defmethod", "defn", "defmacro", "defprotocol",
+      "defrecord", "defstruct", "deftype", "do", "doseq", "dotimes", "doto",
+      "extend", "extend-protocol", "extend-type", "fn", "for", "future", "if",
+      "if-let", "if-not", "let", "letfn", "locking", "loop", "ns", "proxy",
+      "reify", "struct-map", "try", "when", "when-first", "when-let",
+      "when-not", "when-some", "while", "with-open", "with-precision"];
 
   CodeMirror.registerHelper("hintWords", "clojure",
-      commonAtoms.concat(commonSpecialForms, commonCoreSymbols));
+    [].concat(atoms, specialForms, coreSymbols));
 
-  var atom = createLookupMap(commonAtoms);
-  var specialForm = createLookupMap(commonSpecialForms);
-  var coreSymbol = createLookupMap(commonCoreSymbols);
-  var indentSymbol = createLookupMap(commonIndentSymbols);
-  var assumeBody = /^(?:def|with)[^\/]+$|\/(?:def|with)/;
+  var atom = createLookupMap(atoms);
+  var specialForm = createLookupMap(specialForms);
+  var coreSymbol = createLookupMap(coreSymbols);
+  var hasBodyParameter = createLookupMap(formsThatHaveBodyParameter);
   var numberLiteral = /^[+\-]?\d+(?:(?:N|(?:[eE][+\-]?\d+))|(?:\.?\d*(?:M|(?:[eE][+\-]?\d+))?)|\/\d+|[xX][0-9a-fA-F]+|r[0-9a-zA-Z]+)?/;
   var symbol = /[!#'*+\-.\/:<>?_\w\xa1-\uffff]/;
 
@@ -253,8 +252,7 @@ CodeMirror.defineMode("clojure", function (options) {
 
       if (type !== "space") {
         if (state.lastToken === "(" && state.ctx.indentTo === null) {
-          if (type === "symbol" &&
-            (is(current, indentSymbol) || is(current, assumeBody)))
+          if (type === "symbol" && is(current, hasBodyParameter))
             state.ctx.indentTo = state.ctx.start + options.indentUnit;
           else state.ctx.indentTo = "next";
         } else if (state.ctx.indentTo === "next") {

--- a/mode/clojure/clojure.js
+++ b/mode/clojure/clojure.js
@@ -138,13 +138,14 @@ CodeMirror.defineMode("clojure", function (options) {
       "with-precision", "with-redefs", "with-redefs-fn", "xml-seq", "zero?",
       "zipmap"];
   var formsThatHaveBodyParameter = [
-      "assoc", "binding", "bound-fn", "case", "catch", "comment", "cond",
-      "condp", "def", "defmethod", "defn", "defmacro", "defprotocol",
-      "defrecord", "defstruct", "deftype", "do", "doseq", "dotimes", "doto",
-      "extend", "extend-protocol", "extend-type", "fn", "for", "future", "if",
-      "if-let", "if-not", "let", "letfn", "locking", "loop", "ns", "proxy",
-      "reify", "struct-map", "try", "when", "when-first", "when-let",
-      "when-not", "when-some", "while", "with-open", "with-precision"];
+      "binding", "bound-fn", "case", "catch", "comment", "cond", "cond->",
+      "cond->>", "condp", "def", "definterface", "defmethod", "defn",
+      "defmacro", "defprotocol", "defrecord", "defstruct", "deftype", "do",
+      "doseq", "dotimes", "doto", "extend", "extend-protocol", "extend-type",
+      "fn", "for", "future", "if", "if-let", "if-not", "if-some", "let",
+      "letfn", "locking", "loop", "ns", "proxy", "reify", "struct-map", "try",
+      "when", "when-first", "when-let", "when-not", "when-some", "while",
+      "with-open", "with-precision"];
 
   CodeMirror.registerHelper("hintWords", "clojure",
     [].concat(atoms, specialForms, coreSymbols));

--- a/mode/clojure/clojure.js
+++ b/mode/clojure/clojure.js
@@ -137,7 +137,7 @@ CodeMirror.defineMode("clojure", function (options) {
       "with-local-vars", "with-meta", "with-open", "with-out-str",
       "with-precision", "with-redefs", "with-redefs-fn", "xml-seq", "zero?",
       "zipmap"];
-  var formsThatHaveBodyParameter = [
+  var haveBodyParameter = [
       "binding", "bound-fn", "case", "catch", "comment", "cond", "cond->",
       "cond->>", "condp", "def", "definterface", "defmethod", "defn",
       "defmacro", "defprotocol", "defrecord", "defstruct", "deftype", "do",
@@ -153,9 +153,9 @@ CodeMirror.defineMode("clojure", function (options) {
   var atom = createLookupMap(atoms);
   var specialForm = createLookupMap(specialForms);
   var coreSymbol = createLookupMap(coreSymbols);
-  var hasBodyParameter = createLookupMap(formsThatHaveBodyParameter);
+  var hasBodyParameter = createLookupMap(haveBodyParameter);
   var numberLiteral = /^[+\-]?\d+(?:(?:N|(?:[eE][+\-]?\d+))|(?:\.?\d*(?:M|(?:[eE][+\-]?\d+))?)|\/\d+|[xX][0-9a-fA-F]+|r[0-9a-zA-Z]+)?/;
-  var symbol = /[!#'*+\-.\/:<>?_\w\xa1-\uffff]/;
+  var symbolCharacter = /[!#'*+\-.\/:<>?_\w\xa1-\uffff]/;
 
   function base(stream, state) {
     if (stream.eatSpace()) return ["space", null];
@@ -170,12 +170,12 @@ CodeMirror.defineMode("clojure", function (options) {
     if (ch === ";") {stream.skipToEnd(); return ["space", "comment"];}
     if (is(ch, /[#'@^`~]/)) return [null, "meta"];
 
-    var name = readSymbol(stream);
+    var symbol = readSymbol(stream);
 
-    if (name === "comment" && state.lastToken === "(")
+    if (symbol === "comment" && state.lastToken === "(")
       return (state.tokenize = inComment)(stream, state);
-    if (is(name, atom) || name.charAt(0) === ":") return ["symbol", "atom"];
-    if (is(name, specialForm) || is(name, coreSymbol)) return ["symbol", "keyword"];
+    if (is(symbol, atom) || symbol.charAt(0) === ":") return ["symbol", "atom"];
+    if (is(symbol, specialForm) || is(symbol, coreSymbol)) return ["symbol", "keyword"];
     if (state.lastToken === "(") return ["symbol", "builtin"]; // other operator
 
     return ["symbol", "variable"];
@@ -214,7 +214,7 @@ CodeMirror.defineMode("clojure", function (options) {
 
     while (ch = stream.next()) {
       if (ch === "\\") stream.next();
-      else if (!is(ch, symbol)) {stream.backUp(1); break;}
+      else if (!is(ch, symbolCharacter)) {stream.backUp(1); break;}
     }
 
     return stream.current();

--- a/mode/clojure/test.js
+++ b/mode/clojure/test.js
@@ -192,7 +192,7 @@
         typeTokenPairs("keyword", coreSymbols2)
     );
 
-    MT("should indent list literal",
+    MT("should properly indent forms in list literals",
         "[bracket (][builtin foo] [atom :a] [number 1] [atom true] [atom nil][bracket )]",
         "",
         "[bracket (][builtin foo] [atom :a]",
@@ -217,7 +217,7 @@
         "     [atom nil][bracket )]"
     );
 
-    MT("should indent vector literal",
+    MT("should properly indent forms in vector literals",
         "[bracket [[][atom :a] [number 1] [atom true] [atom nil][bracket ]]]",
         "",
         "[bracket [[][atom :a]",
@@ -237,7 +237,7 @@
         " [atom nil][bracket ]]]"
     );
 
-    MT("should indent map literal",
+    MT("should properly indent forms in map literals",
         "[bracket {][atom :a] [atom :a] [atom :b] [number 1] [atom :c] [atom true] [atom :d] [atom nil] [bracket }]",
         "",
         "[bracket {][atom :a] [atom :a]",
@@ -261,7 +261,7 @@
         " [atom :d] [atom nil][bracket }]"
     );
 
-    MT("should indent set literal",
+    MT("should properly indent forms in set literals",
         "[meta #][bracket {][atom :a] [number 1] [atom true] [atom nil] [bracket }]",
         "",
         "[meta #][bracket {][atom :a]",
@@ -276,378 +276,32 @@
         "  [atom nil][bracket }]"
     );
 
-    MT("should indent assoc",
-        "[bracket (][keyword assoc] [variable foo]",
-        "  [atom :1] [string \"three\"]",
-        "  [atom :2] [string \"two\"]",
-        "  [atom :3] [string \"three\"][bracket )]"
-    );
+    var formsThatHaveBodyParameter = [
+        "binding", "bound-fn", "case", "catch", "cond", "cond->",
+        "cond->>", "condp", "def", "definterface", "defmethod", "defn",
+        "defmacro", "defprotocol", "defrecord", "defstruct", "deftype", "do",
+        "doseq", "dotimes", "doto", "extend", "extend-protocol", "extend-type",
+        "fn", "for", "future", "if", "if-let", "if-not", "if-some", "let",
+        "letfn", "locking", "loop", "ns", "proxy", "reify", "struct-map", "try",
+        "when", "when-first", "when-let", "when-not", "when-some", "while",
+        "with-open", "with-precision"];
 
-    MT("should indent binding",
-        "[bracket (][keyword binding] [bracket [[][variable foo] [number 2]",
-        "          [variable *bar*] [number 3][bracket ]]]",
-        "  [bracket (][keyword +] [variable foo] [variable *bar*][bracket ))]");
+    function testFormsThatHaveBodyParameter(forms) {
+        for (var i = 0; i < forms.length; i++) {
+            MT("should indent body argument of `" + forms[i] + "` by `options.indentUnit` spaces",
+                "[bracket (][keyword " + forms[i] + "] [variable foo] [variable bar]",
+                "  [variable baz]",
+                "  [variable qux][bracket )]"
+            );
+        }
+    }
 
-    MT("should indent bound-fn",
-        "[bracket (][keyword bound-fn] [bracket [[]]]",
-        "  [bracket (][builtin f][bracket ))]"
-    );
+    testFormsThatHaveBodyParameter(formsThatHaveBodyParameter);
 
-    MT("should indent case",
-        "[bracket (][keyword case] [variable foo]",
-        "  [string \"\"] [number 0]",
-        "  [string \"hello\"] [atom :bar]",
-        "  [bracket [[][number 1] [number 2][bracket ]]] [bracket (][string \"my seq\"][bracket )]",
-        "  [bracket (][builtin x] [variable y] [variable z][bracket )] [string \"x, y, or z\"]",
-        "  [atom :default]"
-    );
-
-    MT("should indent catch",
-        "[bracket (][keyword catch] [variable Exception] [variable e]",
-        "  [bracket (][keyword println] [string \"Some other exception, won't be caught in this case...\"][bracket )]",
-        "  [number 666][bracket )]"
-    );
-
-    MT("should indent comment",
-        "[bracket (][comment comment (foo)]",
-        "[comment  (bar 1 2 3)][bracket )]"
-    );
-
-    MT("should indent cond",
-        "[bracket (][keyword cond]",
-        "  [bracket (][keyword <] [variable n] [number 0][bracket )] [string \"negative\"]",
-        "  [bracket (][keyword >] [variable n] [number 0][bracket )] [string \"positive\"]",
-        "  [atom :else] [string \"zero\"][bracket ))]"
-    );
-
-    MT("should indent condp",
-        "[bracket (][keyword condp] [keyword =] [variable foo]",
-        "  [number 1] [string \"one\"]",
-        "  [number 2] [string \"two\"]",
-        "  [number 3] [string \"three\"]",
-        "  [string \"unexpected value\"][bracket )]"
-    );
-
-    MT("should indent def",
-        "[bracket (][keyword def] [variable x]",
-        "  [string \"here is an indented doc-string.\"]",
-        "  [number 1][bracket )]"
-    );
-
-    MT("should indent defn",
-        "[bracket (][keyword defn] [variable foo]",
-        "  [bracket [[][variable x][bracket ]]]",
-        "  [bracket (][builtin bar] [variable x][bracket ))]",
-        "",
-        "[bracket (][keyword defn] [variable foo] [bracket [[][variable x][bracket ]]]",
-        "  [bracket (][builtin bar] [variable x][bracket ))]"
-    );
-
-    MT("should indent defmacro",
-        "[bracket (][keyword defmacro] [variable foo]",
-        "  [string \"here is an indented doc-string.\"]",
-        "  [bracket [[][variable x] [variable y][bracket ]]]",
-        "  [meta `][bracket (][keyword println] [meta ~][variable x#] [meta ~@][variable y][bracket ))]"
-    );
-
-    MT("should indent defmethod",
-        "[bracket (][keyword defmethod] [variable foo] [atom :bar] [bracket [[][variable x][bracket ]]] [bracket (][builtin baz] [variable x][bracket ))]",
-        "",
-        "[bracket (][keyword defmethod] [variable foo] [atom :bar]",
-        "  [bracket [[][variable x][bracket ]]]",
-        "  [bracket (][builtin baz] [variable x][bracket ))]"
-    );
-
-    MT("should indent defstruct",
-        "[bracket (][keyword defstruct] [variable person]",
-        "  [atom :name]",
-        "  [atom :age]",
-        "  [atom :height][bracket )]"
-    );
-
-    MT("should indent doseq",
-        "[bracket (][keyword doseq] [bracket [[][variable x] [bracket [[][number -1] [number 0] [number 1][bracket ]]]",
-        "        [variable y] [bracket [[][number 1] [number 2] [number 3][bracket ]]]]]",
-        "  [bracket (][keyword prn] [bracket (][keyword *] [variable x] [variable y][bracket )))]"
-    );
-
-    MT("should indent dotimes",
-        "[bracket (][keyword dotimes] [bracket [[][variable n] [number 5][bracket ]]]",
-        "  [bracket (][keyword println] [string \"n is\"] [variable n][bracket ))]");
-
-    MT("should indent for",
-        "[bracket (][keyword for] [bracket [[][variable x] [bracket [[][number 1] [number 2] [number 3][bracket ]]]",
-        "      [atom :let] [bracket [[][variable y] [bracket (][keyword *] [variable x] [number 3][bracket )]]]",
-        "      [atom :when] [bracket (][keyword even?] [variable y][bracket )]]]",
-        "  [variable y][bracket )]"
-    );
-
-    MT("should indent if-let",
-        "[bracket (][keyword if-let] [bracket [[][variable x] [variable foo][bracket ]]]",
-        "  [string \"then\"]",
-        "  [string \"else\"][bracket ))]"
-    );
-
-    MT("should indent let",
-        "[bracket (][keyword let] [bracket [[][variable foo] [number 2]",
-        "      [variable bar] [number 3][bracket ]]]",
-        "  [bracket (][keyword +] [variable foo] [variable *bar*][bracket ))]"
-    );
-
-    MT("should indent letfn",
-        "[bracket (][keyword letfn] [bracket [[(][builtin twice] [bracket [[][variable x][bracket ]]]",
-        "               [bracket (][keyword *] [variable x] [number 2][bracket ))]",
-        "        [bracket (][builtin six-times] [bracket [[][variable y][bracket ]]]",
-        "                   [bracket (][keyword *] [bracket (][builtin twice] [variable y][bracket )] [number 3][bracket ))]]]",
-        "  [bracket (][keyword println] [string \"twice 15 =\"] [bracket (][builtin twice] [number 15][bracket ))]",
-        "  [bracket (][keyword println] [string \"six times 15 =\"] [bracket (][builtin six-times] [number 15][bracket )))]"
-    );
-
-    MT("should indent loop",
-        "[bracket (][keyword loop] [bracket [[][variable foo] [number 2]",
-        "       [variable bar] [number 3][bracket ]]]",
-        "  [bracket (][keyword +] [variable foo] [variable *bar*][bracket ))]"
-    );
-
-    MT("should indent when-first",
-        "[bracket (][keyword when-first] [bracket [[][variable a] [bracket [[][number 1] [number 2] [number 3][bracket ]]]]]",
-        "  [variable a][bracket )]"
-    );
-
-    MT("should indent when-let",
-        "[bracket (][keyword when-let] [bracket [[][variable x] [variable foo][bracket ]]]",
-        "  [string \"foo\"]"
-    );
-
-    MT("should indent when-some",
-        "[bracket (][keyword when-some] [bracket [[][variable x] [variable foo][bracket ]]]",
-        "  [string \"foo\"]"
-    );
-
-    MT("should indent struct-map",
-        "[bracket (][keyword struct-map] [variable foo]",
-        "  [atom :1] [string \"one\"]",
-        "  [atom :2] [string \"two\"][bracket )]"
-    );
-
-    MT("should indent defprotocol",
-        "[bracket (][keyword defprotocol] [variable Protocol]",
-        "  [bracket (][builtin foo] [bracket [[][variable this][bracket ]])]",
-        "  [bracket (][builtin bar] [bracket [[][variable this][bracket ]]] [bracket [[][variable this] [variable x][bracket ]])]",
-        "  [bracket (][builtin baz] [bracket [[][variable this][bracket ]]]",
-        "       [bracket [[][variable this] [variable y][bracket ]]))]"
-    );
-
-    MT("should indent defrecord",
-        "[bracket (][keyword defrecord] [variable Person] [bracket [[][variable first-name] [variable last-name] [variable address][bracket ]])]",
-        "",
-        "[bracket (][keyword defrecord] [variable Person] [bracket [[][variable first-name] [variable last-name] [variable address][bracket ]]]",
-        "  [variable Protocol]",
-        "  [bracket (][builtin foo] [bracket [[][variable this][bracket ]]] [variable first-name][bracket )]",
-        "  [bracket (][builtin bar] [bracket [[][variable this][bracket ]]] [variable last-name][bracket )]",
-        "  [bracket (][builtin baz] [bracket [[][variable this] [variable y][bracket ]]] [bracket (][keyword str] [variable first-name] [variable last-name][bracket )))]",
-        "",
-        "[bracket (][keyword defrecord] [variable Person] [bracket [[][variable first-name]",
-        "                   [variable last-name]",
-        "                   [variable address][bracket ]])]",
-        "",
-        "[bracket (][keyword defrecord] [variable Person]",
-        "  [bracket [[][variable first-name]",
-        "   [variable last-name]",
-        "   [variable address][bracket ]])]"
-    );
-
-    MT("should indent deftype",
-        "[bracket (][keyword deftype] [variable Person] [bracket [[][variable first-name] [variable last-name] [variable address][bracket ]])]",
-        "",
-        "[bracket (][keyword deftype] [variable Person] [bracket [[][variable first-name] [variable last-name] [variable address][bracket ]]]",
-        "  [variable Protocol]",
-        "  [bracket (][builtin foo] [bracket [[][variable this][bracket ]]] [variable first-name][bracket )]",
-        "  [bracket (][builtin bar] [bracket [[][variable this][bracket ]]] [variable last-name][bracket )]",
-        "  [bracket (][builtin baz] [bracket [[][variable this] [variable y][bracket ]]] [bracket (][keyword str] [variable first-name] [variable last-name][bracket )))]",
-        "",
-        "[bracket (][keyword deftype] [variable Person] [bracket [[][variable first-name]",
-        "                 [variable last-name]",
-        "                 [variable address][bracket ]])]",
-        "",
-        "[bracket (][keyword deftype] [variable Person]",
-        "  [bracket [[][variable first-name]",
-        "   [variable last-name]",
-        "   [variable address][bracket ]])]"
-    );
-
-    MT("should indent do",
-        "[bracket (][keyword do] [bracket (][builtin foo][bracket )]",
-        "  [bracket (][builtin bar][bracket ))]",
-        "",
-        "[bracket (][keyword do]",
-        "  [bracket (][builtin foo][bracket )]",
-        "  [bracket (][builtin bar][bracket ))]"
-    );
-
-    MT("should indent doto",
-        "[bracket (][keyword doto] [bracket (][keyword new] [variable java.util.HashMap][bracket )] [bracket (][builtin .put] [string \"a\"] [number 1][bracket )] [bracket (][builtin .put] [string \"b\"] [number 2][bracket ))]",
-        "",
-        "[bracket (][keyword doto] [bracket (][builtin java.util.HashMap.][bracket )]",
-        "  [bracket (][builtin .put] [string \"a\"] [number 1][bracket )]",
-        "  [bracket (][builtin .put] [string \"b\"] [number 2][bracket ))]"
-    );
-
-    MT("should indent extend",
-        "[bracket (][keyword extend] [variable FooType]",
-        "  [variable FooProtocol]",
-        "  [bracket {][atom :foo] [variable an-existing-fn]",
-        "   [atom :bar] [bracket (][keyword fn] [bracket [[][variable a] [variable b][bracket ]]]",
-        "          [bracket (][builtin f] [variable a] [variable b][bracket ))]",
-        "   [atom :baz] [bracket (][keyword fn] [bracket ([[][variable a][bracket ]]] [variable a][bracket )]",
-        "          [bracket ([[][variable a] [variable b][bracket ]]] [bracket [[][variable a] [variable b][bracket ]]))})]"
-    );
-
-    MT("should indent extend-protocol",
-        "[bracket (][keyword extend-protocol] [variable Protocol]",
-        "  [variable FooType]",
-        "  [bracket (][builtin foo] [bracket [[][variable x][bracket ]]] [bracket (][builtin f] [variable x][bracket ))]",
-        "  [bracket (][builtin bar] [bracket [[][variable x] [variable y][bracket ]]] [bracket (][builtin g] [variable x] [variable y][bracket ))]"
-    );
-
-    MT("should indent extend-type",
-        "[bracket (][keyword extend-type] [variable FooType]",
-        "  [variable Countable]",
-        "  [bracket (][builtin cnt] [bracket [][variable c][bracket ]]] [bracket (][keyword count] [variable c][bracket ))]",
-        "  ",
-        "  [variable Foo]",
-        "  [bracket (][builtin bar] [bracket [[][variable x] [variable y][bracket ]]] [bracket (][builtin f] [variable x] [variable y][bracket ))]",
-        "  [bracket (][builtin baz] [bracket ([][variable x] [variable x][bracket ]])] [bracket ([[][variable x] [variable y] [variable &] [variable zs][bracket ]]] [bracket [[][variable x] [variable y] [bracket (][builtin g] [variable zs][bracket )]])))]"
-    );
-
-    MT("should indent fn",
-        "[bracket (][keyword fn] [variable foo]",
-        "  [bracket [[][variable x][bracket ]]]",
-        "  [bracket (][builtin bar] [variable x][bracket ))]",
-        "",
-        "[bracket (][keyword fn] [variable foo] [bracket [[][variable x][bracket ]]]",
-        "  [bracket (][builtin bar] [variable x][bracket ))]"
-    );
-
-    MT("should indent future",
-        "[bracket (][keyword future] [bracket (][builtin Thread/sleep] [number 10000][bracket )] [bracket (][keyword println] [string \"done\"][bracket )] [number 100][bracket )]",
-        "",
-        "[bracket (][keyword future] [bracket (][builtin Thread/sleep] [number 10000][bracket )]",
-        "  [bracket (][keyword println] [string \"done\"][bracket )]",
-        "  [number 100][bracket )]",
-        "",
-        "[bracket (][keyword future]",
-        "  [bracket (][builtin Thread/sleep] [number 10000][bracket )]",
-        "  [bracket (][keyword println] [string \"done\"][bracket )]",
-        "  [number 100][bracket )]"
-    );
-
-    MT("should indent if",
-        "[bracket (][keyword if] [bracket (][keyword <] [variable foo] [number 100][bracket )] [string \"yes\"] [string \"no\"][bracket )]",
-        "",
-        "[bracket (][keyword if] [bracket (][keyword <] [variable foo] [number 100][bracket )]",
-        "  [string \"yes\"]",
-        "  [string \"no\"][bracket )]",
-        "",
-        "[bracket (][keyword if] [bracket (][keyword and] [bracket (][keyword <] [variable foo] [number 100][bracket )]",
-        "         [bracket (][keyword <] [variable bar] [number 50][bracket ))]",
-        "  [string \"yes\"]",
-        "  [string \"no\"][bracket )]"
-    );
-
-    MT("should indent if-not",
-        "[bracket (][keyword if-not] [bracket (][keyword <] [variable foo] [number 100][bracket )] [string \"yes\"] [string \"no\"][bracket )]",
-        "",
-        "[bracket (][keyword if-not] [bracket (][keyword <] [variable foo] [number 100][bracket )]",
-        "  [string \"yes\"]",
-        "  [string \"no\"][bracket )]",
-        "",
-        "[bracket (][keyword if-not] [bracket (][keyword and] [bracket (][keyword <] [variable foo] [number 100][bracket )]",
-        "             [bracket (][keyword <] [variable bar] [number 50][bracket ))]",
-        "  [string \"yes\"]",
-        "  [string \"no\"][bracket )]"
-    );
-
-    MT("should indent locking",
-        "[bracket (][keyword locking] [variable foo] [bracket (][builtin Thread/sleep] [number 1000][bracket )] [bracket (][keyword println] [string \"done\"][bracket ))]",
-        "",
-        "[bracket (][keyword locking] [variable foo]",
-        "  [bracket (][builtin Thread/sleep] [number 1000][bracket )]",
-        "  [bracket (][keyword println] [string \"done\"][bracket ))]"
-    );
-
-    MT("should indent ns",
-        "[bracket (][keyword ns] [variable foo.bar]",
-        "  [bracket (][atom :refer-clojure] [atom :exclude] [bracket [][keyword ancestors] [keyword printf][bracket ]])]",
-        "  [bracket (][atom :require] [bracket [][variable clojure.contrib] [variable sql] [variable combinatorics][bracket ]])]",
-        "  [bracket (][atom :use] [bracket [][variable my.lib] [variable this] [variable that][bracket ]])]",
-        "  [bracket (][atom :import] [bracket (][builtin java.util] [variable Date] [variable Timer] [variable Random][bracket )]",
-        "           [bracket (][builtin java.sql] [variable Connection] [variable Statement][bracket )))]"
-    );
-
-    MT("should indent proxy",
-        "[bracket (][keyword proxy] [bracket [][variable MouseAdapter][bracket ]]] [bracket [[]]]",
-        "  [bracket (][builtin mousePressed] [bracket [][variable event][bracket ]]]",
-        "                [bracket (][keyword apply] [variable f] [variable event] [variable args][bracket )))]"
-    );
-
-    MT("should indent reify",
-        "[bracket (][keyword reify] [variable Foo]",
-        "  [bracket (][builtin foo] [bracket [[][variable _] [variable x][bracket ]]] [variable x][bracket )]",
-        "  [bracket (][builtin foo] [bracket [[][variable _] [variable x] [variable y][bracket ]]] [variable y][bracket ))]"
-    );
-
-    MT("should indent try",
-        "[bracket (][keyword try]",
-        "  [bracket (][keyword /] [number 1] [number 0][bracket )]",
-        "  [bracket (][keyword catch] [variable Exception] [variable e] [bracket (][keyword str] [string \"caught exception: \"] [bracket (][builtin .getMessage] [variable e][bracket ))))]"
-    );
-
-    MT("should indent with-open",
-        "[bracket (][keyword with-open] [bracket [[][variable out-data] [bracket (][builtin io/writer] [variable out-file][bracket )]]]",
-        "  [bracket (][builtin csv/write-csv] [variable out-data] [variable out-sos][bracket )))]"
-    );
-
-    MT("should indent with-precision",
-        "[bracket (][keyword with-precision] [number 10] [bracket (][keyword /] [number 1M] [number 3][bracket ))]",
-        "",
-        "[bracket (][keyword with-precision] [number 10] [atom :rounding] [variable HALF_DOWN] [bracket (][keyword /] [number 1M] [number 3][bracket ))]",
-        "",
-        "[bracket (][keyword with-precision]",
-        "  [number 10]",
-        "  [atom :rounding]",
-        "  [variable HALF_DOWN]",
-        "  [bracket (][keyword /] [number 1M] [number 3][bracket ))]"
-    );
-
-    MT("should indent when",
-        "[bracket (][keyword when] [bracket (][keyword <] [variable foo] [number 100][bracket )] [string \"yes\"][bracket )]",
-        "",
-        "[bracket (][keyword when] [bracket (][keyword <] [variable foo] [number 100][bracket )]",
-        "  [string \"yes\"][bracket )]",
-        "",
-        "[bracket (][keyword when] [bracket (][keyword and] [bracket (][keyword <] [variable foo] [number 100][bracket )]",
-        "           [bracket (][keyword <] [variable bar] [number 50][bracket ))]",
-        "  [string \"yes\"][bracket )]"
-    );
-
-    MT("should indent when-not",
-        "[bracket (][keyword when-not] [bracket (][keyword <] [variable foo] [number 100][bracket )] [string \"no\"][bracket )]",
-        "",
-        "[bracket (][keyword when-not] [bracket (][keyword <] [variable foo] [number 100][bracket )]",
-        "  [string \"no\"][bracket )]",
-        "",
-        "[bracket (][keyword when-not] [bracket (][keyword and] [bracket (][keyword <] [variable foo] [number 100][bracket )]",
-        "               [bracket (][keyword <] [variable bar] [number 50][bracket ))]",
-        "  [string \"no\"][bracket )]"
-    );
-
-    MT("should indent while",
-        "[bracket (][keyword while] [variable foo] [bracket (][keyword do] [bracket (][keyword println] [variable a][bracket )] [bracket (][keyword println] [variable b][bracket )))]",
-        "",
-        "[bracket (][keyword while] [variable foo]",
-        "  [bracket (][keyword do] [bracket (][keyword println] [variable a][bracket )]",
-        "    [bracket (][keyword println] [variable b][bracket )))]"
+    MT("should indent body argument of `comment` by `options.indentUnit` spaces",
+        "[bracket (][comment comment foo bar]",
+        "[comment  baz]",
+        "[comment  qux][bracket )]"
     );
 
     function typeTokenPairs(type, tokens) {

--- a/mode/clojure/test.js
+++ b/mode/clojure/test.js
@@ -650,12 +650,6 @@
         "    [bracket (][keyword println] [variable b][bracket )))]"
     );
 
-    MT("should indent deftest and similar forms that assume body parameter",
-        "[bracket (][builtin clojure.test/deftest] [variable foo-test]",
-        "  [bracket (][builtin testing] [string \"that foo should work\"]",
-        "           [bracket (][builtin is] [bracket (][keyword =] [atom :baz] [bracket (][builtin foo] [atom :bar][bracket )))))]"
-    );
-
     function typeTokenPairs(type, tokens) {
         return "[" + type + " " + tokens.join("] [" + type + " ") + "]";
     }

--- a/mode/clojure/test.js
+++ b/mode/clojure/test.js
@@ -650,6 +650,12 @@
         "    [bracket (][keyword println] [variable b][bracket )))]"
     );
 
+    MT("should indent deftest and similar forms that assume body parameter",
+        "[bracket (][builtin clojure.test/deftest] [variable foo-test]",
+        "  [bracket (][builtin testing] [string \"that foo should work\"]",
+        "           [bracket (][builtin is] [bracket (][keyword =] [atom :baz] [bracket (][builtin foo] [atom :bar][bracket )))))]"
+    );
+
     function typeTokenPairs(type, tokens) {
         return "[" + type + " " + tokens.join("] [" + type + " ") + "]";
     }

--- a/mode/clojure/test.js
+++ b/mode/clojure/test.js
@@ -276,7 +276,7 @@
         "  [atom nil][bracket }]"
     );
 
-    var formsThatHaveBodyParameter = [
+    var haveBodyParameter = [
         "binding", "bound-fn", "case", "catch", "cond", "cond->",
         "cond->>", "condp", "def", "definterface", "defmethod", "defn",
         "defmacro", "defprotocol", "defrecord", "defstruct", "deftype", "do",
@@ -296,7 +296,7 @@
         }
     }
 
-    testFormsThatHaveBodyParameter(formsThatHaveBodyParameter);
+    testFormsThatHaveBodyParameter(haveBodyParameter);
 
     MT("should indent body argument of `comment` by `options.indentUnit` spaces",
         "[bracket (][comment comment foo bar]",


### PR DESCRIPTION
This PR:
- reverts some of the previous code and uses `===` for equality checks.
- gets rid of the unreliable and sloppy regular expression-based heuristics for identifying forms that have body parameter and instead uses a purely whitelist-base approach.
- adds a few other forms that have body parameter to the indentation list.
- refactors the tests for forms that have body parameter.
