### PR TITLE
Scheme mode fixes: properly marks 'atoms and '(lists of s-exp)

### DIFF
--- a/mode/scheme/scheme.js
+++ b/mode/scheme/scheme.js
@@ -122,7 +122,7 @@ CodeMirror.defineMode("scheme", function () {
                         state.sExprComment = 0;
                     }else{
                         // if not we just comment the entire of the next token
-                        stream.eatWhile(/[^\s]/); // eat non spaces
+                        stream.eatWhile(/[^\s\(\)\[\]]/); // eat symbol atom
                         returnType = COMMENT;
                         break;
                     }

--- a/mode/scheme/scheme.js
+++ b/mode/scheme/scheme.js
@@ -134,10 +134,10 @@ CodeMirror.defineMode("scheme", function () {
                         returnType = STRING;
 
                     } else if (ch == "'") {
-			if (stream.peek() == "(" || stream.peek() == "["){
+                        if (stream.peek() == "(" || stream.peek() == "["){
                             if (typeof state.sExprQuote != "number") {
-				state.sExprQuote = 0;
-			    } // else already in a quoted expression
+                                state.sExprQuote = 0;
+                            } // else already in a quoted expression
                             returnType = ATOM;
                         } else {
                             stream.eatWhile(/[\w_\-!$%&*+\.\/:<=>?@\^~]/);

--- a/mode/scheme/scheme.js
+++ b/mode/scheme/scheme.js
@@ -73,7 +73,8 @@ CodeMirror.defineMode("scheme", function () {
                 indentStack: null,
                 indentation: 0,
                 mode: false,
-                sExprComment: false
+                sExprComment: false,
+                sExprQuote: false
             };
         },
 
@@ -121,7 +122,7 @@ CodeMirror.defineMode("scheme", function () {
                         state.sExprComment = 0;
                     }else{
                         // if not we just comment the entire of the next token
-                        stream.eatWhile(/[^/s]/); // eat non spaces
+                        stream.eatWhile(/[^\s]/); // eat non spaces
                         returnType = COMMENT;
                         break;
                     }
@@ -133,7 +134,15 @@ CodeMirror.defineMode("scheme", function () {
                         returnType = STRING;
 
                     } else if (ch == "'") {
-                        returnType = ATOM;
+			if (stream.peek() == "(" || stream.peek() == "["){
+                            if (typeof state.sExprQuote != "number") {
+				state.sExprQuote = 0;
+			    } // else already in a quoted expression
+                            returnType = ATOM;
+                        } else {
+                            stream.eatWhile(/[\w_\-!$%&*+\.\/:<=>?@\^~]/);
+                            returnType = ATOM;
+                        }
                     } else if (ch == '#') {
                         if (stream.eat("|")) {                    // Multi-line comment
                             state.mode = "comment"; // toggle to comment mode
@@ -209,6 +218,7 @@ CodeMirror.defineMode("scheme", function () {
                         stream.backUp(stream.current().length - 1); // undo all the eating
 
                         if(typeof state.sExprComment == "number") state.sExprComment++;
+                        if(typeof state.sExprQuote == "number") state.sExprQuote++;
 
                         returnType = BRACKET;
                     } else if (ch == ")" || ch == "]") {
@@ -222,6 +232,12 @@ CodeMirror.defineMode("scheme", function () {
                                     state.sExprComment = false; // turn off s-expr commenting mode
                                 }
                             }
+                            if(typeof state.sExprQuote == "number"){
+                                if(--state.sExprQuote == 0){
+                                    returnType = ATOM; // final closing bracket
+                                    state.sExprQuote = false; // turn off s-expr quote mode
+                                }
+                            }
                         }
                     } else {
                         stream.eatWhile(/[\w_\-!$%&*+\.\/:<=>?@\^~]/);
@@ -231,7 +247,7 @@ CodeMirror.defineMode("scheme", function () {
                         } else returnType = "variable";
                     }
             }
-            return (typeof state.sExprComment == "number") ? COMMENT : returnType;
+            return (typeof state.sExprComment == "number") ? COMMENT : ((typeof state.sExprQuote == "number") ? ATOM : returnType);
         },
 
         indent: function (state) {


### PR DESCRIPTION
Also fixes `#;` comments

Fixes https://github.com/codemirror/CodeMirror/issues/5574