### PR TITLE
Update colour contrast of commented code

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -126,7 +126,7 @@
 .cm-s-default .cm-operator {}
 .cm-s-default .cm-variable-2 {color: #05a;}
 .cm-s-default .cm-variable-3, .cm-s-default .cm-type {color: #085;}
-.cm-s-default .cm-comment {color: #a50;}
+.cm-s-default .cm-comment {color: #6b7884;}
 .cm-s-default .cm-string {color: #a11;}
 .cm-s-default .cm-string-2 {color: #f50;}
 .cm-s-default .cm-meta {color: #555;}


### PR DESCRIPTION
Update colour contrast of commented code
The current contrast is 3.49:1, which is below the minimum 4.5 ratio needed to meet the WCAG AA guidelines. The proposed change increases the contrast to 4.52:1

Example of how new contract looks
![image](https://user-images.githubusercontent.com/9624541/45918070-28d26f00-be79-11e8-8d49-74ba2693863d.png)
