### PR TITLE
Add `module` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "codemirror",
   "version": "5.40.3",
   "main": "lib/codemirror.js",
+  "module": "src/codemirror.js",
   "style": "lib/codemirror.css",
   "description": "Full-featured in-browser code editor",
   "license": "MIT",


### PR DESCRIPTION
It looks like you may have already qualified all of your imports and are using no external dependencies so I guess there is no need at this point for a separate Rollup `dist` build to provide support for direct use of ES6 Modules... (If you decided to change that, Rollup does allow an "es" `format` export which lets you roll up files, use plugins that are aware of `node_modules`, etc., yet still export as ES6 Modules.)

However, for the sake of bundlers finding the main ES6 Modules entry file, this PR adds a `module` field to `package.json` (see https://stackoverflow.com/a/42817320/271577 ) pointing at what appears to be an already ready-for-browser, ES6 Modules distributable file entrance point...