### PR TITLE
package.json/dependency updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /npm-debug.log
+/package-lock.json
 /test*.html
 .tern-*
 *~

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "5.40.3",
   "main": "lib/codemirror.js",
   "style": "lib/codemirror.css",
+  "author": {
+    "name": "Marijn Haverbeke",
+    "email": "marijnh@gmail.com",
+    "url": "http://marijnhaverbeke.nl"
+  },
   "description": "Full-featured in-browser code editor",
   "license": "MIT",
   "directories": {
@@ -17,11 +22,11 @@
   },
   "devDependencies": {
     "blint": "^1",
-    "node-static": "0.6.0",
+    "node-static": "0.7.11",
     "phantomjs-prebuilt": "^2.1.12",
-    "rollup": "^0.41.0",
-    "rollup-plugin-buble": "^0.15.0",
-    "rollup-watch": "^3.2.0"
+    "rollup": "^0.66.2",
+    "rollup-plugin-buble": "^0.19.2",
+    "rollup-watch": "^4.3.1"
   },
   "bugs": "http://github.com/codemirror/CodeMirror/issues",
   "keywords": [
@@ -30,13 +35,6 @@
     "Editor"
   ],
   "homepage": "https://codemirror.net",
-  "maintainers": [
-    {
-      "name": "Marijn Haverbeke",
-      "email": "marijnh@gmail.com",
-      "web": "http://marijnhaverbeke.nl"
-    }
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/codemirror/CodeMirror.git"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,9 @@
 import buble from 'rollup-plugin-buble';
 
 export default {
-  banner: `// CodeMirror, copyright (c) by Marijn Haverbeke and others
+  input: "src/codemirror.js",
+  output: {
+    banner: `// CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
 
 // This is CodeMirror (https://codemirror.net), a code editor
@@ -9,10 +11,10 @@ export default {
 //
 // You can find some technical background for some of the code below
 // at http://marijnhaverbeke.nl/blog/#cm-internals .
-`,
-  entry: "src/codemirror.js",
-  format: "umd",
-  dest: "lib/codemirror.js",
-  moduleName: "CodeMirror",
+  `,
+    format: "umd",
+    file: "lib/codemirror.js",
+    name: "CodeMirror"
+  },
   plugins: [ buble({namedFunctionExpressions: false}) ]
 };


### PR DESCRIPTION
- ~Enhancement: Add ES6 Module distributed file to build process; add minified files with terser and add source map files~
- ~Enhancement: For ESM bundlers, point to new distributed ESM entrance file as `module` in `package.json`~
- Refactoring: ~Switch from Buble to Babel 7 with preset-env (Buble was breaking on array destructuring) and~ update to latest Rollup API
- npm: Update node-static, Rollup deps; add npm-recommended `package-lock.json` ~and `package.json` linting recommended~ meta-data field[s]

Let me know if you need further clarification on any of these. Btw, I put the new ES distribution inside of `dist`. I could put it in `lib` also, but `dist` seemed more clear to me (though if it weren't backward-breaking, I'd think all of `lib` should be moved to `dist`). Let me know if you'd like it elsewhere.