### PR TITLE
[mscgen mode] Add new keywords for xù and msgenny

### DIFF
--- a/mode/mscgen/mscgen.js
+++ b/mode/mscgen/mscgen.js
@@ -33,9 +33,9 @@
     },
     xu: {
       "keywords" : ["msc", "xu"],
-      "options" : ["hscale", "width", "arcgradient", "wordwraparcs", "watermark"],
+      "options" : ["hscale", "width", "arcgradient", "wordwraparcs", "wordwrapentities", "watermark"],
       "constants" : ["true", "false", "on", "off", "auto"],
-      "attributes" : ["label", "idurl", "id", "url", "linecolor", "linecolour", "textcolor", "textcolour", "textbgcolor", "textbgcolour", "arclinecolor", "arclinecolour", "arctextcolor", "arctextcolour", "arctextbgcolor", "arctextbgcolour", "arcskip"],
+      "attributes" : ["label", "idurl", "id", "url", "linecolor", "linecolour", "textcolor", "textcolour", "textbgcolor", "textbgcolour", "arclinecolor", "arclinecolour", "arctextcolor", "arctextcolour", "arctextbgcolor", "arctextbgcolour", "arcskip", "title", "deactivate", "activate", "activation"],
       "brackets" : ["\\{", "\\}"],  // [ and  ] are brackets too, but these get handled in with lists
       "arcsWords" : ["note", "abox", "rbox", "box", "alt", "else", "opt", "break", "par", "seq", "strict", "neg", "critical", "ignore", "consider", "assert", "loop", "ref", "exc"],
       "arcsOthers" : ["\\|\\|\\|", "\\.\\.\\.", "---", "--", "<->", "==", "<<=>>", "<=>", "\\.\\.", "<<>>", "::", "<:>", "->", "=>>", "=>", ">>", ":>", "<-", "<<=", "<=", "<<", "<:", "x-", "-x"],
@@ -44,7 +44,7 @@
     },
     msgenny: {
       "keywords" : null,
-      "options" : ["hscale", "width", "arcgradient", "wordwraparcs", "watermark"],
+      "options" : ["hscale", "width", "arcgradient", "wordwraparcs", "wordwrapentities", "watermark"],
       "constants" : ["true", "false", "on", "off", "auto"],
       "attributes" : null,
       "brackets" : ["\\{", "\\}"],

--- a/mode/mscgen/mscgen_test.js
+++ b/mode/mscgen/mscgen_test.js
@@ -25,7 +25,8 @@
   );
 
   MT("xù/ msgenny keywords classify as 'base'",
-    "[base watermark wordwrapentities]",
+    "[base watermark]",
+    "[base wordwrapentities]",
     "[base alt loop opt ref else break par seq assert]"
   );
 

--- a/mode/mscgen/mscgen_test.js
+++ b/mode/mscgen/mscgen_test.js
@@ -25,7 +25,7 @@
   );
 
   MT("xù/ msgenny keywords classify as 'base'",
-    "[base watermark]",
+    "[base watermark wordwrapentities]",
     "[base alt loop opt ref else break par seq assert]"
   );
 

--- a/mode/mscgen/msgenny_test.js
+++ b/mode/mscgen/msgenny_test.js
@@ -20,6 +20,7 @@
 
   MT("xù/ msgenny keywords classify as 'keyword'",
     "[keyword watermark]",
+    "[keyword wordwrapentities]",
     "[keyword alt]","[keyword loop]","[keyword opt]","[keyword ref]","[keyword else]","[keyword break]","[keyword par]","[keyword seq]","[keyword assert]"
   );
 

--- a/mode/mscgen/xu_test.js
+++ b/mode/mscgen/xu_test.js
@@ -60,7 +60,8 @@
     "[attribute id]","[attribute url]","[attribute idurl]",
     "[attribute linecolor]","[attribute linecolour]","[attribute textcolor]","[attribute textcolour]","[attribute textbgcolor]","[attribute textbgcolour]",
     "[attribute arclinecolor]","[attribute arclinecolour]","[attribute arctextcolor]","[attribute arctextcolour]","[attribute arctextbgcolor]","[attribute arctextbgcolour]",
-    "[attribute arcskip][bracket ]]]"
+    "[attribute arcskip]","[attribute title]",
+    "[attribute activate]","[attribute deactivate]","[attribute activation][bracket ]]]"
   );
 
   MT("outside an attribute list, attributes classify as base",
@@ -68,7 +69,7 @@
     "[base id]","[base url]","[base idurl]",
     "[base linecolor]","[base linecolour]","[base textcolor]","[base textcolour]","[base textbgcolor]","[base textbgcolour]",
     "[base arclinecolor]","[base arclinecolour]","[base arctextcolor]","[base arctextcolour]","[base arctextbgcolor]","[base arctextbgcolour]",
-    "[base arcskip]"
+    "[base arcskip]", "[base title]"
   );
 
   MT("a typical program",
@@ -79,7 +80,7 @@
     "[base   b][bracket [[][attribute label][operator =][string \"Entity B\"][bracket ]]][base ,]",
     "[base   c][bracket [[][attribute label][operator =][string \"Entity C\"][bracket ]]][base ;]",
     "[base   a ][keyword =>>][base  b][bracket [[][attribute label][operator =][string \"Hello entity B\"][bracket ]]][base ;]",
-    "[base   a ][keyword <<][base  b][bracket [[][attribute label][operator =][string \"Here's an answer dude!\"][bracket ]]][base ;]",
+    "[base   a ][keyword <<][base  b][bracket [[][attribute label][operator =][string \"Here's an answer dude!\"][base , ][attribute title][operator =][string \"This is a title for this message\"][bracket ]]][base ;]",
     "[base   c ][keyword :>][base  *][bracket [[][attribute label][operator =][string \"What about me?\"][base , ][attribute textcolor][operator =][base red][bracket ]]][base ;]",
     "[bracket }]"
   );


### PR DESCRIPTION
- The xù and msgenny mini-languages grew a new option keyword
- Xù grew some new attribute keywords (one a while ago, three very recently)

This PR adds these to the mscgen _mode_ in which xù and msgenny are defined. 