### PR TITLE
Add a non-recursive map command to the Vim API

### DIFF
--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -4245,7 +4245,6 @@ testVim('ex_unmap_api', function(cm, vim, helpers) {
   CodeMirror.Vim.unmap("<Alt-X>", "normal");
   is(!CodeMirror.Vim.handleKey(cm, "<Alt-X>", "normal"), "Alt-X key is unmapped");
 });
-
 // Testing registration of functions as ex-commands and mapping to <Key>-keys
 testVim('ex_api_test', function(cm, vim, helpers) {
   var res=false;
@@ -4267,6 +4266,30 @@ testVim('ex_map_key2key_from_colon', function(cm, vim, helpers) {
   helpers.assertCursorAt(0, 0);
   eq('bc', cm.getValue());
 }, { value: 'abc' });
+
+testVim('noremap', function(cm, vim, helpers) {
+  CodeMirror.Vim.noremap(';', 'l');
+  cm.setCursor(0, 0);
+  eq('wOrd1', cm.getValue());
+  // Mapping should work in normal mode.
+  helpers.doKeys(';', 'r', '1');
+  eq('w1rd1', cm.getValue());
+  // Mapping will not work in insert mode because of no current fallback
+  // keyToKey mapping support.
+  helpers.doKeys('i', ';', '<Esc>');
+  eq('w;1rd1', cm.getValue());
+}, { value: 'wOrd1' });
+testVim('noremap_swap', function(cm, vim, helpers) {
+  CodeMirror.Vim.noremap('i', 'a', 'normal');
+  CodeMirror.Vim.noremap('a', 'i', 'normal');
+  cm.setCursor(0, 0);
+  // 'a' should act like 'i'.
+  helpers.doKeys('a');
+  eqCursorPos(Pos(0, 0), cm.getCursor());
+  // ...and 'i' should act like 'a'.
+  helpers.doKeys('<Esc>', 'i');
+  eqCursorPos(Pos(0, 1), cm.getCursor());
+}, { value: 'foo' });
 
 // Test event handlers
 testVim('beforeSelectionChange', function(cm, vim, helpers) {


### PR DESCRIPTION
This will allow for more powerful mapping capabilities like arbitrary command
remapping, rebinding the home row, etc.

This doesn't quite match Vim's non-recursive behavior because there's no support
for non-recursive keyToKey mappings. Without this support, we'd just be creating
normal, recursive keyToKey mappings which I think would be even more frustrating
and/or surprising (e.g. two inverse non-recursive maps would cause infinite recursion).
Once this support is added for this, though, it will be trivial to create these mappings
at the end of the added function and achieve the most accurate behavior.

One potential paper cut with this implementation is that multiple calls to `unmap` may
be required to fully remove the `noremap`ed values. I think this isn't that severe though
because this looks to be the current behavior with all other `map` operations.