### PR TITLE
Fix comments for d lang mode

### DIFF
--- a/mode/d/d.js
+++ b/mode/d/d.js
@@ -182,7 +182,12 @@ CodeMirror.defineMode("d", function(config, parserConfig) {
       else return ctx.indented + (closing ? 0 : indentUnit);
     },
 
-    electricChars: "{}"
+    electricChars: "{}",
+    blockCommentStart: "/*",
+    blockCommentEnd: "*/",
+    blockCommentContinue: " * ",
+    lineComment: "//",
+    fold: "brace"
   };
 });
 


### PR DESCRIPTION
Comments are not working for d lang. I tried with following snippet
```
editor.execCommand('selectAll');
editor.toggleComment()
```

I checked and tested that for d lang mode 
`options.lineComment || mode.lineComment are undefined `
