### PR TITLE
WIP: Support string templates in Kotlin mode

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -583,14 +583,39 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
         if (!tripleString && !escaped && stream.match('"') ) {end = true; break;}
         if (tripleString && stream.match('"""')) {end = true; break;}
         next = stream.next();
-        if(!escaped && next == "$" && stream.match('{'))
+        if(!escaped && next == "$" && stream.match('{')){
           stream.skipTo("}");
+          state.tokenize = tokenBaseUntilBrace(stream, state);
+          return state.tokenize(stream, state);
+        }
         escaped = !escaped && next == "\\" && !tripleString;
       }
       if (end || !tripleString)
         state.tokenize = null;
       return "string";
     }
+  }
+
+  function tokenBaseUntilBrace() {
+    var depth = 1;
+    function t(stream, state) {
+      if (stream.peek() == "}") {
+        depth--;
+        if (depth == 0) {
+          //TODO:
+          //state.tokenize.pop();
+          //return state.tokenize[state.tokenize.length-1](stream, state);
+          return state.tokenize(stream, state);
+        }
+      } else if (stream.peek() == "{") {
+        depth++;
+      }
+      //TODO:
+      //return tokenBase(stream, state);
+      return state.tokenize(stream, state);
+    }
+    t.isBase = true;
+    return t;
   }
 
   def("text/x-kotlin", {


### PR DESCRIPTION
Hello @marijnh !

Kotlin is supported [string templates](https://kotlinlang.org/docs/reference/basic-types.html#string-templates). A template expression starts with a dollar sign ($) and consists of either a simple name:
<img width="360" alt="screen shot 2018-10-08 at 3 18 40 pm" src="https://user-images.githubusercontent.com/10503748/46608570-e31ad500-cb0d-11e8-8d9d-aab18295ab00.png">

Now in kotlin mode we have plain string. I notice the gradle mode supports string templates.

I tried to use the same logic to kotlin mode.
Unfortunately, I do not know the codemirror API.

I would be happy if you give some advice or help with string templates in kotlin mode.
Probably it's actual in C# mode too.

Thanks!