### PR TITLE
Add isRemote to replaceRange to apply remote changes

### DIFF
--- a/src/model/Doc.js
+++ b/src/model/Doc.js
@@ -78,10 +78,10 @@ Doc.prototype = createObj(BranchChunk.prototype, {
     if (this.cm) scrollToCoords(this.cm, 0, 0)
     setSelection(this, simpleSelection(top), sel_dontScroll)
   }),
-  replaceRange: function(code, from, to, origin) {
+  replaceRange: function(code, from, to, origin, isRemote) {
     from = clipPos(this, from)
     to = to ? clipPos(this, to) : from
-    replaceRange(this, code, from, to, origin)
+    replaceRange(this, code, from, to, origin, isRemote)
   },
   getRange: function(from, to, lineSep) {
     let lines = getBetween(this, clipPos(this, from), clipPos(this, to))

--- a/src/model/change_measurement.js
+++ b/src/model/change_measurement.js
@@ -13,7 +13,8 @@ export function changeEnd(change) {
 
 // Adjust a position to refer to the post-change position of the
 // same text, or the end of the change if the change covers it.
-function adjustForChange(pos, change) {
+function adjustForChange(pos, change, isRemote) {
+  if (isRemote && cmp(pos, change.from) == 0) return pos
   if (cmp(pos, change.from) < 0) return pos
   if (cmp(pos, change.to) <= 0) return changeEnd(change)
 
@@ -22,12 +23,12 @@ function adjustForChange(pos, change) {
   return Pos(line, ch)
 }
 
-export function computeSelAfterChange(doc, change) {
+export function computeSelAfterChange(doc, change, isRemote) {
   let out = []
   for (let i = 0; i < doc.sel.ranges.length; i++) {
     let range = doc.sel.ranges[i]
-    out.push(new Range(adjustForChange(range.anchor, change),
-                       adjustForChange(range.head, change)))
+    out.push(new Range(adjustForChange(range.anchor, change, isRemote),
+                       adjustForChange(range.head, change, isRemote)))
   }
   return normalizeSelection(doc.cm, out, doc.sel.primIndex)
 }

--- a/test/multi_test.js
+++ b/test/multi_test.js
@@ -292,4 +292,36 @@
     cm.extendSelections([Pos(0, 3), Pos(0, 4)])
     hasSelections(cm, 0, 0, 0, 4)
   }, {selectionsMayTouch: true, value: "1234"})
+
+  testCM("replaceRangeLocal", function(cm) {
+    select(cm, Pos(0, 2), Pos(0, 2));
+
+    cm.replaceRange('x', Pos(0, 3));
+    eq(cm.getValue(), "123x4");
+    hasCursors(cm, 0, 2);
+
+    cm.replaceRange('x', Pos(0, 2));
+    eq(cm.getValue(), "12x3x4");
+    hasCursors(cm, 0, 3);
+
+    cm.replaceRange('x', Pos(0, 0));
+    eq(cm.getValue(), "x12x3x4");
+    hasCursors(cm, 0, 4);
+  }, {value: "1234"});
+
+  testCM("replaceRangeRemote", function(cm) {
+    select(cm, Pos(0, 2), Pos(0, 2));
+
+    cm.replaceRange('x', Pos(0, 3), Pos(0, 3), 'remote', true);
+    eq(cm.getValue(), "123x4");
+    hasCursors(cm, 0, 2);
+
+    cm.replaceRange('x', Pos(0, 2), Pos(0, 2), 'remote', true);
+    eq(cm.getValue(), "12x3x4");
+    hasCursors(cm, 0, 2);
+
+    cm.replaceRange('x', Pos(0, 0), Pos(0, 0), 'remote', true);
+    eq(cm.getValue(), "x12x3x4");
+    hasCursors(cm, 0, 3);
+  }, {value: "1234"});
 })();


### PR DESCRIPTION
First of all, thank you for your wonderful work.

I recently used `cm.replaceRange` to apply remote changes to the local editor while building the group editor with CRDT. `cm.replaceRange` works well in most cases, but when a remote change inserts text at the same location of local cursor, I notice that it moves the cursor like the local action.

http://recordit.co/I63LH3efd9

I'm not sure this is right way, but I added isRemote parameter to replaceRange and processed them differently.

https://github.com/codemirror/CodeMirror/compare/master...hackerwins:replace-range-on-remote-change?expand=1#diff-54bc1a87df59cc68a1005071201142a3R312

Please let me know if there is a better way.
Thank you.