### PR TITLE
Change Google Inc. to Google LLC

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -179,6 +179,7 @@ darealshinji
 Darius Roberts
 databricks-david-lewis
 Dave Brondsema
+Dave MacLachlan
 Dave Myers
 David Barnett
 David H. Bronke
@@ -258,7 +259,7 @@ Glenn Jorde
 Glenn Ruehle
 goldsmcb
 Golevka
-Google Inc.
+Google LLC
 Gordon Smith
 Grant Skinner
 greengiant

--- a/bin/authors.sh
+++ b/bin/authors.sh
@@ -2,5 +2,5 @@
 tail --lines=+3 AUTHORS > AUTHORS.tmp
 git log --format='%aN' | grep -v "Piët Delport" >> AUTHORS.tmp
 echo -e "List of CodeMirror contributors. Updated before every release.\n" > AUTHORS
-sort -u AUTHORS.tmp >> AUTHORS
+sort -u AUTHORS.tmp | sed 's/Google Inc\./Google LLC/' >> AUTHORS
 rm -f AUTHORS.tmp


### PR DESCRIPTION
(and added myself)

The main change here is to make sure that Google Inc. gets changed over to Google LLC (our proper name now).