### PR TITLE
Update darcula.css

### DIFF
--- a/theme/darcula.css
+++ b/theme/darcula.css
@@ -1,46 +1,51 @@
 /**
-    Name:       IntelliJ IDEA darcula theme
+    Name: IntelliJ IDEA darcula theme
     From IntelliJ IDEA by JetBrains
  */
 
+.cm-s-darcula  { font-family: Consolas, Menlo, Monaco, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Courier New', monospace, serif;}
+.cm-s-darcula.CodeMirror { background: #2B2B2B; color: #A9B7C6; } 
+
 .cm-s-darcula span.cm-meta { color: #BBB529; }
 .cm-s-darcula span.cm-number { color: #6897BB; }
-.cm-s-darcula span.cm-keyword { line-height: 1em; font-weight: bold; color: #CC7832; }
-.cm-s-darcula span.cm-def { color: #FFC66D; }
+.cm-s-darcula span.cm-keyword { color: #CC7832; line-height: 1em; font-weight: bold; }  
+.cm-s-darcula span.cm-def { color: #A9B7C6; font-style: italic; }
 .cm-s-darcula span.cm-variable { color: #A9B7C6; }
 .cm-s-darcula span.cm-variable-2 { color: #A9B7C6; }
-.cm-s-darcula span.cm-variable-3, .cm-s-darcula span.cm-type { color: #A9B7C6; }
-.cm-s-darcula span.cm-property { color: #A9B7C6; }
+.cm-s-darcula span.cm-variable-3 { color: #9876AA; }
+.cm-s-darcula span.cm-type { color: #AABBCC; font-weight: bold; }
+.cm-s-darcula span.cm-property { color: #FFC66D; }
 .cm-s-darcula span.cm-operator { color: #A9B7C6; }
 .cm-s-darcula span.cm-string { color: #6A8759; }
 .cm-s-darcula span.cm-string-2 { color: #6A8759; }
-.cm-s-darcula span.cm-comment { color: #808080; }
-.cm-s-darcula span.cm-link { color: #287BDE; }
-.cm-s-darcula span.cm-atom { font-weight: bold; color: #CC7832; }
+.cm-s-darcula span.cm-comment { color: #61A151; font-style: italic; } 
+.cm-s-darcula span.cm-link { color: #CC7832; }
+.cm-s-darcula span.cm-atom { color: #CC7832; }
 .cm-s-darcula span.cm-error { color: #BC3F3C; }
-.cm-s-darcula span.cm-tag { color: #CC7832; }
-.cm-s-darcula span.cm-attribute { color: #6A8759; }
+.cm-s-darcula span.cm-tag { color: #629755; font-weight: bold; font-style: italic; text-decoration: underline; }
+.cm-s-darcula span.cm-attribute { color: #6897bb; }
 .cm-s-darcula span.cm-qualifier { color: #6A8759; }
 .cm-s-darcula span.cm-bracket { color: #A9B7C6; }
-.cm-s-darcula.CodeMirror { background: #2B2B2B; color: #A9B7C6; }
+.cm-s-darcula span.cm-builtin { color: #FF9E59; }
+.cm-s-darcula span.cm-special { color: #FF9E59; }
 
+.cm-s-darcula .CodeMirror-cursor { border-left: 1px solid #A9B7C6; }  
+.cm-s-darcula .CodeMirror-activeline-background { background: #323232; } 
+.cm-s-darcula .CodeMirror-gutters { background: #313335; border-right: 1px solid #313335; } 
+.cm-s-darcula .CodeMirror-guttermarker { color: #FFEE80; }  
+.cm-s-darcula .CodeMirror-guttermarker-subtle { color: #D0D0D0; }  
+.cm-s-darcula .CodeMirrir-linenumber { color: #606366; } 
+.cm-s-darcula .CodeMirror-matchingbracket { background-color: #3B514D; color: #FFEF28 !important; font-weight: bold; } 
 
-.cm-s-darcula .CodeMirror-cursor { border-left: 1px solid #dddddd; }
-.cm-s-darcula .CodeMirror-activeline-background { background: #3A3A3A; }
-.cm-s-darcula div.CodeMirror-selected { background: #085a9c; }
-.cm-s-darcula .CodeMirror-gutters { background: rgb(72, 72, 72); border-right: 1px solid grey; color: #606366 }
-
-.cm-s-darcula span.cm-builtin { color: #A9B7C6; }
-.cm-s-darcula  { font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;}
-.cm-s-darcula .CodeMirror-matchingbracket { background-color: #3b514d; color: yellow !important; }
+.cm-s-darcula div.CodeMirror-selected { background: #214283; }  
 
 .CodeMirror-hints.darcula {
   font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
-  color: #9c9e9e;
-  background-color: #3b3e3f !important;
+  color: #9C9E9E;
+  background-color: #3B3E3F !important;
 }
 
 .CodeMirror-hints.darcula .CodeMirror-hint-active {
-  background-color: #494d4e !important;
-  color: #9c9e9e !important;
+  background-color: #494D4E !important;
+  color: #9C9E9E !important;
 }


### PR DESCRIPTION
Adjust colours and font modifiers a little bit to make code more readable.

- CodeMirror does not distinguish comments and annotation strings (docstrings/javadocs/jsdocs/etc.), so comments is turned to greenish colour typical for annotation strings, since they are dominant way of documenting a code.
- Emphasized comments, def's and tags with text decorations.
