### PR TITLE
Support cross-window hint rendering

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -198,20 +198,22 @@
     this.data = data;
     this.picked = false;
     var widget = this, cm = completion.cm;
+    var ownerDocument = cm.getInputField().ownerDocument;
+    var parentWindow = ownerDocument.defaultView || ownerDocument.parentWindow;
 
-    var hints = this.hints = document.createElement("ul");
+    var hints = this.hints = ownerDocument.createElement("ul");
     var theme = completion.cm.options.theme;
     hints.className = "CodeMirror-hints " + theme;
     this.selectedHint = data.selectedHint || 0;
 
     var completions = data.list;
     for (var i = 0; i < completions.length; ++i) {
-      var elt = hints.appendChild(document.createElement("li")), cur = completions[i];
+      var elt = hints.appendChild(ownerDocument.createElement("li")), cur = completions[i];
       var className = HINT_ELEMENT_CLASS + (i != this.selectedHint ? "" : " " + ACTIVE_HINT_ELEMENT_CLASS);
       if (cur.className != null) className = cur.className + " " + className;
       elt.className = className;
       if (cur.render) cur.render(elt, data, cur);
-      else elt.appendChild(document.createTextNode(cur.displayText || getText(cur)));
+      else elt.appendChild(ownerDocument.createTextNode(cur.displayText || getText(cur)));
       elt.hintId = i;
     }
 
@@ -220,9 +222,9 @@
     hints.style.left = left + "px";
     hints.style.top = top + "px";
     // If we're at the edge of the screen, then we want the menu to appear on the left of the cursor.
-    var winW = window.innerWidth || Math.max(document.body.offsetWidth, document.documentElement.offsetWidth);
-    var winH = window.innerHeight || Math.max(document.body.offsetHeight, document.documentElement.offsetHeight);
-    (completion.options.container || document.body).appendChild(hints);
+    var winW = parentWindow.innerWidth || Math.max(ownerDocument.body.offsetWidth, ownerDocument.documentElement.offsetWidth);
+    var winH = parentWindow.innerHeight || Math.max(ownerDocument.body.offsetHeight, ownerDocument.documentElement.offsetHeight);
+    (completion.options.container || ownerDocument.body).appendChild(hints);
     var box = hints.getBoundingClientRect(), overlapY = box.bottom - winH;
     var scrolls = hints.scrollHeight > hints.clientHeight + 1
     var startScroll = cm.getScrollInfo();
@@ -273,7 +275,7 @@
     cm.on("scroll", this.onScroll = function() {
       var curScroll = cm.getScrollInfo(), editor = cm.getWrapperElement().getBoundingClientRect();
       var newTop = top + startScroll.top - curScroll.top;
-      var point = newTop - (window.pageYOffset || (document.documentElement || document.body).scrollTop);
+      var point = newTop - (parentWindow.pageYOffset || (ownerDocument.documentElement || ownerDocument.body).scrollTop);
       if (!below) point += hints.offsetHeight;
       if (point <= editor.top || point >= editor.bottom) return completion.close();
       hints.style.top = newTop + "px";


### PR DESCRIPTION
We're working on a new feature for [Playroom](https://github.com/seek-oss/playroom) where you can [detach the code editor from the main window](https://github.com/seek-oss/playroom/pull/7) and open it in a new window. This has highlighted an issue in the `show-hint` addon.

Currently, `show-hint` references the globals `window` and `document` to make layout calculations and add elements to the page. In our case, the code is executing in the parent window, so these global references are actually pointing at the wrong window. When writing code in the popup window, the suggestions are instead rendered to the parent window ([video link](https://cl.ly/92433d9175fd)).

To fix this, we ensure that references to `document` and `window` are scoped to the window that contains the textarea. We achieve this by calling `cm.getInputField().ownerDocument`, which is [supported across all browsers](https://caniuse.com/#search=ownerdocument). We then get a reference to the parent window via `ownerDocument.defaultView || ownerDocument.parentWindow`, which ensures backwards compatibility with older versions of IE since it doesn't support [defaultView](https://developer.mozilla.org/en-US/docs/Web/API/Document/defaultView), instead providing its own proprietary [parentWindow](https://msdn.microsoft.com/en-us/windows/ms534331(v=vs.71)) property.