### PR TITLE
Changed styling for bracket matching in Base 16 Light

### DIFF
--- a/theme/base16-light.css
+++ b/theme/base16-light.css
@@ -35,4 +35,4 @@
 .cm-s-base16-light span.cm-error { background: #ac4142; color: #505050; }
 
 .cm-s-base16-light .CodeMirror-activeline-background { background: #DDDCDC; }
-.cm-s-base16-light .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
+.cm-s-base16-light .CodeMirror-matchingbracket { color: #f5f5f5 !important; background-color: #6A9FB5 !important}


### PR DESCRIPTION
The current bracket matching highlight for Base 16 Light is pure white, which (a) isn't part of the theme and (b) is extremely difficult to see against the light background. I changed it to have a themed colour, a blue backround (like a block highlight)  and remove the underline (redundant with the other change).

Before:

![bracket2](https://user-images.githubusercontent.com/311239/48747853-fb633f80-ecc8-11e8-988d-4e0bc482d7cb.png)

After:

![bracket3](https://user-images.githubusercontent.com/311239/48747858-fef6c680-ecc8-11e8-8e7d-cd3fd37ef235.png)
