### PR TITLE
Linting for htmlmixed

### DIFF
--- a/addon/lint/htmlmixed-lint.js
+++ b/addon/lint/htmlmixed-lint.js
@@ -1,0 +1,167 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others,
+// Initial htmlmixed-lint.js from István Király, https://github.com/LaKing
+// Distributed under an MIT license: https://codemirror.net/LICENSE
+
+// Depends on htmlhint jshint and csshint
+
+(function(mod) {
+    if (typeof exports == "object" && typeof module == "object") // CommonJS
+        mod(require("../../lib/codemirror"), require("htmlhint"));
+    else if (typeof define == "function" && define.amd) // AMD
+        define(["../../lib/codemirror", "htmlhint"], mod);
+    else // Plain browser env
+        mod(CodeMirror, window.HTMLHint);
+})(function(CodeMirror, HTMLHint) {
+    "use strict";
+
+    var defaultRules = {
+        "tagname-lowercase": true,
+        "attr-lowercase": true,
+        "attr-value-double-quotes": true,
+        "doctype-first": false,
+        "tag-pair": true,
+        "spec-char-escape": true,
+        "id-unique": true,
+        "src-not-empty": true,
+        "attr-no-duplication": true
+    };
+
+    CodeMirror.registerHelper("lint", "html", function(text, options) {
+
+        // dependency verification
+        // htmllint
+        var found = [];
+        if (HTMLHint && !HTMLHint.verify) HTMLHint = HTMLHint.HTMLHint;
+        if (!HTMLHint) HTMLHint = window.HTMLHint;
+        if (!HTMLHint) {
+            if (window.console) {
+                window.console.error("Error: window.HTMLHint not found, CodeMirror HTML mixed linting cannot run.");
+            }
+            return found;
+        }
+        //  csslint
+        if (!window.CSSLint) {
+            if (window.console) {
+                window.console.error("Error: window.CSSLint not defined, CodeMirror HTML mixed linting cannot run.");
+            }
+            return found;
+        }
+        // jshint
+        if (!window.JSHINT) {
+            if (window.console) {
+                window.console.error("Error: window.JSHINT not defined, CodeMirror HTML mixed linting cannot run.");
+            }
+            return [];
+        }
+        if (!options.indent) // JSHint error.character actually is a column index, this fixes underlining on lines using tabs for indentation
+            options.indent = 1; // JSHint default value is 4
+
+        // external linters may modify the options object, so for example CSSLinter adds options.errors, but then JSLint complains that it is not a valid option
+        // let us add an additional layer in case we want to define linter-specific option via options, otherwise take clones of the defualt options object
+        var CSSoptions = options.css || JSON.parse(JSON.stringify(options));
+        var JSoptions = options.js || JSON.parse(JSON.stringify(options));
+        var HTMLoptions = options.html || JSON.parse(JSON.stringify(options));
+
+ 
+        // our JS error parser is extended with the offset argument
+        function parseErrors(errors, output, offset) {
+            for (var i = 0; i < errors.length; i++) {
+                var error = errors[i];
+                if (error) {
+                    if (error.line <= 0) {
+                        if (window.console) {
+                            window.console.warn("Cannot display JSHint error (invalid line " + error.line + ")", error);
+                        }
+                        continue;
+                    }
+
+                    var start = error.character - 1,
+                        end = start + 1;
+                    if (error.evidence) {
+                        var index = error.evidence.substring(start).search(/.\b/);
+                        if (index > -1) {
+                            end += index;
+                        }
+                    }
+
+                    var line = error.line - 1 + offset - 1;
+                    // Convert to format expected by validation service
+                    var hint = {
+                        message: error.reason,
+                        severity: error.code ? (error.code.startsWith('W') ? "warning" : "error") : "error",
+                        from: CodeMirror.Pos(line, start),
+                        to: CodeMirror.Pos(line, end)
+                    };
+
+                    output.push(hint);
+                }
+            }
+        }
+
+        function newlines(str) {
+            return str.split('\n').length;
+        }
+
+        function processHTML(text, options, found) {
+            var messages = HTMLHint.verify(text, options && options.rules || defaultRules);
+            for (var i = 0; i < messages.length; i++) {
+                var message = messages[i];
+                var startLine = message.line - 1,
+                    endLine = message.line - 1,
+                    startCol = message.col - 1,
+                    endCol = message.col;
+                found.push({
+                    from: CodeMirror.Pos(startLine, startCol),
+                    to: CodeMirror.Pos(endLine, endCol),
+                    message: message.message,
+                    severity: message.type
+                });
+            }
+        }
+
+        processHTML(text, HTMLoptions, found);
+
+        function processCSS(text, options, found) {
+            var blocks = text.split(/<style[\s\S]*?>|<\/style>/gi);
+            for (var j = 1; j < blocks.length; j += 2) {
+                var offset = newlines(blocks.slice(0, j).join());
+                var results = CSSLint.verify(blocks[j], options);
+                var messages = results.messages;
+                var message = null;
+                for (var i = 0; i < messages.length; i++) {
+                    message = messages[i];
+                    var startLine = offset - 1 + message.line - 1,
+                        endLine = offset - 1 + message.line - 1,
+                        startCol = message.col - 1,
+                        endCol = message.col;
+                    found.push({
+                        from: CodeMirror.Pos(startLine, startCol),
+                        to: CodeMirror.Pos(endLine, endCol),
+                        message: message.message,
+                        severity: message.type
+                    });
+                }
+            }
+        }
+
+        processCSS(text, CSSoptions, found);
+
+        function processJS(text, options, found) {
+            var blocks = text.split(/<script[\s\S]*?>|<\/script>/gi);
+            for (var j = 1; j < blocks.length; j += 2) {
+                if (blocks[j].length>1) {
+                    JSHINT(blocks[j], options, options.globals);
+                    var errors = JSHINT.data().errors;
+                    if (errors) parseErrors(errors, found, newlines(blocks.slice(0, j).join()));
+                }
+            }
+        }
+
+        processJS(text, JSoptions, found);
+
+
+        console.log("end", found);
+
+        return found;
+    });
+});

--- a/demo/lint-htmlmixed.html
+++ b/demo/lint-htmlmixed.html
@@ -1,0 +1,85 @@
+<!doctype html>
+
+<title>CodeMirror: Linter Demo</title>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../doc/docs.css">
+
+<link rel="stylesheet" href="../lib/codemirror.css">
+<link rel="stylesheet" href="../addon/lint/lint.css">
+<script src="../lib/codemirror.js"></script>
+<script src="../mode/xml/xml.js"></script>
+<!-- added -->
+<script src="../mode/javascript/javascript.js"></script>
+<script src="../mode/css/css.js"></script>
+<!-- to run locally -->
+<script src="jshint.min.js"></script>
+<script src="jsonlint.js"></script>
+<script src="https://unpkg.com/csslint@1.0.5/dist/csslint.js"></script>
+<script src="../addon/lint/lint.js"></script>
+<script src="../addon/lint/javascript-lint.js"></script>
+<script src="../addon/lint/json-lint.js"></script>
+<script src="../addon/lint/css-lint.js"></script>
+<!-- https://raw.github.com/htmlhint/HTMLHint/master/lib/htmlhint.js  -->
+<script src="htmlhint.js"></script>
+<script src="../addon/lint/htmlmixed-lint.js"></script>
+
+<style>
+    .CodeMirror {
+        border: 1px solid black;
+      	height: 800px;
+    }
+</style>
+<div id="nav">
+    <a href="https://codemirror.net">
+        <h1>CodeMirror</h1><img id="logo" src="../doc/logo.png"></a>
+
+  <ul>
+    <li><a href="../index.html">Home</a></li>
+    <li><a href="../doc/manual.html">Manual</a></li>
+    <li><a href="https://github.com/codemirror/codemirror">Code</a></li>
+  </ul>
+  <ul>
+    <li><a class="active" href="#">Linter</a></li>
+  </ul>
+</div>
+
+<article>
+    <h2>Linter Demo</h2>
+
+    <h3>HTML mixed</h3>
+    <p><textarea id="code-htmlmixed">
+<html style="color: green">
+  <!-- this is a comment -->
+  <head>
+	<script src="../mode/xml/xml.js"></script>
+    <title>Mixed HTML Example</title>
+    <style>
+      h1 {font-family: comic sans; color: #f0f;}
+      div {background: yellow !important;}
+      body {
+        max-width: 50em;
+        margin: 1em 2em 1em 5em;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Mixed HTML Example</h1>
+    <script>
+      function jsFunc(arg1, arg2) {
+        if (arg1 && arg2) document.body.innerHTML = "achoo";
+      }
+    </script>
+  </body>
+</html>
+</textarea></p>
+
+    <script>
+        var editor_html = CodeMirror.fromTextArea(document.getElementById("code-htmlmixed"), {
+            lineNumbers: true,
+            mode: "text/html",
+            gutters: ["CodeMirror-lint-markers"],
+            lint: true
+        });
+    </script>
+
+</article>

--- a/demo/lint.html
+++ b/demo/lint.html
@@ -2,15 +2,15 @@
 
 <title>CodeMirror: Linter Demo</title>
 <meta charset="utf-8"/>
-<link rel=stylesheet href="../doc/docs.css">
+<link rel="stylesheet" href="../doc/docs.css">
 
 <link rel="stylesheet" href="../lib/codemirror.css">
 <link rel="stylesheet" href="../addon/lint/lint.css">
 <script src="../lib/codemirror.js"></script>
 <script src="../mode/javascript/javascript.js"></script>
 <script src="../mode/css/css.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/jshint/2.9.5/jshint.min.js"></script>
-<script src="//rawgithub.com/zaach/jsonlint/79b553fb65c192add9066da64043458981b3972b/lib/jsonlint.js"></script>
+<script src="https://unpkg.com/jshint@2.9.6/dist/jshint.js"></script>
+<script src="https://unpkg.com/jsonlint@1.6.3/web/jsonlint.js"></script>
 <script src="https://unpkg.com/csslint@1.0.5/dist/csslint.js"></script>
 <script src="../addon/lint/lint.js"></script>
 <script src="../addon/lint/javascript-lint.js"></script>
@@ -19,16 +19,16 @@
 <style>
       .CodeMirror {border: 1px solid black;}
     </style>
-<div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../doc/logo.png"></a>
+<div id="nav">
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id="logo" src="../doc/logo.png"></a>
 
   <ul>
-    <li><a href="../index.html">Home</a>
-    <li><a href="../doc/manual.html">Manual</a>
-    <li><a href="https://github.com/codemirror/codemirror">Code</a>
+    <li><a href="../index.html">Home</a></li>
+    <li><a href="../doc/manual.html">Manual</a></li>
+    <li><a href="https://github.com/codemirror/codemirror">Code</a></li>
   </ul>
   <ul>
-    <li><a class=active href="#">Linter</a>
+    <li><a class="active" href="#">Linter</a></li>
   </ul>
 </div>
 


### PR DESCRIPTION
Updated the linter demo page, the html code had some syntax errors.

Updated links to unpkg links. Added prefix for https protocols, so that people that clone the repo can access it instantly. Problem is that if no protocol is specified file protocol is assumed in a local clone.

I created a separate js file for the htmlmixed mode linter, so we have an independent file not modifying anything else. Mostly combined the existing code into 3 functions that take a look at the input text. Regexp based separators separate it into code blocks and apply the linters. The base syntax is html, so for scripts and styles we assume the odd blocks are scripts and style blocks and run the linters in there, therefore lines in the message are not calculated with offsets. Offsets are calculated via line breaks.
Had to clone local options objects as the external linters modified the options object, and the linters complained at each other's runtime-added options. Added some extra properties as default so that there is a way for language-specific options: options.css, options.js and options.html are taken first if exists, if not, we take the clones.

Let me know if there is anything that should be done differently.
