### PR TITLE
[css] support double dash css variable

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -63,7 +63,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
       if (/[\d.]/.test(stream.peek())) {
         stream.eatWhile(/[\w.%]/);
         return ret("number", "unit");
-      } else if (stream.match(/^-[\w\\\-]+/)) {
+      } else if (stream.match(/^-[\w\\\-]*/)) {
         stream.eatWhile(/[\w\\\-]/);
         if (stream.match(/^\s*:/, false))
           return ret("variable-2", "variable-definition");

--- a/mode/css/test.js
+++ b/mode/css/test.js
@@ -149,6 +149,14 @@
      "  [property color]: [atom var]([variable-2 --main-color]);",
      "}");
 
+  MT("blank_css_variable",
+     ":[variable-3 root] {",
+     "  [variable-2 --]: [atom #06c];",
+     "}",
+     "[tag h1][builtin #foo] {",
+     "  [property color]: [atom var]([variable-2 --]);",
+     "}");
+
   MT("supports",
      "[def @supports] ([keyword not] (([property text-align-last]: [atom justify]) [keyword or] ([meta -moz-][property text-align-last]: [atom justify])) {",
      "  [property text-align-last]: [atom justify];",


### PR DESCRIPTION
In css `--` is a legal css custom property. CodeMirror gets confused when it is used though.

Fixes #5686