### PR TITLE
soy mode - classify param def type as type token

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -206,7 +206,7 @@
               return null;
             }
             if (stream.eatWhile(/^[\w]+/)) {
-              return "variable-3";
+              return "type";
             }
             stream.next();
             return null;

--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -29,16 +29,16 @@
 
   MT('param-type-test',
      '[keyword {@param] [def a]: ' +
-         '[variable-3 list]<[[[variable-3 a]: [variable-3 int], ' +
-         '[variable-3 b]: [variable-3 map]<[variable-3 string], ' +
-         '[variable-3 bool]>]]>][keyword }]');
+         '[type list]<[[[type a]: [type int], ' +
+         '[type b]: [type map]<[type string], ' +
+         '[type bool]>]]>][keyword }]');
 
   MT('undefined-var',
      '[keyword {][variable-2&error $var]');
 
   MT('param-scope-test',
      '[keyword {template] [def .a][keyword }]',
-     '  [keyword {@param] [def x]: [variable-3 string][keyword }]',
+     '  [keyword {@param] [def x]: [type string][keyword }]',
      '  [keyword {][variable-2 $x][keyword }]',
      '[keyword {/template}]',
      '',
@@ -55,7 +55,7 @@
 
   MT('defined-if-variable-test',
      '[keyword {template] [def .foo][keyword }]',
-     '  [keyword {@param?] [def showThing]: [variable-3 bool][keyword }]',
+     '  [keyword {@param?] [def showThing]: [type bool][keyword }]',
      '  [keyword {if] [variable-2 $showThing][keyword }]',
      '    Yo!',
      '  [keyword {/if}]',
@@ -73,7 +73,7 @@
      '');
 
   MT('foreach-scope-test',
-     '[keyword {@param] [def bar]: [variable-3 string][keyword }]',
+     '[keyword {@param] [def bar]: [type string][keyword }]',
      '[keyword {foreach] [def $foo] [keyword in] [variable-2&error $foos][keyword }]',
      '  [keyword {][variable-2 $foo][keyword }]',
      '[keyword {/foreach}]',
@@ -108,7 +108,7 @@
 
   MT('allow-missing-colon-in-@param',
      '[keyword {template] [def .foo][keyword }]',
-     '  [keyword {@param] [def showThing] [variable-3 bool][keyword }]',
+     '  [keyword {@param] [def showThing] [type bool][keyword }]',
      '  [keyword {if] [variable-2 $showThing][keyword }]',
      '    Yo!',
      '  [keyword {/if}]',


### PR DESCRIPTION
- changed classification of param-def-type to "type" instead of using "variable-3"
- updated tests to match this expectation

This will provide more accurate syntax highlighting and make the parameter types standout better for theming.