### PR TITLE
soy updated "templ-ref" namespaces and local templates

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -170,11 +170,11 @@
             return null;
 
           case "templ-ref":
-            if (match = stream.match(/^\.?([\w]+)/)) {
+            if (match = stream.match(/(\.?[a-zA-Z_][a-zA-Z_0-9]+)+/)) {
               state.soyState.pop();
-              // If the first character is '.', try to match against a local template name.
+              // If the first character is '.', it can only be a local template.
               if (match[0][0] == '.') {
-                return ref(state.templates, match[1], true);
+                return "variable-2"
               }
               // Otherwise
               return "variable";

--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -63,13 +63,11 @@
      '');
 
   MT('template-calls-test',
-     '[keyword {template] [def .foo][keyword }]',
-     '  Yo!',
-     '[keyword {/template}]',
      '[keyword {call] [variable-2 .foo][keyword /}]',
      '[keyword {call] [variable foo][keyword /}]',
-     '[keyword {call] [variable .bar][keyword /}]',
-     '[keyword {call] [variable bar][keyword /}]',
+     '[keyword {call] [variable foo][keyword }] [keyword {/call}]',
+     '[keyword {call] [variable first1.second.third_3][keyword /}]',
+     '[keyword {call] [variable first1.second.third_3] [keyword }] [keyword {/call}]',
      '');
 
   MT('foreach-scope-test',
@@ -91,7 +89,7 @@
   MT('nested-kind-test',
      '[keyword {template] [def .foo] [attribute kind]=[string "html"][keyword }]',
      '  [tag&bracket <][tag div][tag&bracket >]',
-     '    [keyword {call] [variable .bar][keyword }]',
+     '    [keyword {call] [variable-2 .bar][keyword }]',
      '      [keyword {param] [attribute kind]=[string "js"][keyword }]',
      '        [keyword var] [def bar] [operator =] [number 5];',
      '      [keyword {/param}]',


### PR DESCRIPTION
This PR updates the {call /} command in soy mode to better support namespaced template names.

- updated "templ-ref" to match namespaced templates e.g.
my.namespaced.component.element. The existing regex matches the first
word and nothing after the "."

- updated "templ-ref" to treat all "." templates as variable-2.
Local templates are the only ones capable of starting with a dot and
because a template earlier in the file can reference a local template
later in the file, there are no guarantees of it being in the variable
list. Treating all .templates as local is more consistent and
predictable for syntax highlighting.

Here is a link to test out the regular expression I added: https://regexr.com/44okk.  It should work with local templates and namespaced templates.