### PR TITLE
[soy mode] tokenize property names in {param}

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -200,6 +200,14 @@
             stream.next();
             return null;
 
+          case "param-ref":
+            if (match = stream.match(/^\w+/)) {
+              state.soyState.pop();
+              return "property";
+            }
+            stream.next();
+            return null;
+
           case "param-type":
             if (stream.peek() == "}") {
               state.soyState.pop();
@@ -313,6 +321,8 @@
             }
           } else if (state.tag.match(/^@(?:param\??|inject|prop)/)) {
             state.soyState.push("param-def");
+          } else if (state.tag.match(/^(?:param)/)) {
+            state.soyState.push("param-ref");
           }
           return "keyword";
 

--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -96,7 +96,7 @@
      '[keyword {template] [def .foo] [attribute kind]=[string "html"][keyword }]',
      '  [tag&bracket <][tag div][tag&bracket >]',
      '    [keyword {call] [variable-2 .bar][keyword }]',
-     '      [keyword {param] [attribute kind]=[string "js"][keyword }]',
+     '      [keyword {param] [property propertyName] [attribute kind]=[string "js"][keyword }]',
      '        [keyword var] [def bar] [operator =] [number 5];',
      '      [keyword {/param}]',
      '    [keyword {/call}]',


### PR DESCRIPTION
- added token "property" to `name` in `{param name: '' /}`
- adjusted nested-kind-test for this change.

I used property because I imagine for the following soy code:
```soy
{template .fullName kind="text"}
  {@param firstName: string /}
  {@param lastName: string /}
  {$firstName} {$lastName}
{/template}

{call .fullName}
  {param firstName: 'Terry' /}
  {param lastName: 'Jones' /}
{/call}
```
The following JavaScript is equivalent:

```javascript
function fullName({ firstName, lastName}) {
  return firstName + ' ' + lastName;
}

fullName({ firstName: 'Terry', lastName: 'Jones' });
```

If that is a good representation, then property is the most appropriate.  Since params can be defined in any order, I think the options pattern above is the closest equivalent.