### PR TITLE
Allow linting of multi-document YAML stream

### DIFF
--- a/addon/lint/yaml-lint.js
+++ b/addon/lint/yaml-lint.js
@@ -23,7 +23,7 @@ CodeMirror.registerHelper("lint", "yaml", function(text) {
     }
     return found;
   }
-  try { jsyaml.load(text); }
+  try { jsyaml.loadAll(text); }
   catch(e) {
       var loc = e.mark,
           // js-yaml YAMLException doesn't always provide an accurate lineno


### PR DESCRIPTION
This still works transparently for single-document YAML.
https://yaml.org/spec/1.2/spec.html#id2800132