### PR TITLE
Updating MIME type of Jinja2

### DIFF
--- a/mode/jinja2/jinja2.js
+++ b/mode/jinja2/jinja2.js
@@ -141,4 +141,6 @@
       blockCommentEnd: "#}"
     };
   });
+
+  CodeMirror.defineMIME("text/plain", "jinja2");
 });

--- a/mode/meta.js
+++ b/mode/meta.js
@@ -75,7 +75,7 @@
     {name: "JSON", mimes: ["application/json", "application/x-json"], mode: "javascript", ext: ["json", "map"], alias: ["json5"]},
     {name: "JSON-LD", mime: "application/ld+json", mode: "javascript", ext: ["jsonld"], alias: ["jsonld"]},
     {name: "JSX", mime: "text/jsx", mode: "jsx", ext: ["jsx"]},
-    {name: "Jinja2", mime: "null", mode: "jinja2", ext: ["j2", "jinja", "jinja2"]},
+    {name: "Jinja2", mime: "text/plain", mode: "jinja2", ext: ["j2", "jinja", "jinja2"]},
     {name: "Julia", mime: "text/x-julia", mode: "julia", ext: ["jl"]},
     {name: "Kotlin", mime: "text/x-kotlin", mode: "clike", ext: ["kt"]},
     {name: "LESS", mime: "text/x-less", mode: "css", ext: ["less"]},


### PR DESCRIPTION
Hi CodeMirror team,

In this pull request I'm setting the mime type for the Jinja2 language to "plain/text".

The setting of this to "null" is causing issues with projects that reference/use CodeMirror.
For example, see a [pull request I've submitted on the Github/linguist](https://github.com/github/linguist/pull/4349) project.

Thanks for look at this PR. Let me know what you think.