### PR TITLE
[soy mode] boolean and number tokenization in expressions

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -266,6 +266,17 @@
               state.quoteKind = match;
               return "string";
             }
+            if (match = stream.match(/(true|false)(?!\w)/)) {
+              return "atom";
+            }
+            if (match = stream.match(/0x([0-9a-fA-F]{2,})/)) {
+              // Match hexadecimal number.
+              return "atom";
+            }
+            if (match = stream.match(/-?([0-9]*[.])?[0-9]+/)) {
+              // Match all decimals and whole numbers.
+              return "atom";
+            }
             if (match = stream.match(/^\$([\w]+)/)) {
               return ref(state.variables, match[1]);
             }

--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -266,15 +266,9 @@
               state.quoteKind = match;
               return "string";
             }
-            if (match = stream.match(/(true|false)(?!\w)/)) {
-              return "atom";
-            }
-            if (match = stream.match(/0x([0-9a-fA-F]{2,})/)) {
-              // Match hexadecimal number.
-              return "atom";
-            }
-            if (match = stream.match(/-?([0-9]*[.])?[0-9]+/)) {
-              // Match all decimals and whole numbers.
+            if (stream.match(/(true|false)(?!\w)/) || 
+              stream.match(/0x([0-9a-fA-F]{2,})/) || 
+              stream.match(/-?([0-9]*[.])?[0-9]+/)) {
               return "atom";
             }
             if (match = stream.match(/^\$([\w]+)/)) {

--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -266,8 +266,8 @@
               state.quoteKind = match;
               return "string";
             }
-            if (stream.match(/(true|false)(?!\w)/) || 
-              stream.match(/0x([0-9a-fA-F]{2,})/) || 
+            if (stream.match(/(true|false)(?!\w)/) ||
+              stream.match(/0x([0-9a-fA-F]{2,})/) ||
               stream.match(/-?([0-9]*[.])?[0-9]+/)) {
               return "atom";
             }

--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -33,6 +33,19 @@
      '[keyword {namespace] [variable my.namespace.templates] ' +
          '[attribute requirecss]=[string "my.namespace"][keyword }]');
 
+  MT('primitive-test',
+     '[keyword {] [atom true] [keyword }]',
+     '[keyword {] [atom false] [keyword }]',
+     '[keyword {] truethy [keyword }]',
+     '[keyword {] falsey [keyword }]',
+     '[keyword {] [atom 42] [keyword }]',
+     '[keyword {] [atom .42] [keyword }]',
+     '[keyword {] [atom 0.42] [keyword }]',
+     '[keyword {] [atom -0.42] [keyword }]',
+     '[keyword {] [atom -.2] [keyword }]',
+     '[keyword {] [atom 0x1F] [keyword }]',
+     '[keyword {] [atom 0x1F00BBEA] [keyword }]');
+
   MT('param-type-test',
      '[keyword {@param] [def a]: ' +
          '[type list]<[[[type a]: [type int], ' +


### PR DESCRIPTION
Highlights { true } or { false } as atoms.  Also highlights all number literals.

- added tokenization for decimals
- added tokenization for hexadecimals
- added tokenization for true/false
- added test cases for those new atom tokens