### PR TITLE
[soy mode] add support for scientific notation

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -268,7 +268,7 @@
             }
             if (stream.match(/(true|false)(?!\w)/) ||
               stream.match(/0x([0-9a-fA-F]{2,})/) ||
-              stream.match(/-?([0-9]*[.])?[0-9]+/)) {
+              stream.match(/-?([0-9]*[.])?[0-9]+(e[0-9]*)?/)) {
               return "atom";
             }
             if (stream.match(/(\||[+\-*\/%]|[=!][=]|[<>][=]?)/)) {

--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -57,6 +57,8 @@
      '[keyword {] [atom 0.42] [keyword }]',
      '[keyword {] [atom -0.42] [keyword }]',
      '[keyword {] [atom -.2] [keyword }]',
+     '[keyword {] [atom 6.03e23] [keyword }]',
+     '[keyword {] [atom -0.03e0] [keyword }]',
      '[keyword {] [atom 0x1F] [keyword }]',
      '[keyword {] [atom 0x1F00BBEA] [keyword }]');
 


### PR DESCRIPTION
- modified the decimal expression to support scientific notation
- added tests to verify new highlighting behavior

I was looking through the expressions and realized I missed this one.  I think this might be the last atom change that soy needs for expressions.