### PR TITLE
show-hint: bind "Ctrl-P" to "Up" and "Ctrl-N" to "Down" by default

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -159,6 +159,8 @@
     var baseMap = {
       Up: function() {handle.moveFocus(-1);},
       Down: function() {handle.moveFocus(1);},
+      "Ctrl-P": function() {handle.moveFocus(-1);},
+      "Ctrl-N": function() {handle.moveFocus(1);},
       PageUp: function() {handle.moveFocus(-handle.menuSize() + 1, true);},
       PageDown: function() {handle.moveFocus(handle.menuSize() - 1, true);},
       Home: function() {handle.setFocus(0);},


### PR DESCRIPTION
I think these are de-facto standard keybindings in completion panels.