### PR TITLE
[css mode] more consistent css function tokens

### DIFF
--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -77,12 +77,11 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
       return ret("qualifier", "qualifier");
     } else if (/[:;{}\[\]\(\)]/.test(ch)) {
       return ret(null, ch);
-    } else if (((ch == "u" || ch == "U") && stream.match(/rl(-prefix)?\(/i)) ||
-               ((ch == "d" || ch == "D") && stream.match("omain(", true, true)) ||
-               ((ch == "r" || ch == "R") && stream.match("egexp(", true, true))) {
-      stream.backUp(1);
-      state.tokenize = tokenParenthesized;
-      return ret("property", "word");
+    } else if (stream.match(/[\w-.]+(?=\()/)) {
+      if (/^(url(-prefix)?|domain|regexp)$/.test(stream.current().toLowerCase())) {
+        state.tokenize = tokenParenthesized;
+      }
+      return ret("variable callee", "variable");
     } else if (/[\w\\\-]/.test(ch)) {
       stream.eatWhile(/[\w\\\-]/);
       return ret("property", "word");

--- a/mode/css/less_test.js
+++ b/mode/css/less_test.js
@@ -10,8 +10,8 @@
   MT("variable",
      "[variable-2 @base]: [atom #f04615];",
      "[qualifier .class] {",
-     "  [property width]: [variable percentage]([number 0.5]); [comment // returns `50%`]",
-     "  [property color]: [variable saturate]([variable-2 @base], [number 5%]);",
+     "  [property width]: [variable&callee percentage]([number 0.5]); [comment // returns `50%`]",
+     "  [property color]: [variable&callee saturate]([variable-2 @base], [number 5%]);",
      "}");
 
   MT("amp",
@@ -26,10 +26,10 @@
 
   MT("mixin",
      "[qualifier .mixin] ([variable dark]; [variable-2 @color]) {",
-     "  [property color]: [atom darken]([variable-2 @color], [number 10%]);",
+     "  [property color]: [variable&callee darken]([variable-2 @color], [number 10%]);",
      "}",
      "[qualifier .mixin] ([variable light]; [variable-2 @color]) {",
-     "  [property color]: [atom lighten]([variable-2 @color], [number 10%]);",
+     "  [property color]: [variable&callee lighten]([variable-2 @color], [number 10%]);",
      "}",
      "[qualifier .mixin] ([variable-2 @_]; [variable-2 @color]) {",
      "  [property display]: [atom block];",

--- a/mode/css/scss_test.js
+++ b/mode/css/scss_test.js
@@ -6,19 +6,19 @@
   function MT(name) { test.mode(name, mode, Array.prototype.slice.call(arguments, 1), "scss"); }
 
   MT('url_with_quotation',
-    "[tag foo] { [property background]:[atom url]([string test.jpg]) }");
+    "[tag foo] { [property background]:[variable&callee url]([string test.jpg]) }");
 
   MT('url_with_double_quotes',
-    "[tag foo] { [property background]:[atom url]([string \"test.jpg\"]) }");
+    "[tag foo] { [property background]:[variable&callee url]([string \"test.jpg\"]) }");
 
   MT('url_with_single_quotes',
-    "[tag foo] { [property background]:[atom url]([string \'test.jpg\']) }");
+    "[tag foo] { [property background]:[variable&callee url]([string \'test.jpg\']) }");
 
   MT('string',
     "[def @import] [string \"compass/css3\"]");
 
   MT('important_keyword',
-    "[tag foo] { [property background]:[atom url]([string \'test.jpg\']) [keyword !important] }");
+    "[tag foo] { [property background]:[variable&callee url]([string \'test.jpg\']) [keyword !important] }");
 
   MT('variable',
     "[variable-2 $blue]:[atom #333]");
@@ -95,7 +95,7 @@
 
   MT('indent_parentheses',
      "[tag foo] {",
-     "  [property color]: [atom darken]([variable-2 $blue],",
+     "  [property color]: [variable&callee darken]([variable-2 $blue],",
      "    [number 9%]);",
      "}");
 

--- a/mode/css/test.js
+++ b/mode/css/test.js
@@ -89,11 +89,11 @@
      "[tag foo] { [property margin]: [number 0]; [property padding]: [number 0]; }");
 
   MT("tagTwoPropertiesURL",
-     "[tag foo] { [property background]: [atom url]([string //example.com/foo.png]); [property padding]: [number 0]; }");
+     "[tag foo] { [property background]: [variable&callee url]([string //example.com/foo.png]); [property padding]: [number 0]; }");
 
   MT("indent_tagSelector",
      "[tag strong], [tag em] {",
-     "  [property background]: [atom rgba](",
+     "  [property background]: [variable&callee rgba](",
      "    [number 255], [number 255], [number 0], [number .2]",
      "  );",
      "}");
@@ -114,7 +114,7 @@
 
   MT("indent_parentheses",
      "[tag foo]:[variable-3 before] {",
-     "  [property background]: [atom url](",
+     "  [property background]: [variable&callee url](",
      "[string     blahblah]",
      "[string     etc]",
      "[string   ]) [keyword !important];",
@@ -124,20 +124,20 @@
      "[def @font-face] {",
      "  [property font-family]: [string 'myfont'];",
      "  [error nonsense]: [string 'abc'];",
-     "  [property src]: [atom url]([string http://blah]),",
-     "    [atom url]([string http://foo]);",
+     "  [property src]: [variable&callee url]([string http://blah]),",
+     "    [variable&callee url]([string http://foo]);",
      "}");
 
   MT("empty_url",
-     "[def @import] [atom url]() [attribute screen];");
+     "[def @import] [variable&callee url]() [attribute screen];");
 
   MT("parens",
      "[qualifier .foo] {",
-     "  [property background-image]: [variable fade]([atom #000], [number 20%]);",
-     "  [property border-image]: [atom linear-gradient](",
+     "  [property background-image]: [variable&callee fade]([atom #000], [number 20%]);",
+     "  [property border-image]: [variable&callee linear-gradient](",
      "    [atom to] [atom bottom],",
-     "    [variable fade]([atom #000], [number 20%]) [number 0%],",
-     "    [variable fade]([atom #000], [number 20%]) [number 100%]",
+     "    [variable&callee fade]([atom #000], [number 20%]) [number 0%],",
+     "    [variable&callee fade]([atom #000], [number 20%]) [number 100%]",
      "  );",
      "}");
 
@@ -146,7 +146,7 @@
      "  [variable-2 --main-color]: [atom #06c];",
      "}",
      "[tag h1][builtin #foo] {",
-     "  [property color]: [atom var]([variable-2 --main-color]);",
+     "  [property color]: [variable&callee var]([variable-2 --main-color]);",
      "}");
 
   MT("blank_css_variable",
@@ -154,7 +154,7 @@
      "  [variable-2 --]: [atom #06c];",
      "}",
      "[tag h1][builtin #foo] {",
-     "  [property color]: [atom var]([variable-2 --]);",
+     "  [property color]: [variable&callee var]([variable-2 --]);",
      "}");
 
   MT("supports",
@@ -163,10 +163,10 @@
      "}");
 
    MT("document",
-      "[def @document] [tag url]([string http://blah]),",
-      "  [tag url-prefix]([string https://]),",
-      "  [tag domain]([string blah.com]),",
-      "  [tag regexp]([string \".*blah.+\"]) {",
+      "[def @document] [variable&callee url]([string http://blah]),",
+      "  [variable&callee url-prefix]([string https://]),",
+      "  [variable&callee domain]([string blah.com]),",
+      "  [variable&callee regexp]([string \".*blah.+\"]) {",
       "    [builtin #id] {",
       "      [property background-color]: [keyword white];",
       "    }",
@@ -176,16 +176,16 @@
       "}");
 
    MT("document_url",
-      "[def @document] [tag url]([string http://blah]) { [qualifier .class] { } }");
+      "[def @document] [variable&callee url]([string http://blah]) { [qualifier .class] { } }");
 
    MT("document_urlPrefix",
-      "[def @document] [tag url-prefix]([string https://]) { [builtin #id] { } }");
+      "[def @document] [variable&callee url-prefix]([string https://]) { [builtin #id] { } }");
 
    MT("document_domain",
-      "[def @document] [tag domain]([string blah.com]) { [tag foo] { } }");
+      "[def @document] [variable&callee domain]([string blah.com]) { [tag foo] { } }");
 
    MT("document_regexp",
-      "[def @document] [tag regexp]([string \".*blah.+\"]) { [builtin #id] { } }");
+      "[def @document] [variable&callee regexp]([string \".*blah.+\"]) { [builtin #id] { } }");
 
    MT("counter-style",
       "[def @counter-style] [variable binary] {",
@@ -207,11 +207,11 @@
       "[tag ol][qualifier .roman] { [property list-style]: [variable simple-roman]; }");
 
    MT("counter-style-symbols",
-      "[tag ol] { [property list-style]: [atom symbols]([atom cyclic] [string \"*\"] [string \"\\2020\"] [string \"\\2021\"] [string \"\\A7\"]); }");
+      "[tag ol] { [property list-style]: [variable&callee symbols]([atom cyclic] [string \"*\"] [string \"\\2020\"] [string \"\\2021\"] [string \"\\A7\"]); }");
 
   MT("comment-does-not-disrupt",
      "[def @font-face] [comment /* foo */] {",
-     "  [property src]: [atom url]([string x]);",
+     "  [property src]: [variable&callee url]([string x]);",
      "  [property font-family]: [variable One];",
      "}")
 })();


### PR DESCRIPTION
- created a css function regexp with a positive lookahead for (. There
are still a few cases with IE functions that have . and : in it that
this does not catch.
- folded url/domain/regexp into that css function regexp including the
special string tokenization that was in place already
- updated css, less, and scss tests to reflect this new tokenization