### PR TITLE
Add option to disable preventDefault on key press for contentEditable input views

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -566,6 +566,9 @@
       
       <dt id="option_autocapitalize"><code><strong>autocapitalize</strong>: boolean</code></dt>
       <dd>Specifies whether or not autocapitalization will be enabled on the input.</dd>
+      
+      <dt id="option_preventDefaultOnKeyPress"><code><strong>preventDefaultOnKeyPress</strong>: boolean</code></dt>
+      <dd>Specifies whether or not key press events for the  <code>"contenteditable"</code> input style will have <code>preventDefault()</code> called on them and handled by Codemirror instead of the standard event propagation. This defaults to <code>true</code> but setting it to <code>false</code> works around an iOS issue that prevents the on-screen keyboard from updating properly.</dd>
     </dl>
 </section>
 

--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -158,6 +158,7 @@ export function defineOptions(CodeMirror) {
   option("autofocus", null)
   option("direction", "ltr", (cm, val) => cm.doc.setDirection(val), true)
   option("phrases", null)
+  option("preventDefaultOnKeyPress", true)
 }
 
 function guttersChanged(cm) {

--- a/src/input/ContentEditableInput.js
+++ b/src/input/ContentEditableInput.js
@@ -359,6 +359,9 @@ export default class ContentEditableInput {
   }
 
   onKeyPress(e) {
+    if (!this.cm.options.preventDefaultOnKeyPress) {
+      return
+    }
     if (e.charCode == 0 || this.composing) return
     e.preventDefault()
     if (!this.cm.isReadOnly())

--- a/src/input/ContentEditableInput.js
+++ b/src/input/ContentEditableInput.js
@@ -359,13 +359,13 @@ export default class ContentEditableInput {
   }
 
   onKeyPress(e) {
-    if (e.charCode == 0 || this.composing) return
-    let shouldPreventDefault = this.cm.options.preventDefaultOnKeyPress
-    if (shouldPreventDefault) {
-      e.preventDefault()
+    if (!this.cm.options.preventDefaultOnKeyPress) {
+      return
     }
+    if (e.charCode == 0 || this.composing) return
+    e.preventDefault()
     if (!this.cm.isReadOnly())
-      operation(this.cm, applyTextInput)(this.cm, String.fromCharCode(e.charCode == null ? e.keyCode : e.charCode, null, null, shouldPreventDefault), 0)
+      operation(this.cm, applyTextInput)(this.cm, String.fromCharCode(e.charCode == null ? e.keyCode : e.charCode), 0)
   }
 
   readOnlyChanged(val) {

--- a/src/input/ContentEditableInput.js
+++ b/src/input/ContentEditableInput.js
@@ -359,13 +359,13 @@ export default class ContentEditableInput {
   }
 
   onKeyPress(e) {
-    if (!this.cm.options.preventDefaultOnKeyPress) {
-      return
-    }
     if (e.charCode == 0 || this.composing) return
-    e.preventDefault()
+    let shouldPreventDefault = this.cm.options.preventDefaultOnKeyPress
+    if (shouldPreventDefault) {
+      e.preventDefault()
+    }
     if (!this.cm.isReadOnly())
-      operation(this.cm, applyTextInput)(this.cm, String.fromCharCode(e.charCode == null ? e.keyCode : e.charCode), 0)
+      operation(this.cm, applyTextInput)(this.cm, String.fromCharCode(e.charCode == null ? e.keyCode : e.charCode, null, null, shouldPreventDefault), 0)
   }
 
   readOnlyChanged(val) {

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -20,7 +20,7 @@ export function setLastCopied(newLastCopied) {
   lastCopied = newLastCopied
 }
 
-export function applyTextInput(cm, inserted, deleted, sel, origin, shouldMakeChange) {
+export function applyTextInput(cm, inserted, deleted, sel, origin) {
   let doc = cm.doc
   cm.display.shift = false
   if (!sel) sel = doc.sel
@@ -55,9 +55,7 @@ export function applyTextInput(cm, inserted, deleted, sel, origin, shouldMakeCha
     }
     let changeEvent = {from: from, to: to, text: multiPaste ? multiPaste[i % multiPaste.length] : textLines,
                        origin: origin || (paste ? "paste" : cm.state.cutIncoming ? "cut" : "+input")}
-    if (shouldMakeChange !== false) {
-      makeChange(cm.doc, changeEvent)
-    }
+    makeChange(cm.doc, changeEvent)
     signalLater(cm, "inputRead", cm, changeEvent)
   }
   if (inserted && !paste)

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -20,7 +20,7 @@ export function setLastCopied(newLastCopied) {
   lastCopied = newLastCopied
 }
 
-export function applyTextInput(cm, inserted, deleted, sel, origin) {
+export function applyTextInput(cm, inserted, deleted, sel, origin, shouldMakeChange) {
   let doc = cm.doc
   cm.display.shift = false
   if (!sel) sel = doc.sel
@@ -55,7 +55,9 @@ export function applyTextInput(cm, inserted, deleted, sel, origin) {
     }
     let changeEvent = {from: from, to: to, text: multiPaste ? multiPaste[i % multiPaste.length] : textLines,
                        origin: origin || (paste ? "paste" : cm.state.cutIncoming ? "cut" : "+input")}
-    makeChange(cm.doc, changeEvent)
+    if (shouldMakeChange !== false) {
+      makeChange(cm.doc, changeEvent)
+    }
     signalLater(cm, "inputRead", cm, changeEvent)
   }
   if (inserted && !paste)


### PR DESCRIPTION
Adds a setting to work around the iOS issue detailed in #3403.

This doesn't seem to break anything in our use case, but let me know if there are other unintended consequences to this setting & change.