### PR TITLE
Fix middle-click paste on Firefox.

### DIFF
--- a/src/input/TextareaInput.js
+++ b/src/input/TextareaInput.js
@@ -76,8 +76,16 @@ export default class TextareaInput {
 
     on(display.scroller, "paste", e => {
       if (eventInWidget(display, e) || signalDOMEvent(cm, e)) return
-      cm.state.pasteIncoming = true
-      input.focus()
+      if (!te.dispatchEvent) {
+        cm.state.pasteIncoming = true
+        input.focus()
+        return
+      }
+
+      // Pass the `paste` event to the textarea so it's handled by its event listener.
+      const event = new Event("paste")
+      event.clipboardData = e.clipboardData
+      te.dispatchEvent(event)
     })
 
     // Prevent normal selection in the editor (we handle our own)


### PR DESCRIPTION
The current solution consists in focusing the
input when the scroll container capture a paste
event, which does not work on Firefox.

In order to fix this, creating a new paste event,
copying the clipboardData and dispatching it
on the textarea seems to do the trick.

This works on Firefox 64, with the
config set to true.