### PR TITLE
[soy mode] Add {element} as valid indenting tag.

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -13,7 +13,7 @@
 
   var indentingTags = ["template", "literal", "msg", "fallbackmsg", "let", "if", "elseif",
                        "else", "switch", "case", "default", "foreach", "ifempty", "for",
-                       "call", "param", "deltemplate", "delcall", "log"];
+                       "call", "param", "deltemplate", "delcall", "log", "element"];
 
   CodeMirror.defineMode("soy", function(config) {
     var textMode = CodeMirror.getMode(config, "text/plain");


### PR DESCRIPTION
The {element} command is a new feature in Soy.