### PR TITLE
Update to dark themes

### DIFF
--- a/theme/lesser-dark.css
+++ b/theme/lesser-dark.css
@@ -40,7 +40,7 @@ Ported to CodeMirror by Peter Kroon
 .cm-s-lesser-dark span.cm-tag { color: #669199; }
 .cm-s-lesser-dark span.cm-attribute { color: #81a4d5; }
 .cm-s-lesser-dark span.cm-hr { color: #999; }
-.cm-s-lesser-dark span.cm-link { color: #00c; }
+.cm-s-lesser-dark span.cm-link { color: #7070E6; }
 .cm-s-lesser-dark span.cm-error { color: #9d1e15; }
 
 .cm-s-lesser-dark .CodeMirror-activeline-background { background: #3C3A3A; }

--- a/theme/vibrant-ink.css
+++ b/theme/vibrant-ink.css
@@ -27,7 +27,7 @@
 .cm-s-vibrant-ink .cm-attribute { color: #8DA6CE; }
 .cm-s-vibrant-ink .cm-header { color: #FF6400; }
 .cm-s-vibrant-ink .cm-hr { color: #AEAEAE; }
-.cm-s-vibrant-ink .cm-link { color: #4C4CFD; }
+.cm-s-vibrant-ink .cm-link { color: #5656f3; }
 .cm-s-vibrant-ink .cm-error { border-bottom: 1px solid red; }
 
 .cm-s-vibrant-ink .CodeMirror-activeline-background { background: #27282E; }

--- a/theme/vibrant-ink.css
+++ b/theme/vibrant-ink.css
@@ -27,7 +27,7 @@
 .cm-s-vibrant-ink .cm-attribute { color: #8DA6CE; }
 .cm-s-vibrant-ink .cm-header { color: #FF6400; }
 .cm-s-vibrant-ink .cm-hr { color: #AEAEAE; }
-.cm-s-vibrant-ink .cm-link { color: #5656f3; }
+.cm-s-vibrant-ink .cm-link { color: #5656F3; }
 .cm-s-vibrant-ink .cm-error { border-bottom: 1px solid red; }
 
 .cm-s-vibrant-ink .CodeMirror-activeline-background { background: #27282E; }

--- a/theme/vibrant-ink.css
+++ b/theme/vibrant-ink.css
@@ -27,7 +27,7 @@
 .cm-s-vibrant-ink .cm-attribute { color: #8DA6CE; }
 .cm-s-vibrant-ink .cm-header { color: #FF6400; }
 .cm-s-vibrant-ink .cm-hr { color: #AEAEAE; }
-.cm-s-vibrant-ink .cm-link { color: blue; }
+.cm-s-vibrant-ink .cm-link { color: #4C4CFD; }
 .cm-s-vibrant-ink .cm-error { border-bottom: 1px solid red; }
 
 .cm-s-vibrant-ink .CodeMirror-activeline-background { background: #27282E; }


### PR DESCRIPTION
Lightening the blue link color (cm-link) on vibrant-ink and lesser-dark so that links show up better against the dark background.

theme/vibrant-ink.css     Before/After
![vibrant-ink-before](https://user-images.githubusercontent.com/1778998/52751698-5f428f00-2fbe-11e9-9eec-ae02b0752127.png)
![vibrant-ink-after](https://user-images.githubusercontent.com/1778998/52751700-623d7f80-2fbe-11e9-9d11-2fcf0ba8322d.png)

theme/lesser-dark.css    Before/After
![lesser-dark-before](https://user-images.githubusercontent.com/1778998/52751679-505bdc80-2fbe-11e9-9fe9-98ae9680306c.png)
![lesser-dark-after](https://user-images.githubusercontent.com/1778998/52751646-391cef00-2fbe-11e9-97eb-4e6ee668ea7b.png)