### PR TITLE
Typo: `npm build` should be `npm run build`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -646,7 +646,7 @@ Line endings for pasted content are now normalized to the editor's [preferred en
 
 ### New features
 
-The core is now maintained as a number of small files, using ES6 syntax and modules, under the `src/` directory. A git checkout no longer contains a working `codemirror.js` until you `npm build` (but when installing from NPM, it is included).
+The core is now maintained as a number of small files, using ES6 syntax and modules, under the `src/` directory. A git checkout no longer contains a working `codemirror.js` until you `npm run build` (but when installing from NPM, it is included).
 
 The [`refresh`](https://codemirror.net/doc/manual.html#event_refresh) event is now documented and stable.
 

--- a/doc/releases.html
+++ b/doc/releases.html
@@ -412,7 +412,7 @@
     <li><a href="https://codemirror.net/mode/javascript">javascript mode</a>: Improve support for class expressions. Support TypeScript optional class properties, the <code>abstract</code> keyword, and return type declarations for arrow functions.</li>
     <li><a href="https://codemirror.net/mode/css">css mode</a>: Fix highlighting of mixed-case keywords.</li>
     <li><a href="https://codemirror.net/doc/manual.html#addon_closebrackets">closebrackets addon</a>: Improve behavior when typing a quote before a string.</li>
-    <li>The core is now maintained as a number of small files, using ES6 syntax and modules, under the <code>src/</code> directory. A git checkout no longer contains a working <code>codemirror.js</code> until you <code>npm build</code> (but when installing from NPM, it is included).</li>
+    <li>The core is now maintained as a number of small files, using ES6 syntax and modules, under the <code>src/</code> directory. A git checkout no longer contains a working <code>codemirror.js</code> until you <code>npm run build</code> (but when installing from NPM, it is included).</li>
     <li>The <a href="https://codemirror.net/doc/manual.html#event_refresh"><code>refresh</code></a> event is now documented and stable.</li>
   </ul>
 


### PR DESCRIPTION
Hi! 👋

Wondering why I didn't have a `/lib/codemirror.js`, I grepped through the repository, and found this instruction:

```
npm build
```

However, running it doesn't work:

```
$ npm build
npm WARN build `npm build` called with no arguments. Did you mean to `npm run-script build`?
```

I then guessed the correct instruction, `npm run build`. I suppose this is a typo, so I fixed the changelog and release notes accordingly.