### PR TITLE
Added json-frontmatter and toml-frontmatter modes

### DIFF
--- a/mode/json-frontmatter/index.html
+++ b/mode/json-frontmatter/index.html
@@ -1,0 +1,107 @@
+<!doctype html>
+
+<title>CodeMirror: YAML front matter mode</title>
+<meta charset="utf-8"/>
+<link rel=stylesheet href="../../doc/docs.css">
+
+<link rel="stylesheet" href="../../lib/codemirror.css">
+<script src="../../lib/codemirror.js"></script>
+<script src="../../addon/mode/overlay.js"></script>
+<script src="../markdown/markdown.js"></script>
+<script src="../gfm/gfm.js"></script>
+<script src="../javascript/javascript.js"></script>
+<script src="json-frontmatter.js"></script>
+<style>.CodeMirror { border-top: 1px solid #ddd; border-bottom: 1px solid #ddd; }</style>
+<div id=nav>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+
+  <ul>
+    <li><a href="../../index.html">Home</a>
+    <li><a href="../../doc/manual.html">Manual</a>
+    <li><a href="https://github.com/codemirror/codemirror">Code</a>
+  </ul>
+  <ul>
+    <li><a href="../index.html">Language modes</a>
+    <li><a class=active href="#">TOML-Frontmatter</a>
+  </ul>
+</div>
+
+<article>
+  <h2>YAML front matter mode</h2>
+  <form><textarea id="code" name="code">
+---
+{
+     "Name": "John Doe",
+     "PermissionToCall": true,
+     "PhoneNumbers": [
+       {
+           "Location": "Home",
+           "Number": "555-555-1234"
+       },
+       {
+           "Location": "Work",
+           "Number": "555-555-9999 Ext. 123"
+       },
+       {
+           "Location": "Mobile",
+           "Number": "555-555-888"
+       }
+     ]
+}
+---
+
+GitHub Flavored Markdown
+========================
+
+Everything from markdown plus GFM features:
+
+## URL autolinking
+
+Underscores_are_allowed_between_words.
+
+## Strikethrough text
+
+GFM adds syntax to strikethrough text, which is missing from standard Markdown.
+
+~~Mistaken text.~~
+~~**works with other formatting**~~
+
+~~spans across
+lines~~
+
+## Fenced code blocks (and syntax highlighting)
+
+```javascript
+for (var i = 0; i &lt; items.length; i++) {
+    console.log(items[i], i); // log them
+}
+```
+
+## Task Lists
+
+- [ ] Incomplete task list item
+- [x] **Completed** task list item
+
+## A bit of GitHub spice
+
+* SHA: be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2
+* User@SHA ref: mojombo@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2
+* User/Project@SHA: mojombo/god@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2
+* \#Num: #1
+* User/#Num: mojombo#1
+* User/Project#Num: mojombo/god#1
+
+See http://github.github.com/github-flavored-markdown/.
+</textarea></form>
+
+<p>Defines a mode that parses
+a <a href="http://jekyllrb.com/docs/frontmatter/">YAML frontmatter</a>
+at the start of a file, switching to a base mode at the end of that.
+Takes a mode configuration option <code>base</code> to configure the
+base mode, which defaults to <code>"gfm"</code>.</p>
+
+    <script>
+      var editor = CodeMirror.fromTextArea(document.getElementById("code"), {mode: "json-frontmatter"});
+    </script>
+
+  </article>

--- a/mode/json-frontmatter/json-frontmatter.js
+++ b/mode/json-frontmatter/json-frontmatter.js
@@ -1,0 +1,68 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: https://codemirror.net/LICENSE
+
+(function (mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"), require("../javascript/javascript"))
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror", "../javascript/javascript"], mod)
+  else // Plain browser env
+    mod(CodeMirror)
+})(function (CodeMirror) {
+
+  var START = 0, FRONTMATTER = 1, BODY = 2
+
+  // a mixed mode for Markdown text with an optional TOML front matter
+  CodeMirror.defineMode("json-frontmatter", function (config, parserConfig) {
+    var jsonMode = CodeMirror.getMode(config, "javascript")
+    var innerMode = CodeMirror.getMode(config, parserConfig && parserConfig.base || "gfm")
+
+    function curMode(state) {
+      return state.state == BODY ? innerMode : jsonMode
+    }
+
+    return {
+      startState: function () {
+        return {
+          state: START,
+          inner: CodeMirror.startState(jsonMode)
+        }
+      },
+      copyState: function (state) {
+        return {
+          state: state.state,
+          inner: CodeMirror.copyState(curMode(state), state.inner)
+        }
+      },
+      token: function (stream, state) {
+        if (state.state == START) {
+          if (stream.match(/---/, false)) {
+            state.state = FRONTMATTER
+            return jsonMode.token(stream, state.inner)
+          } else {
+            state.state = BODY
+            state.inner = CodeMirror.startState(innerMode)
+            return innerMode.token(stream, state.inner)
+          }
+        } else if (state.state == FRONTMATTER) {
+          var end = stream.sol() && stream.match(/---/, false)
+          var style = jsonMode.token(stream, state.inner)
+          if (end) {
+            state.state = BODY
+            state.inner = CodeMirror.startState(innerMode)
+          }
+          return style
+        } else {
+          return innerMode.token(stream, state.inner)
+        }
+      },
+      innerMode: function (state) {
+        return {mode: curMode(state), state: state.inner}
+      },
+      blankLine: function (state) {
+        var mode = curMode(state)
+        if (mode.blankLine) return mode.blankLine(state.inner)
+      }
+    }
+  })
+});

--- a/mode/toml-frontmatter/index.html
+++ b/mode/toml-frontmatter/index.html
@@ -1,0 +1,122 @@
+<!doctype html>
+
+<title>CodeMirror: YAML front matter mode</title>
+<meta charset="utf-8"/>
+<link rel=stylesheet href="../../doc/docs.css">
+
+<link rel="stylesheet" href="../../lib/codemirror.css">
+<script src="../../lib/codemirror.js"></script>
+<script src="../../addon/mode/overlay.js"></script>
+<script src="../markdown/markdown.js"></script>
+<script src="../gfm/gfm.js"></script>
+<script src="../toml/toml.js"></script>
+<script src="toml-frontmatter.js"></script>
+<style>.CodeMirror { border-top: 1px solid #ddd; border-bottom: 1px solid #ddd; }</style>
+<div id=nav>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+
+  <ul>
+    <li><a href="../../index.html">Home</a>
+    <li><a href="../../doc/manual.html">Manual</a>
+    <li><a href="https://github.com/codemirror/codemirror">Code</a>
+  </ul>
+  <ul>
+    <li><a href="../index.html">Language modes</a>
+    <li><a class=active href="#">TOML-Frontmatter</a>
+  </ul>
+</div>
+
+<article>
+  <h2>YAML front matter mode</h2>
+  <form><textarea id="code" name="code">
+---
+# This is a TOML document.
+
+title = "TOML Example"
+
+[owner]
+name = "Tom Preston-Werner"
+dob = 1979-05-27T07:32:00-08:00 # First class dates
+
+[database]
+server = "192.168.1.1"
+ports = [ 8001, 8001, 8002 ]
+connection_max = 5000
+enabled = true
+
+[servers]
+
+  # Indentation (tabs and/or spaces) is allowed but not required
+  [servers.alpha]
+  ip = "10.0.0.1"
+  dc = "eqdc10"
+
+  [servers.beta]
+  ip = "10.0.0.2"
+  dc = "eqdc10"
+
+[clients]
+data = [ ["gamma", "delta"], [1, 2] ]
+
+# Line breaks are OK when inside arrays
+hosts = [
+  "alpha",
+  "omega"
+]
+---
+
+GitHub Flavored Markdown
+========================
+
+Everything from markdown plus GFM features:
+
+## URL autolinking
+
+Underscores_are_allowed_between_words.
+
+## Strikethrough text
+
+GFM adds syntax to strikethrough text, which is missing from standard Markdown.
+
+~~Mistaken text.~~
+~~**works with other formatting**~~
+
+~~spans across
+lines~~
+
+## Fenced code blocks (and syntax highlighting)
+
+```javascript
+for (var i = 0; i &lt; items.length; i++) {
+    console.log(items[i], i); // log them
+}
+```
+
+## Task Lists
+
+- [ ] Incomplete task list item
+- [x] **Completed** task list item
+
+## A bit of GitHub spice
+
+* SHA: be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2
+* User@SHA ref: mojombo@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2
+* User/Project@SHA: mojombo/god@be6a8cc1c1ecfe9489fb51e4869af15a13fc2cd2
+* \#Num: #1
+* User/#Num: mojombo#1
+* User/Project#Num: mojombo/god#1
+
+See http://github.github.com/github-flavored-markdown/.
+</textarea></form>
+
+<p>Defines a mode that parses
+a <a href="http://jekyllrb.com/docs/frontmatter/">YAML frontmatter</a>
+at the start of a file, switching to a base mode at the end of that.
+Takes a mode configuration option <code>base</code> to configure the
+base mode, which defaults to <code>"gfm"</code>.</p>
+
+    <script>
+      var editor = CodeMirror.fromTextArea(document.getElementById("code"), {mode: "toml-frontmatter"});
+    </script>
+
+  </article>

--- a/mode/toml-frontmatter/toml-frontmatter.js
+++ b/mode/toml-frontmatter/toml-frontmatter.js
@@ -1,0 +1,68 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: https://codemirror.net/LICENSE
+
+(function (mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"), require("../toml/toml"))
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror", "../toml/toml"], mod)
+  else // Plain browser env
+    mod(CodeMirror)
+})(function (CodeMirror) {
+
+  var START = 0, FRONTMATTER = 1, BODY = 2
+
+  // a mixed mode for Markdown text with an optional TOML front matter
+  CodeMirror.defineMode("toml-frontmatter", function (config, parserConfig) {
+    var tomlMode = CodeMirror.getMode(config, "toml")
+    var innerMode = CodeMirror.getMode(config, parserConfig && parserConfig.base || "gfm")
+
+    function curMode(state) {
+      return state.state == BODY ? innerMode : tomlMode
+    }
+
+    return {
+      startState: function () {
+        return {
+          state: START,
+          inner: CodeMirror.startState(tomlMode)
+        }
+      },
+      copyState: function (state) {
+        return {
+          state: state.state,
+          inner: CodeMirror.copyState(curMode(state), state.inner)
+        }
+      },
+      token: function (stream, state) {
+        if (state.state == START) {
+          if (stream.match(/---/, false)) {
+            state.state = FRONTMATTER
+            return tomlMode.token(stream, state.inner)
+          } else {
+            state.state = BODY
+            state.inner = CodeMirror.startState(innerMode)
+            return innerMode.token(stream, state.inner)
+          }
+        } else if (state.state == FRONTMATTER) {
+          var end = stream.sol() && stream.match(/---/, false)
+          var style = tomlMode.token(stream, state.inner)
+          if (end) {
+            state.state = BODY
+            state.inner = CodeMirror.startState(innerMode)
+          }
+          return style
+        } else {
+          return innerMode.token(stream, state.inner)
+        }
+      },
+      innerMode: function (state) {
+        return {mode: curMode(state), state: state.inner}
+      },
+      blankLine: function (state) {
+        var mode = curMode(state)
+        if (mode.blankLine) return mode.blankLine(state.inner)
+      }
+    }
+  })
+});


### PR DESCRIPTION
I am integrating CodeMirror to a markdown editor that will be used as editor for markdowns to be fed to static site generator Hugo, which uses YAML/TOML/JSON frontmatters.

I basically copied the yaml-frontmatter code to toml and json frontmatter modes and changed the start state to json/toml.

Sample / test index.html is also provided under the respective folders under the two new frontmatter modes.