### PR TITLE
Don't % jump to angled brackets

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1978,7 +1978,7 @@
           }
         }
         if (ch < lineText.length) {
-          var matched = cm.findMatchingBracket(Pos(line, ch), {bracketRegex: /[(){}[\]<>]/});
+          var matched = cm.findMatchingBracket(Pos(line, ch), {bracketRegex: /[(){}[\]]/});
           return matched.to;
         } else {
           return cursor;


### PR DESCRIPTION
Missed in prior commit 3675309aa9a9950a34c0e5cdc5a79e88d4ef9bc5

Repro is in the google_modes index.html test page for C++ editor if vim keyMap is used; the { in line 34 in the editor should not match against line 36's > character, but rather to line 38's } character.