### PR TITLE
Handle scanning for user provided brackets, e.g. "

### DIFF
--- a/addon/edit/matchbrackets.js
+++ b/addon/edit/matchbrackets.js
@@ -69,7 +69,7 @@
         var ch = line.charAt(pos);
         if (re.test(ch) && (style === undefined || cm.getTokenTypeAt(Pos(lineNo, pos + 1)) == style)) {
           var match = matching[ch];
-          if ((match.charAt(1) == ">") == (dir > 0)) stack.push(ch);
+          if (match && (match.charAt(1) == ">") == (dir > 0)) stack.push(ch);
           else if (!stack.length) return {pos: Pos(lineNo, pos), ch: ch};
           else stack.pop();
         }


### PR DESCRIPTION
Here's a PR to fix `scanForBracket` support for user provided "brackets", e.g. `"`, that fails with type error.

Editor content with cursor position indicated by |:

```
"wo|o"
```

and calling 

```js
editor.scanForBracket(editor.getCursor(), 1, "string", { bracketRegex: /"/ })
```

results in type error: 

```js
matchbrackets.js:108 Uncaught TypeError: Cannot read property 'charAt' of undefined
    at scanForBracket (matchbrackets.js:108)
    at CodeMirror.scanForBracket (matchbrackets.js:216)
    at <anonymous>:1:8
```

This fixes the issue at hand, making the call return the following, which is what you'd expect.

```json
{
  "pos": {
    "line": 0,
    "ch": 4,
    "sticky": null
  },
  "ch": "\""
}
```
