### PR TITLE
panda-syntax theme: use monospaced Source Code Pro instead of Source Sans Pro

### DIFF
--- a/theme/panda-syntax.css
+++ b/theme/panda-syntax.css
@@ -7,7 +7,7 @@
 	background: #292A2B;
 	color: #E6E6E6;
 	line-height: 1.5;
-	font-family: 'Operator Mono', 'Source Sans Pro', Menlo, Monaco, Consolas, Courier New, monospace;
+	font-family: 'Operator Mono', 'Source Code Pro', Menlo, Monaco, Consolas, Courier New, monospace;
 }
 .cm-s-panda-syntax .CodeMirror-cursor { border-color: #ff2c6d; }
 .cm-s-panda-syntax .CodeMirror-activeline-background {


### PR DESCRIPTION
https://codemirror.net/demo/theme.html#panda-syntax

#### before:
https://adobe-fonts.github.io/source-sans-pro/ is a proportional font family by Adobe (the "Source" in the name refers to being open source).
![image](https://user-images.githubusercontent.com/273688/54141626-b9543a00-442e-11e9-833b-e0d43c5338d1.png)

#### after:
https://adobe-fonts.github.io/source-code-pro/ is a matching monospace font family.
![image](https://user-images.githubusercontent.com/273688/54141930-4eefc980-442f-11e9-95a8-87347426bcc8.png)

(screenshots in chrome on fedora)

cc @siamak
