### PR TITLE
Added a new theme: yonce

### DIFF
--- a/demo/theme.html
+++ b/demo/theme.html
@@ -58,6 +58,7 @@
 <link rel="stylesheet" href="../theme/yeti.css">
 <link rel="stylesheet" href="../theme/idea.css">
 <link rel="stylesheet" href="../theme/darcula.css">
+<link rel="stylesheet" href="../theme/yonce.css">
 <link rel="stylesheet" href="../theme/zenburn.css">
 <script src="../lib/codemirror.js"></script>
 <script src="../mode/javascript/javascript.js"></script>
@@ -151,6 +152,7 @@ function findSequence(goal) {
     <option>xq-dark</option>
     <option>xq-light</option>
     <option>yeti</option>
+    <option>yonce</option>
     <option>zenburn</option>
 </select>
 </p>

--- a/theme/yonce.css
+++ b/theme/yonce.css
@@ -1,0 +1,44 @@
+/*
+
+    Name:       yoncé
+    Author:     Thomas MacLean (http://github.com/thomasmaclean)
+
+    Original yoncé color scheme by Mina Markham (https://github.com/minamarkham)
+
+*/
+
+.cm-s-yonce.CodeMirror { background: #1C1C1C; color: #d4d4d4; } /**/
+.cm-s-yonce div.CodeMirror-selected { background: rgba(252, 69, 133, 0.478); } /**/
+.cm-s-yonce .CodeMirror-line::selection, .cm-s-yonce .CodeMirror-line > span::selection, .cm-s-yonce .CodeMirror-line > span > span::selection { background: rgba(252, 67, 132, 0.47); }
+.cm-s-yonce .CodeMirror-line::-moz-selection, .cm-s-yonce .CodeMirror-line > span::-moz-selection, .cm-s-yonce .CodeMirror-line > span > span::-moz-selection { background: rgba(252, 67, 132, 0.47); }
+
+.cm-s-yonce.CodeMirror pre { padding-left: 15px; }
+.cm-s-yonce .CodeMirror-gutters {background: #1C1C1C; border-right: 0px;}
+.cm-s-yonce .CodeMirror-linenumber {color: #777777;  padding-right: 10px; }
+.cm-s-yonce .CodeMirror-activeline .CodeMirror-linenumber.CodeMirror-gutter-elt { background: #1C1C1C; color: #fc4384; }
+.cm-s-yonce .CodeMirror-linenumber { color: #777; }
+.cm-s-yonce .CodeMirror-cursor { border-left: 1px solid #FC4384; }
+
+.cm-s-yonce .cm-keyword { color: #00A7AA; } /**/
+.cm-s-yonce .cm-atom { color: #F39B35; }
+.cm-s-yonce .cm-number, .cm-s-yonce span.cm-type { color:  #A06FCA; } /**/
+.cm-s-yonce .cm-def { color: #D4D4D4; font-style: italic; }
+.cm-s-yonce .cm-property { color: #FC4384;  }
+.cm-s-yonce span.cm-variable-2 { color: #da7dae; font-style: italic; }
+.cm-s-yonce span.cm-variable-3 { color: #FC4384; } /**/
+.cm-s-yonce span.cm-tag { color: #D4D4D4; font-style: italic; } /**/
+.cm-s-yonce .cm-operator { color: #98E342; } /**/
+.cm-s-yonce .cm-comment { color:#696d70; font-style:italic; font-weight:normal; } /**/
+.cm-s-yonce .cm-string { color:#E6DB74; font-style:italic; } /**/
+.cm-s-yonce .cm-string-2 { color:#F39B35; } /*?*/
+.cm-s-yonce .cm-meta { background-color:#141414; color:#D4D4D4; } /*?*/
+.cm-s-yonce .cm-builtin { color: #FC4384; } /*?*/
+.cm-s-yonce .cm-tag { color: #00A7AA; } /**/
+.cm-s-yonce .cm-attribute { color: #A06FCA; } /*?*/
+.cm-s-yonce .cm-header { color: #da7dae; }
+.cm-s-yonce .cm-hr { color: #98E342; }
+.cm-s-yonce .cm-link { color:#696d70; font-style:italic; text-decoration:none; } /**/
+.cm-s-yonce .cm-error { border-bottom: 1px solid #C42412; }
+
+.cm-s-yonce .CodeMirror-activeline-background { background: #272727; }
+.cm-s-yonce .CodeMirror-matchingbracket { outline:1px solid grey; color:#D4D4D4 !important; }


### PR DESCRIPTION
Adapted from the popular Bash-It/Visual Studio Code/iTerm/Slack & Alfred theme, Yoncé, by @minamarkham. I say "adapted" as VSCode themes are very complex and allow for a bit more nuance, so I did the best I could. Along those same lines, only ASCII characters seem to work with the demo page, for whatever reason, so I changed the `é` to an `e`. 

Licence from the original VSCode theme:
https://github.com/minamarkham/yonce-vscode/blob/master/LICENSE

More info:
https://yoncetheme.com/