### PR TITLE
Fix clike mode to only match "_t" at the end of an identifier

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -284,7 +284,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
   // and those that end in _t (Reserved by POSIX for types)
   // http://www.gnu.org/software/libc/manual/html_node/Reserved-Names.html
   function cTypes(identifier) {
-    return contains(basicCTypes, identifier) || /.+_t/.test(identifier);
+    return contains(basicCTypes, identifier) || /.+_t$/.test(identifier);
   }
 
   // Returns true if identifier is a "Objective C" type.


### PR DESCRIPTION
Currently, clike mode will assign token "type" to C++ variable decls like:

```cpp
int m_total_population;
```

because the regex `.+_t` matches the `_t` part of total. The rule should only apply to names that end in `_t`, as referenced by the link in the comment above the function.