### PR TITLE
Recursively compute innerMode in continuelist addon

### DIFF
--- a/addon/edit/continuelist.js
+++ b/addon/edit/continuelist.js
@@ -23,7 +23,7 @@
 
       // If we're not in Markdown mode, fall back to normal newlineAndIndent
       var eolState = cm.getStateAfter(pos.line);
-      var inner = cm.getMode().innerMode(eolState);
+      var inner = CodeMirror.innerMode(cm.getMode(), eolState);
       if (inner.mode.name !== "markdown") {
         cm.execCommand("newlineAndIndent");
         return;


### PR DESCRIPTION
When creating an overlay mode from e.g. `gfm`, which has `markdown` as an `innerMode`, we need to recursively compute `innerMode` via `CodeMirror.innerMode` to correctly determine `markdown` descendant mode.

Fixes part of #5790.