### PR TITLE
Cancel selection before swapping document

### DIFF
--- a/src/edit/methods.js
+++ b/src/edit/methods.js
@@ -423,6 +423,8 @@ export default function(CodeMirror) {
     swapDoc: methodOp(function(doc) {
       let old = this.doc
       old.cm = null
+      // Cancel the current text selection if any (#5821)
+      if (this.state.selectingText) this.state.selectingText()
       attachDoc(this, doc)
       clearCaches(this)
       this.display.input.reset()

--- a/src/edit/mouse_events.js
+++ b/src/edit/mouse_events.js
@@ -305,8 +305,10 @@ function leftButtonSelect(cm, event, start, behavior) {
   function done(e) {
     cm.state.selectingText = false
     counter = Infinity
-    if (e) e_preventDefault(e)
-    display.input.focus()
+    if (e) {
+      e_preventDefault(e)
+      display.input.focus()
+    }
     off(display.wrapper.ownerDocument, "mousemove", move)
     off(display.wrapper.ownerDocument, "mouseup", up)
     doc.history.lastSelOrigin = null

--- a/src/edit/mouse_events.js
+++ b/src/edit/mouse_events.js
@@ -305,7 +305,7 @@ function leftButtonSelect(cm, event, start, behavior) {
   function done(e) {
     cm.state.selectingText = false
     counter = Infinity
-    e_preventDefault(e)
+    if (e) e_preventDefault(e)
     display.input.focus()
     off(display.wrapper.ownerDocument, "mousemove", move)
     off(display.wrapper.ownerDocument, "mouseup", up)

--- a/src/edit/mouse_events.js
+++ b/src/edit/mouse_events.js
@@ -305,6 +305,9 @@ function leftButtonSelect(cm, event, start, behavior) {
   function done(e) {
     cm.state.selectingText = false
     counter = Infinity
+    // If e is null or undefined we interpret this as someone trying
+    // to explicitly cancel the selection rather than the user
+    // letting go of the mouse button.
     if (e) {
       e_preventDefault(e)
       display.input.focus()


### PR DESCRIPTION
This change attempts to cancel any active selection prior to swapping the document in the `swapDoc` method in order to avoid conflicting information about the selection range. See the problem described in #5821.

Fixes #5821 