### PR TITLE
[xml-hint addon] Prevent extraneous quote

### DIFF
--- a/addon/hint/xml-hint.js
+++ b/addon/hint/xml-hint.js
@@ -92,6 +92,10 @@
             quote = token.string.charAt(len - 1);
             prefix = token.string.substr(n, len - 2);
           }
+          if (n) { // an opening quote
+            var line = cm.getLine(cur.line);
+            if (line.length > token.end && line.charAt(token.end) == quote) token.end++; // include a closing quote
+          }
           replaceToken = true;
         }
         for (var i = 0; i < atValues.length; ++i) if (!prefix || matches(atValues[i], prefix, matchInMiddle))


### PR DESCRIPTION
If typing `attribute="` and by `closetag` it becomes `attribute=""` and user presses `Ctrl-Space` to autocomplete and the completion is `"x"` then by this fix  it nicely gives `attribute="x"` instead of obnoxious `attribute="x""`.

Intentionally coded to cause least change to previous behavior, to deal with the frequent most obnoxious case.

Resisted temptation to make changes affecting other cases too.