### PR TITLE
[closetag addon] Optionally prefer empty-element tags

### DIFF
--- a/addon/edit/closetag.js
+++ b/addon/edit/closetag.js
@@ -21,6 +21,8 @@
  *   An array of tag names that should, when opened, cause a
  *   blank line to be added inside the tag, and the blank line and
  *   closing line to be indented.
+ * `emptyTags` (default is none)
+ *   An array of XML tag names that should be autoclosed with '/>'.
  *
  * See demos/closetag.html for a usage example.
  */
@@ -75,6 +77,12 @@
           dontCloseTags && indexOf(dontCloseTags, lowerTagName) > -1 ||
           closingTagExists(cm, tagName, pos, state, true))
         return CodeMirror.Pass;
+
+      var emptyTags = typeof opt == "object" && opt.emptyTags;
+      if (emptyTags && indexOf(emptyTags, tagName) > -1) {
+        replacements[i] = { text: "/>", newPos: CodeMirror.Pos(pos.line, pos.ch + 2) };
+        continue;
+      }
 
       var indent = indentTags && indexOf(indentTags, lowerTagName) > -1;
       replacements[i] = {indent: indent,


### PR DESCRIPTION
When user types `<atomic>` substitute `<atomic/>` if so configured.

In XML closing is required, and this option allows to automatically direct users towards entering
```
<very-long-but-empty-element attribute="something"/>
```
instead of
```
<very-long-but-empty-element attribute="something"></very-long-but-empty-element>
```
If necessary in an exceptional situation, however, user can easily override by removing the `/` in `/>` and type `</` to get a closing tag.