### PR TITLE
Adding compatibilty with HTMLHint 0.11.0

### DIFF
--- a/addon/lint/html-lint.js
+++ b/addon/lint/html-lint.js
@@ -29,7 +29,13 @@
 
   CodeMirror.registerHelper("lint", "html", function(text, options) {
     var found = [];
-    if (HTMLHint && !HTMLHint.verify) HTMLHint = HTMLHint.HTMLHint;
+    if (HTMLHint && !HTMLHint.verify) {
+      if(typeof HTMLHint.default !== 'undefined') {
+        HTMLHint = HTMLHint.default;
+      } else {
+        HTMLHint = HTMLHint.HTMLHint;
+      }
+    }
     if (!HTMLHint) HTMLHint = window.HTMLHint;
     if (!HTMLHint) {
       if (window.console) {


### PR DESCRIPTION
HTMLHint's v.0.11.0 added some structure changes to the HTMLHint Class. Because of that it is not being properly loaded within CodeMirror. This PR fixes that.

For better understanding on the problem, check the [differences on HTMHint's code](https://github.com/htmlhint/HTMLHint/commit/85a1c78984a8ec09ab17595efba2e6ac479e6f31#diff-7eb52b366866677666470e019283c8ea). 