### PR TITLE
[matchesonscrollbar addon] Fix possible discrepancy with search query

### DIFF
--- a/addon/search/matchesonscrollbar.js
+++ b/addon/search/matchesonscrollbar.js
@@ -46,7 +46,7 @@
       if (match.from.line >= this.gap.to) break;
       if (match.to.line >= this.gap.from) this.matches.splice(i--, 1);
     }
-    var cursor = this.cm.getSearchCursor(this.query, CodeMirror.Pos(this.gap.from, 0), this.caseFold);
+    var cursor = this.cm.getSearchCursor(this.query, CodeMirror.Pos(this.gap.from, 0), {caseFold: this.caseFold, multiline: this.options.multiline});
     var maxMatches = this.options && this.options.maxMatches || MAX_MATCHES;
     while (cursor.findNext()) {
       var match = {from: cursor.from(), to: cursor.to()};


### PR DESCRIPTION
The scrollbar annotations may fail to match search query under certain circumstances. This happens when the search cursor is `multiline: false`.

The matchesonscrollbar addon does not have a way to indicate `multiline: false`, the multiline status is heuristically determined and because of this it may end up being opposite of the status of the search cursor used by the search addon.

### Steps to reproduce:

1. Go to online demo page for CodeMirror search feature: <https://codemirror.net/demo/search.html>.
1. Replace the CodeMirror editor content with the following text:
  
  ```! https://github.com/uBlockOrigin/uAssets/issues/2380
  sportnews.to##+js(abort-on-property-write.js, KillAdBlock)
  
  ! https://github.com/uBlockOrigin/uAssets/issues/2382
  0mniscient.github.io##+js(bab-defuser.js)
  
  ! https://github.com/uBlockOrigin/uAssets/issues/2398
  tvcatchup.com##+js(bab-defuser.js)
  
  ! https://github.com/uBlockOrigin/uAssets/issues/2399
  viewasian.tv##+js(set-constant.js, allow_ads, true)
  viewasian.tv##.inside-video
  viewasian.tv##.inside-video-before
  viewasian.tv##+js(nowebrtc.js)
  
  ! https://github.com/uBlockOrigin/uAssets/issues/2400
  @@||h-anime.com^$generichide
  h-anime.com##[href^="https://www.yedclip.com/"]
  h-anime.com##+js(abort-current-inline-script.js, atob, tabunder)
  h-anime.com##+js(abort-current-inline-script.js, parseInt, tabunder)
  
  ! https://github.com/uBlockOrigin/uAssets/issues/2401
  @@||nysexoffenders.com^$generichide
  
  ! https://github.com/uBlockOrigin/uAssets/issues/2402
  @@||silicongadget.com^$generichide
  
  ! https://github.com/uBlockOrigin/uAssets/issues/2403
  @@||faststore.org^$generichide
  faststore.org##+js(abort-on-property-write.js, Fingerprint2)
  faststore.org##.adsbygoogle
  
  ! https://github.com/uBlockOrigin/uAssets/issues/2406
  empressleak.biz##+js(popads-dummy.js)
  ||empressleak.biz/wp-content/uploads/*skin.jpg$image
  ```
3. Be sure the caret is at the top of the CodeMirror editor then Ctrl-F the following search query:
  `/^[^!].*?github/`

### Result:

Only one instance will be highlighted in the CodeMirror edtor, while many instances will be highlighted in the scrollbar.

Now, the repro steps are a bit contrived in that the `multiline: false` is not set in the search option (I do not control that editor), but visually, you would get the same result should you call `getSearchCursor()` with `multiline: false`.

The issue is that there is no way to set `multiline` to  `false` for the search cursor used internally by the  matchesonscrollbar addon. The code change here is to address this, it allows to force `multiline` to `false` through the already existing ability to pass options to `showMatchesOnScrollbar()`. Once I pass `multiline: false` to both `getSearchCursor()` and `showMatchesOnScrollbar()`, the scrollbar annotations match the instances found in the main CodeMirror editor.

P.S. There are typos in my commit message, sorry about this: "ondicate" should be "indicate"; "determine" should be "determined".