### PR TITLE
Improve support for minification

### DIFF
--- a/mode/sql/sql.js
+++ b/mode/sql/sql.js
@@ -22,7 +22,7 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
       dateSQL        = parserConfig.dateSQL || {"date" : true, "time" : true, "timestamp" : true},
       backslashStringEscapes = parserConfig.backslashStringEscapes !== false,
       brackets       = parserConfig.brackets || /^[\{}\(\)\[\]]/,
-      punctuation    = parserConfig.punctuation || /^[;.,:]/
+      punctuation    = parserConfig.punctuation || /^[;.,:]/;
 
   function tokenBase(stream, state) {
     var ch = stream.next();


### PR DESCRIPTION
When this file is minified, the absence of a ";" after the definition of variable "punctuation" can lead to a run-time error. In my case, I'm using the minification engine embedded in the DNN platform (https://www.dnnsoftware.com).