### PR TITLE
Swift: properly handle empty strings

### DIFF
--- a/mode/swift/test.js
+++ b/mode/swift/test.js
@@ -40,7 +40,8 @@
      "[string multi]",
      "[string line]",
      "[string \"test\"]",
-     "[string \"\"\"]");
+     "[string \"\"\"]",
+     "[variable print][punctuation (][string \"\"][punctuation )]");
 
   // Comments.
   MT("comments",


### PR DESCRIPTION
Fixes #5793, a bug that was introduced in PR #5675. I'm working for and contributing this code on behalf of @CoderPad.

While writing this, I discovered a couple other bugs with Swift strings that I don't plan to work on at the moment (pre-existing bugs, not regressions; let me know if you want me to file a separate issue for these):

-The mode does not flag it as an error if you fail to include a newline after the opening `"""` or before the closing `"""` of a multiline string
-The mode doesn't properly highlight strings which use [extended string delimiters](https://docs.swift.org/swift-book/LanguageGuide/StringsAndCharacters.html#ID606)