### PR TITLE
[vim] fix issues related to visualBlock mode

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -2005,7 +2005,7 @@
                              '{': '}', '}': '{',
                              '[': ']', ']': '[',
                              '<': '>', '>': '<'};
-        var selfPaired = {'\'': true, '"': true};
+        var selfPaired = {'\'': true, '"': true, '`': true};
 
         var character = motionArgs.selectedCharacter;
         // 'b' refers to  '()' block.

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -1845,7 +1845,7 @@
         if (line < first && cur.line == first){
           return this.moveToStartOfLine(cm, head, motionArgs, vim);
         }else if (line > last && cur.line == last){
-            return this.moveToEol(cm, head, motionArgs, vim);
+            return this.moveToEol(cm, head, motionArgs, vim, true);
         }
         if (motionArgs.toFirstChar){
           endCh=findFirstNonWhiteSpaceCharacter(cm.getLine(line));
@@ -1947,13 +1947,15 @@
         vim.lastHSPos = cm.charCoords(head,'div').left;
         return moveToColumn(cm, repeat);
       },
-      moveToEol: function(cm, head, motionArgs, vim) {
+      moveToEol: function(cm, head, motionArgs, vim, keepHPos) {
         var cur = head;
-        vim.lastHPos = Infinity;
         var retval= Pos(cur.line + motionArgs.repeat - 1, Infinity);
         var end=cm.clipPos(retval);
         end.ch--;
-        vim.lastHSPos = cm.charCoords(end,'div').left;
+        if (!keepHPos) {
+          vim.lastHPos = Infinity;
+          vim.lastHSPos = cm.charCoords(end,'div').left;
+        }
         return retval;
       },
       moveToFirstNonWhiteSpaceCharacter: function(cm, head) {

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -286,7 +286,8 @@
         enterVimMode(cm);
     }
 
-    function fatCursorMarks(cm) {
+    function updateFatCursorMark(cm) {
+      clearFatCursorMark(cm);
       var ranges = cm.listSelections(), result = []
       for (var i = 0; i < ranges.length; i++) {
         var range = ranges[i]
@@ -302,25 +303,23 @@
           }
         }
       }
-      return result
+      cm.state.fatCursorMarks = result;
     }
 
-    function updateFatCursorMark(cm) {
-      var marks = cm.state.fatCursorMarks
-      if (marks) for (var i = 0; i < marks.length; i++) marks[i].clear()
-      cm.state.fatCursorMarks = fatCursorMarks(cm)
+    function clearFatCursorMark(cm) {
+      var marks = cm.state.fatCursorMarks;
+      if (marks) for (var i = 0; i < marks.length; i++) marks[i].clear();
+      cm.state.fatCursorMarks = null;
     }
 
     function enableFatCursorMark(cm) {
-      cm.state.fatCursorMarks = fatCursorMarks(cm)
+      updateFatCursorMark(cm)
       cm.on("cursorActivity", updateFatCursorMark)
     }
 
     function disableFatCursorMark(cm) {
-      var marks = cm.state.fatCursorMarks
-      if (marks) for (var i = 0; i < marks.length; i++) marks[i].clear()
-      cm.state.fatCursorMarks = null
-      cm.off("cursorActivity", updateFatCursorMark)
+      clearFatCursorMark(cm);
+      cm.off("cursorActivity", updateFatCursorMark);
     }
 
     // Deprecated, simply setting the keymap works again.

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1316,6 +1316,10 @@ testEdit('di)_close_spc', 'foo (bAr) baz', /\)/, 'di)', 'foo () baz');
 testEdit('da(_close_spc', 'foo (bAr) baz', /\)/, 'da(', 'foo  baz');
 testEdit('da)_close_spc', 'foo (bAr) baz', /\)/, 'da)', 'foo  baz');
 
+testEdit('di`', 'foo `bAr` baz', /`/, 'di`', 'foo `` baz');
+testEdit('di>', 'foo <bAr> baz', /</, 'di>', 'foo <> baz');
+testEdit('da<', 'foo <bAr> baz', /</, 'da<', 'foo  baz');
+
 //  delete around and inner b.
 testEdit('dab_on_(_should_delete_around_()block', 'o( in(abc) )', /\(a/, 'dab', 'o( in )');
 

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -323,6 +323,8 @@ testMotion('k', 'k', offsetCursor(word3.end, -1, 0), word3.end);
 testMotion('k_repeat', ['2', 'k'], makeCursor(0, 4), makeCursor(2, 4));
 testMotion('k_repeat_clip', ['1000', 'k'], makeCursor(0, 4), makeCursor(2, 4));
 testMotion('w', 'w', word1.start);
+testMotion('keepHPos', ['5', 'j', 'j', '7', 'k'], makeCursor(8, 12), makeCursor(12, 12));
+testMotion('keepHPosEol', ['$', '2', 'j'], makeCursor(2, 18));
 testMotion('w_multiple_newlines_no_space', 'w', makeCursor(12, 2), makeCursor(11, 2));
 testMotion('w_multiple_newlines_with_space', 'w', makeCursor(14, 0), makeCursor(12, 51));
 testMotion('w_repeat', ['2', 'w'], word2.start);

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1075,6 +1075,28 @@ testVim('c_visual_block_replay', function(cm, vim, helpers) {
   helpers.doKeys('.');
   eq('foo4\nfoo8\nfoodefg', cm.getValue());
 }, {value: '1234\n5678\nabcdefg'});
+testVim('I_visual_block_replay', function(cm, vim, helpers) {
+  cm.setCursor(0, 2);
+  helpers.doKeys('<C-v>', '2', 'j', 'l', 'I');
+  var replacement = fillArray('+-', 3);
+  cm.replaceSelections(replacement);
+  eq('12+-34\n56+-78\nab+-cdefg\nxyz', cm.getValue());
+  helpers.doKeys('<Esc>');
+  // ensure that repeat location doesn't depend on last selection
+  cm.setCursor(3, 2);
+  helpers.doKeys('g', 'v')
+  eq("+-34\n+-78\n+-cd", cm.getSelection())
+  cm.setCursor(0, 3);
+  helpers.doKeys('<C-v>', '1', 'j', '2', 'l');
+  eq("-34\n-78", cm.getSelection());
+  cm.setCursor(0, 0);
+  eq("", cm.getSelection());
+  helpers.doKeys('g', 'v');
+  eq("-34\n-78", cm.getSelection());
+  cm.setCursor(1, 1);
+  helpers.doKeys('.');
+  eq('12+-34\n5+-6+-78\na+-b+-cdefg\nx+-yz', cm.getValue());
+}, {value: '1234\n5678\nabcdefg\nxyz'});
 
 testVim('d_visual_block', function(cm, vim, helpers) {
   cm.setCursor(0, 1);


### PR DESCRIPTION
fixes:
- repeat for changes made with I in block selection mode being applied at the lastSel instead of current cursor
- missing text object for \` 
- desired column changing to infinity when moving down at the end of the file
- extra fatCursorMarks remaining in the document after using c from block selection mode 