### PR TITLE
[vim] fix @@ to rerun last run macro

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -2315,6 +2315,8 @@
         var macroModeState = vimGlobalState.macroModeState;
         if (registerName == '@') {
           registerName = macroModeState.latestRegister;
+        } else {
+          macroModeState.latestRegister = registerName;
         }
         while(repeat--){
           executeMacroRegister(cm, vim, macroModeState, registerName);

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -2644,6 +2644,14 @@ testVim('macro_last_ex_command_register', function (cm, vim, helpers) {
   eq('bbbaa', cm.getValue());
   helpers.assertCursorAt(0, 2);
 }, { value: 'aaaaa'});
+testVim('macro_last_run_macro', function (cm, vim, helpers) {
+  cm.setCursor(0, 0);
+  helpers.doKeys('q', 'a', 'C', 'a', '<Esc>', 'q');
+  helpers.doKeys('q', 'b', 'C', 'b', '<Esc>', 'q');
+  helpers.doKeys('@', 'a');
+  helpers.doKeys('@', '@');
+  eq('a', cm.getValue());
+}, { value: ''});
 testVim('macro_parens', function(cm, vim, helpers) {
   cm.setCursor(0, 0);
   helpers.doKeys('q', 'z', 'i');

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -2649,6 +2649,7 @@ testVim('macro_last_run_macro', function (cm, vim, helpers) {
   helpers.doKeys('q', 'a', 'C', 'a', '<Esc>', 'q');
   helpers.doKeys('q', 'b', 'C', 'b', '<Esc>', 'q');
   helpers.doKeys('@', 'a');
+  helpers.doKeys('d', 'd');
   helpers.doKeys('@', '@');
   eq('a', cm.getValue());
 }, { value: ''});


### PR DESCRIPTION
`vimGlobalState.macroModeState.latestRegister` was only ever updated when defining a macro. This change updates it when running a macro too so that `@@` actually repeats the last macro as it does in vim