### PR TITLE
[ruby] bug fix for curly brace indentation

### DIFF
--- a/mode/ruby/ruby.js
+++ b/mode/ruby/ruby.js
@@ -280,7 +280,16 @@ CodeMirror.defineMode("ruby", function(config) {
       if (state.tokenize[state.tokenize.length-1] != tokenBase) return CodeMirror.Pass;
       var firstChar = textAfter && textAfter.charAt(0);
       var ct = state.context;
-      var closing = ct.type == matching[firstChar] ||
+
+      function hasMatch(){
+        for (const i in matching) {
+          if (firstChar == matching[i]) {
+            return i
+          }
+        }
+      }
+
+      var closing = ct.type == hasMatch() ||
         ct.type == "keyword" && /^(?:end|until|else|elsif|when|rescue)\b/.test(textAfter);
       return ct.indented + (closing ? 0 : config.indentUnit) +
         (state.continuedLine ? config.indentUnit : 0);


### PR DESCRIPTION
There is a particular annoyance when going through an interactive web tutorial which lies in the auto-indenting of your code -- and by auto-indenting I mean to avoid pressing TAB.

In your interactive Ruby tutorial, and playground this was the case. To reproduce this bug, take for example the following uncompleted ruby playground environment, note the use of -> to mark indents.

```
def main
->5.times {|i|
->->puts i
-># ...
end
```
When I add the second curly brace } after the third line puts i, what I expect is one indent like ->} but what I get is the following
```
def main
->5.times {|i|
->->puts i
->->} # unnecessary indent
end
```
There is an extra indent, or in other words, a missing or faulty auto formatting.

I have provided a simple bug fix that solves the indenting issue for curly braces.