### PR TITLE
[emacs] Add "redo" keybinding in Emacs keymap

### DIFF
--- a/keymap/emacs.js
+++ b/keymap/emacs.js
@@ -369,6 +369,7 @@
 
     "Ctrl-/": repeated("undo"), "Shift-Ctrl--": repeated("undo"),
     "Ctrl-Z": repeated("undo"), "Cmd-Z": repeated("undo"),
+    "Shift-Ctrl-Z": "redo",
     "Shift-Alt-,": "goDocStart", "Shift-Alt-.": "goDocEnd",
     "Ctrl-S": "findPersistentNext", "Ctrl-R": "findPersistentPrev", "Ctrl-G": quit, "Shift-Alt-5": "replace",
     "Alt-/": "autocomplete",


### PR DESCRIPTION
Since "redo" is generally assigned to Ctrl+Y, we lose this binding
when using the Emacs keymap. The Emacs default for "redo" is a bit
complicated, but since we're using Ctrl-Z for "undo", it makes sense
to have Ctrl+Shift-Z for "redo".