### PR TITLE
[merge addon] Fix typo in hasMarker()

### DIFF
--- a/addon/merge/merge.js
+++ b/addon/merge/merge.js
@@ -918,7 +918,7 @@
     hasMarker: function(n) {
       var handle = this.cm.getLineHandle(n)
       if (handle.markedSpans) for (var i = 0; i < handle.markedSpans.length; i++)
-        if (handle.markedSpans[i].mark.collapsed && handle.markedSpans[i].to != null)
+        if (handle.markedSpans[i].marker.collapsed && handle.markedSpans[i].to != null)
           return true
       return false
     },


### PR DESCRIPTION
This was causing exceptions to be thrown when using custom markers.

Evidence:

![a](https://user-images.githubusercontent.com/585534/58551457-0b129200-81de-11e9-86d3-be0807f99854.png)
