### PR TITLE
[javascript mode] Support numeric separators

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -67,7 +67,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (ch == '"' || ch == "'") {
       state.tokenize = tokenString(ch);
       return state.tokenize(stream, state);
-    } else if (ch == "." && stream.match(/^\d+(?:[eE][+\-]?\d+)?/)) {
+    } else if (ch == "." && stream.match(/^[\d_]+(?:[eE][+\-]?[\d_]+)?/)) {
       return ret("number", "number");
     } else if (ch == "." && stream.match("..")) {
       return ret("spread", "meta");
@@ -75,10 +75,10 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
       return ret(ch);
     } else if (ch == "=" && stream.eat(">")) {
       return ret("=>", "operator");
-    } else if (ch == "0" && stream.match(/^(?:x[\da-f]+|o[0-7]+|b[01]+)n?/i)) {
+    } else if (ch == "0" && stream.match(/^(?:x[\dA-Fa-f_]+|o[0-7_]+|b[01_]+)n?/)) {
       return ret("number", "number");
     } else if (/\d/.test(ch)) {
-      stream.match(/^\d*(?:n|(?:\.\d*)?(?:[eE][+\-]?\d+)?)?/);
+      stream.match(/^[\d_]*(?:n|(?:\.[\d_]*)?(?:[eE][+\-]?[\d_]+)?)?/);
       return ret("number", "number");
     } else if (ch == "/") {
       if (stream.eat("*")) {

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -298,6 +298,15 @@
      "[keyword return]",
      "{} [string-2 /5/]")
 
+  MT("numeric separator",
+     "[number 123_456];",
+     "[number 0xdead_c0de];",
+     "[number 0o123_456];",
+     "[number 0b1101_1101];",
+     "[number .123_456e0_1];",
+     "[number 1E+123_456];",
+     "[number 12_34_56n];")
+
   var ts_mode = CodeMirror.getMode({indentUnit: 2}, "application/typescript")
   function TS(name) {
     test.mode(name, ts_mode, Array.prototype.slice.call(arguments, 1))


### PR DESCRIPTION
Note that the new regular expression is more permissive than
the spec proposal, e.g. `0_._1` or `1__2` are not valid numbers.

However, filtering out these cases would make the tokenizer
unnecessarily complex.

Fixes: https://github.com/codemirror/CodeMirror/issues/5926