### PR TITLE
[search addon] Escape sequence only for \n, \r, \t and \\

### DIFF
--- a/addon/search/search.js
+++ b/addon/search/search.js
@@ -78,10 +78,12 @@
   }
 
   function parseString(string) {
-    return string.replace(/\\(.)/g, function(_, ch) {
+    return string.replace(/\\([nrt\\])/g, function(match, ch) {
       if (ch == "n") return "\n"
       if (ch == "r") return "\r"
-      return ch
+      if (ch == "t") return "\t"
+      if (ch == "\\") return "\\"
+      return match
     })
   }
 


### PR DESCRIPTION
When `\` is followed by any other character, it will not be
interpreted as an escape sequence, i.e. `\3` will be
interpreted as literal `\3`, not as `3`.

Fixes https://github.com/codemirror/CodeMirror/issues/5428