### PR TITLE
Reflect tab unit and size for defaultTab command

### DIFF
--- a/src/edit/commands.js
+++ b/src/edit/commands.js
@@ -105,7 +105,12 @@ export let commands = {
   },
   defaultTab: cm => {
     if (cm.somethingSelected()) cm.indentSelection("add")
-    else cm.execCommand("insertTab")
+    else {
+      let ranges = cm.listSelections();
+      if (ranges.length === 0) { return }
+
+      cm.indentLine(ranges[0].head.line, null, true);
+    }
   },
   // Swap the two chars left and right of each selection's head.
   // Move cursor behind the two swapped characters afterwards.

--- a/src/edit/commands.js
+++ b/src/edit/commands.js
@@ -106,10 +106,10 @@ export let commands = {
   defaultTab: cm => {
     if (cm.somethingSelected()) cm.indentSelection("add")
     else {
-      let ranges = cm.listSelections();
+      let ranges = cm.listSelections()
       if (ranges.length === 0) { return }
 
-      cm.indentLine(ranges[0].head.line, null, true);
+      cm.indentLine(ranges[0].head.line, null, true)
     }
   },
   // Swap the two chars left and right of each selection's head.


### PR DESCRIPTION
I've tracked a Chromium bug (https://bugs.chromium.org/p/chromium/issues/detail?id=977394) back to the fact that CodeMirror assumes tabs should be done with insertTab execCommand rather than using indentLine. This PR changes the behavior such that the tab unit and size are used instead.