### PR TITLE
[sparql mode] Non-ASCII variable names

### DIFF
--- a/mode/sparql/sparql.js
+++ b/mode/sparql/sparql.js
@@ -41,7 +41,7 @@ CodeMirror.defineMode("sparql", function(config) {
       if(ch == "?" && stream.match(/\s/, false)){
         return "operator";
       }
-      stream.match(/^[\w\d]*/);
+      stream.match(/^[A-Za-z0-9_\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][A-Za-z0-9_\u00B7\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u037D\u037F-\u1FFF\u200C-\u200D\u203F-\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]*/);
       return "variable-2";
     }
     else if (ch == "<" && !stream.match(/^[\s\u00a0=]/, false)) {


### PR DESCRIPTION
This regex is ES3-compliant but it misses non-BMP characters specified in SPARQL standard.

This should be preferred if compatibility with old JavaScript is wanted. Else the other PR #5937 should be preferred. Both PR are excluding.

Closes #5935