### PR TITLE
[javascript mode] don't detect backtick-enclosed fatarrows

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -195,7 +195,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
         ++depth;
       } else if (wordRE.test(ch)) {
         sawSomething = true;
-      } else if (/["'\/]/.test(ch)) {
+      } else if (/["'\/`]/.test(ch)) {
         for (;; --pos) {
           if (pos == 0) return
           var next = stream.string.charAt(pos - 1)


### PR DESCRIPTION
cf. #2993 and 27fe44c which fixed the analogous issue for single-quotes, double-quotes and regex literals.