### PR TITLE
Dart class tokens

### DIFF
--- a/mode/dart/dart.js
+++ b/mode/dart/dart.js
@@ -112,7 +112,7 @@
   function className(stream) {
     stream.backUp(1);
     if (stream.match(/[_$]*[A-Z][a-zA-Z0-9_$]*/, true)) {
-      return "class";
+      return "variable-2";
     }
 
     // variable starting with an underscore

--- a/mode/dart/dart.js
+++ b/mode/dart/dart.js
@@ -78,9 +78,41 @@
         if (!stream.eat("*")) return false
         state.tokenize = tokenNestedComment(1)
         return state.tokenize(stream, state)
-      }
+      },
+      "A": className,
+      "B": className,
+      "C": className,
+      "D": className,
+      "E": className,
+      "F": className,
+      "G": className,
+      "H": className,
+      "I": className,
+      "J": className,
+      "K": className,
+      "L": className,
+      "M": className,
+      "N": className,
+      "O": className,
+      "P": className,
+      "Q": className,
+      "R": className,
+      "S": className,
+      "T": className,
+      "U": className,
+      "V": className,
+      "W": className,
+      "X": className,
+      "Y": className,
+      "Z": className,
+      "_": className,
     }
   });
+
+  function className(stream) {
+    stream.eatWhile(/[a-zA-Z0-9_$]/);
+    return "class";
+  }
 
   function tokenString(quote, stream, state, raw) {
     var tripleQuoted = false;

--- a/mode/dart/dart.js
+++ b/mode/dart/dart.js
@@ -79,46 +79,14 @@
         state.tokenize = tokenNestedComment(1)
         return state.tokenize(stream, state)
       },
-      "A": className,
-      "B": className,
-      "C": className,
-      "D": className,
-      "E": className,
-      "F": className,
-      "G": className,
-      "H": className,
-      "I": className,
-      "J": className,
-      "K": className,
-      "L": className,
-      "M": className,
-      "N": className,
-      "O": className,
-      "P": className,
-      "Q": className,
-      "R": className,
-      "S": className,
-      "T": className,
-      "U": className,
-      "V": className,
-      "W": className,
-      "X": className,
-      "Y": className,
-      "Z": className,
-      "_": className,
+      token: function (stream) {
+        // Assume uppercase symbols are classes, use variable-2
+        if (stream.current().match(/[_$]*[A-Z][a-zA-Z0-9_$]*/, true)) {
+          return 'variable-2';
+        }
+      }
     }
   });
-
-  function className(stream) {
-    stream.backUp(1);
-    if (stream.match(/[_$]*[A-Z][a-zA-Z0-9_$]*/, true)) {
-      return "variable-2";
-    }
-
-    // variable starting with an underscore
-    stream.eatWhile(/[_$]*[a-zA-Z0-9_$]*/);
-    return "variable";
-  }
 
   function tokenString(quote, stream, state, raw) {
     var tripleQuoted = false;

--- a/mode/dart/dart.js
+++ b/mode/dart/dart.js
@@ -79,10 +79,10 @@
         state.tokenize = tokenNestedComment(1)
         return state.tokenize(stream, state)
       },
-      token: function(stream, state, style) {
+      token: function(stream, _, style) {
         if (style == "variable") {
           // Assume uppercase symbols are classes using variable-2
-          let isUpper = RegExp('^[_$]*[A-Z][a-zA-Z0-9_$]*$','g');
+          var isUpper = RegExp('^[_$]*[A-Z][a-zA-Z0-9_$]*$','g');
           if (isUpper.test(stream.current())) {
             return 'variable-2';
           }

--- a/mode/dart/dart.js
+++ b/mode/dart/dart.js
@@ -79,10 +79,13 @@
         state.tokenize = tokenNestedComment(1)
         return state.tokenize(stream, state)
       },
-      token: function (stream) {
-        // Assume uppercase symbols are classes, use variable-2
-        if (stream.current().match(/[_$]*[A-Z][a-zA-Z0-9_$]*/, true)) {
-          return 'variable-2';
+      token: function(stream, state, style) {
+        if (style == "variable") {
+          // Assume uppercase symbols are classes using variable-2
+          let isUpper = RegExp('^[_$]*[A-Z][a-zA-Z0-9_$]*$','g');
+          if (isUpper.test(stream.current())) {
+            return 'variable-2';
+          }
         }
       }
     }

--- a/mode/dart/dart.js
+++ b/mode/dart/dart.js
@@ -110,8 +110,14 @@
   });
 
   function className(stream) {
-    stream.eatWhile(/[a-zA-Z0-9_$]/);
-    return "class";
+    stream.backUp(1);
+    if (stream.match(/[_$]*[A-Z][a-zA-Z0-9_$]*/, true)) {
+      return "class";
+    }
+
+    // variable starting with an underscore
+    stream.eatWhile(/[_$]*[a-zA-Z0-9_$]*/);
+    return "variable";
   }
 
   function tokenString(quote, stream, state, raw) {


### PR DESCRIPTION
This adds additional hooks to the Dart mode. This uses the `variable-2` token type for tokens matching `Uppercase` or `_UppercaseWithUnderscore` where `_lowercaseUnderscore` are assumed to be normal variables.

The Dart mode uses the `clike` mode, so this uses the `hooks` feature from that to avoid writing a  custom `token()` function.