### PR TITLE
[javascript mode] fix tokenizing of underscore properties

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -67,7 +67,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (ch == '"' || ch == "'") {
       state.tokenize = tokenString(ch);
       return state.tokenize(stream, state);
-    } else if (ch == "." && stream.match(/^[\d_]+(?:[eE][+\-]?[\d_]+)?/)) {
+    } else if (ch == "." && stream.match(/^\d[\d_]*(?:[eE][+\-]?[\d_]+)?/)) {
       return ret("number", "number");
     } else if (ch == "." && stream.match("..")) {
       return ret("spread", "meta");

--- a/mode/javascript/test.js
+++ b/mode/javascript/test.js
@@ -310,6 +310,13 @@
      "[number 1E+123_456];",
      "[number 12_34_56n];")
 
+  MT("underscore property",
+     "[variable something].[property _property];",
+     "[variable something].[property _123];",
+     "[variable something].[property _for];",
+     "[variable _for];",
+     "[variable _123];")
+
   var ts_mode = CodeMirror.getMode({indentUnit: 2}, "application/typescript")
   function TS(name) {
     test.mode(name, ts_mode, Array.prototype.slice.call(arguments, 1))


### PR DESCRIPTION
The regexp for parsing numbers with numeric separators is too
broad. This way, we mistake properties starting with underscore
to be numbers.