### PR TITLE
remove unmaintained codev.it

### DIFF
--- a/doc/realworld.html
+++ b/doc/realworld.html
@@ -57,7 +57,6 @@
       <li><a href="http://sasstwo.codeschool.com/levels/1/challenges/1">Code School</a> (online tech learning environment)</li>
       <li><a href="http://code-snippets.bungeshea.com/">Code Snippets</a> (WordPress snippet management plugin)</li>
       <li><a href="http://antonmi.github.io/code_together/">Code together</a> (collaborative editing)</li>
-      <li><a href="http://codev.it/">Codev</a> (collaborative IDE)</li>
       <li><a href="https://www.codevolve.com/">Codevolve</a> (programming lessons as-a-service)</li>
       <li><a href="http://www.codezample.com">CodeZample</a> (code snippet sharing)</li>
       <li><a href="http://codio.com">Codio</a> (Web IDE)</li>


### PR DESCRIPTION
The domain http://codev.it is Inaccessible,  the [latest twitter](https://twitter.com/codevit) was post on Sep 2015.
It's better to remove it.