### PR TITLE
Foldgutter: make it possible to redefine the `widget` prop

### DIFF
--- a/addon/fold/foldgutter.js
+++ b/addon/fold/foldgutter.js
@@ -100,7 +100,7 @@
     if (gutter != opts.gutter) return;
     var folded = isFolded(cm, line);
     if (folded) folded.clear();
-    else cm.foldCode(Pos(line, 0), opts.rangeFinder);
+    else cm.foldCode(Pos(line, 0), opts);
   }
 
   function onChange(cm) {


### PR DESCRIPTION
Currently if I want to specify a custom widget for folded ranges it would not work when I fold a range using the gutter. This happens because `onGutterClick` function passes through only `rangeFinder`  option.
The solution is to pass all options, which is supported by the `foldCode` method.