### PR TITLE
[handlebars mode] add support for triple mustache tags

### DIFF
--- a/mode/handlebars/handlebars.js
+++ b/mode/handlebars/handlebars.js
@@ -13,9 +13,13 @@
 
   CodeMirror.defineSimpleMode("handlebars-tags", {
     start: [
+      { regex: /\{\{\{/, push: "handlebars_raw", token: "tag" },
       { regex: /\{\{!--/, push: "dash_comment", token: "comment" },
       { regex: /\{\{!/,   push: "comment", token: "comment" },
       { regex: /\{\{/,    push: "handlebars", token: "tag" }
+    ],
+    handlebars_raw: [
+      { regex: /\}\}\}/, pop: true, token: "tag" },
     ],
     handlebars: [
       { regex: /\}\}/, pop: true, token: "tag" },

--- a/mode/handlebars/index.html
+++ b/mode/handlebars/index.html
@@ -41,6 +41,8 @@
 
 {{! one line comment }}
 
+{{{propertyContainingRawHtml}}}
+
 {{#each articles}}
   {{~title}}
   <p>{{excerpt body size=120 ellipsis=true}}</p>


### PR DESCRIPTION
This PR adds support for triple mustaches like 

```hbs
{{{rawHtml}}}
```
that can be used in Handlebars to avoid HTML-escaping the output.
