### PR TITLE
Make ".CodeMirror pre" selector more specific

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -13,7 +13,8 @@
 .CodeMirror-lines {
   padding: 4px 0; /* Vertical padding around content */
 }
-.CodeMirror pre {
+.CodeMirror pre.CodeMirror-line,
+.CodeMirror pre.CodeMirror-measure-elem {
   padding: 0 4px; /* Horizontal padding of content */
 }
 
@@ -236,7 +237,8 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
   cursor: text;
   min-height: 1px; /* prevents collapsing before first draw */
 }
-.CodeMirror pre {
+.CodeMirror pre.CodeMirror-line,
+.CodeMirror pre.CodeMirror-measure-elem {
   /* Reset some styles that the rest of the page might have set */
   -moz-border-radius: 0; -webkit-border-radius: 0; border-radius: 0;
   border-width: 0;
@@ -255,7 +257,8 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
   -webkit-font-variant-ligatures: contextual;
   font-variant-ligatures: contextual;
 }
-.CodeMirror-wrap pre {
+.CodeMirror-wrap pre.CodeMirror-line,
+.CodeMirror-wrap pre.CodeMirror-measure-elem {
   word-wrap: break-word;
   white-space: pre-wrap;
   word-break: normal;

--- a/src/measurement/position_measurement.js
+++ b/src/measurement/position_measurement.js
@@ -18,7 +18,7 @@ export function paddingTop(display) {return display.lineSpace.offsetTop}
 export function paddingVert(display) {return display.mover.offsetHeight - display.lineSpace.offsetHeight}
 export function paddingH(display) {
   if (display.cachedPaddingH) return display.cachedPaddingH
-  let e = removeChildrenAndAdd(display.measure, elt("pre", "x"))
+  let e = removeChildrenAndAdd(display.measure, elt("pre", "x", "CodeMirror-measure-elem"))
   let style = window.getComputedStyle ? window.getComputedStyle(e) : e.currentStyle
   let data = {left: parseInt(style.paddingLeft), right: parseInt(style.paddingRight)}
   if (!isNaN(data.left) && !isNaN(data.right)) display.cachedPaddingH = data
@@ -585,7 +585,7 @@ let measureText
 export function textHeight(display) {
   if (display.cachedTextHeight != null) return display.cachedTextHeight
   if (measureText == null) {
-    measureText = elt("pre")
+    measureText = elt("pre", null, "CodeMirror-measure-elem")
     // Measure a bunch of lines, for browsers that compute
     // fractional heights.
     for (let i = 0; i < 49; ++i) {
@@ -605,7 +605,7 @@ export function textHeight(display) {
 export function charWidth(display) {
   if (display.cachedCharWidth != null) return display.cachedCharWidth
   let anchor = elt("span", "xxxxxxxxxx")
-  let pre = elt("pre", [anchor])
+  let pre = elt("pre", [anchor], "CodeMirror-measure-elem")
   removeChildrenAndAdd(display.measure, pre)
   let rect = anchor.getBoundingClientRect(), width = (rect.right - rect.left) / 10
   if (width > 2) display.cachedCharWidth = width


### PR DESCRIPTION
Currently, `lib/codemirror.css` contains a broad selector for `.CodeMirror pre` in a couple places. It seems intended to match the `pre` tags corresponding to `.CodeMirror-line` and also the ones for measurement.

However, if you want to create a widget or line widget that contains a `pre` tag, it ends up inheriting a bunch of styles you don't expect.

Since `pre` tags seem to only be created in a few places, I searched through the code and made sure they always have an appropriate classname. Then I modified the selector to only target the desired CodeMirror elements.