### PR TITLE
Fix placeholder styling after <pre> change

### DIFF
--- a/addon/display/placeholder.js
+++ b/addon/display/placeholder.js
@@ -39,7 +39,7 @@
     var elt = cm.state.placeholder = document.createElement("pre");
     elt.style.cssText = "height: 0; overflow: visible";
     elt.style.direction = cm.getOption("direction");
-    elt.className = "CodeMirror-placeholder";
+    elt.className = "CodeMirror-placeholder CodeMirror-line-like";
     var placeHolder = cm.getOption("placeholder")
     if (typeof placeHolder == "string") placeHolder = document.createTextNode(placeHolder)
     elt.appendChild(placeHolder)

--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -14,7 +14,7 @@
   padding: 4px 0; /* Vertical padding around content */
 }
 .CodeMirror pre.CodeMirror-line,
-.CodeMirror pre.CodeMirror-measure-elem {
+.CodeMirror pre.CodeMirror-line-like {
   padding: 0 4px; /* Horizontal padding of content */
 }
 
@@ -238,7 +238,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
   min-height: 1px; /* prevents collapsing before first draw */
 }
 .CodeMirror pre.CodeMirror-line,
-.CodeMirror pre.CodeMirror-measure-elem {
+.CodeMirror pre.CodeMirror-line-like {
   /* Reset some styles that the rest of the page might have set */
   -moz-border-radius: 0; -webkit-border-radius: 0; border-radius: 0;
   border-width: 0;
@@ -258,7 +258,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
   font-variant-ligatures: contextual;
 }
 .CodeMirror-wrap pre.CodeMirror-line,
-.CodeMirror-wrap pre.CodeMirror-measure-elem {
+.CodeMirror-wrap pre.CodeMirror-line-like {
   word-wrap: break-word;
   white-space: pre-wrap;
   word-break: normal;

--- a/src/measurement/position_measurement.js
+++ b/src/measurement/position_measurement.js
@@ -18,7 +18,7 @@ export function paddingTop(display) {return display.lineSpace.offsetTop}
 export function paddingVert(display) {return display.mover.offsetHeight - display.lineSpace.offsetHeight}
 export function paddingH(display) {
   if (display.cachedPaddingH) return display.cachedPaddingH
-  let e = removeChildrenAndAdd(display.measure, elt("pre", "x", "CodeMirror-measure-elem"))
+  let e = removeChildrenAndAdd(display.measure, elt("pre", "x", "CodeMirror-line-like"))
   let style = window.getComputedStyle ? window.getComputedStyle(e) : e.currentStyle
   let data = {left: parseInt(style.paddingLeft), right: parseInt(style.paddingRight)}
   if (!isNaN(data.left) && !isNaN(data.right)) display.cachedPaddingH = data
@@ -585,7 +585,7 @@ let measureText
 export function textHeight(display) {
   if (display.cachedTextHeight != null) return display.cachedTextHeight
   if (measureText == null) {
-    measureText = elt("pre", null, "CodeMirror-measure-elem")
+    measureText = elt("pre", null, "CodeMirror-line-like")
     // Measure a bunch of lines, for browsers that compute
     // fractional heights.
     for (let i = 0; i < 49; ++i) {
@@ -605,7 +605,7 @@ export function textHeight(display) {
 export function charWidth(display) {
   if (display.cachedCharWidth != null) return display.cachedCharWidth
   let anchor = elt("span", "xxxxxxxxxx")
-  let pre = elt("pre", [anchor], "CodeMirror-measure-elem")
+  let pre = elt("pre", [anchor], "CodeMirror-line-like")
   removeChildrenAndAdd(display.measure, pre)
   let rect = anchor.getBoundingClientRect(), width = (rect.right - rect.left) / 10
   if (width > 2) display.cachedCharWidth = width


### PR DESCRIPTION
Turns out my previous PR #5963 did actually break something -- the `placeholder.js` addon was rendering wrong without these styles. This PR re-adds them for the `pre.CodeMirror-placeholder` class.

The placeholder appears to be the only addon that does this.