### PR TITLE
significant speed optimisation when large amount of lines are folded

### DIFF
--- a/addon/fold/foldgutter.js
+++ b/addon/fold/foldgutter.js
@@ -51,8 +51,13 @@
 
   function isFolded(cm, line) {
     var marks = cm.findMarks(Pos(line, 0), Pos(line + 1, 0));
-    for (var i = 0; i < marks.length; ++i)
-      if (marks[i].__isFold && marks[i].find().from.line == line) return marks[i];
+    for (var i = 0; i < marks.length; ++i) {
+      if (marks[i].__isFold) {
+        var fromPos = marks[i].find(-1);
+        if (fromPos && fromPos.line === line)
+          return marks[i];
+      }
+    }
   }
 
   function marker(spec) {


### PR DESCRIPTION
UI begins to lag when a block of text over 10000 lines are folded. Browser will freeze for minutes when line count increased to 100K.
The isFolded function only requires looking forward, optimised the code by passing the -1 argument to the TextMarker.find method.
Code folding is now instantaneous even with 100K lines involved.