### PR TITLE
Add passive event listeners to Chrome audit recommended events

### DIFF
--- a/src/util/event.js
+++ b/src/util/event.js
@@ -10,7 +10,8 @@ const noHandlers = []
 
 export let on = function(emitter, type, f) {
   if (emitter.addEventListener) {
-    emitter.addEventListener(type, f, false)
+    const passive = type === 'wheel' || type === 'mousewheel' || type === 'touchstart' || type === 'touchmove'
+    emitter.addEventListener(type, f, passive ? {passive} :false)
   } else if (emitter.attachEvent) {
     emitter.attachEvent("on" + type, f)
   } else {

--- a/src/util/event.js
+++ b/src/util/event.js
@@ -10,7 +10,7 @@ const noHandlers = []
 
 export let on = function(emitter, type, f) {
   if (emitter.addEventListener) {
-    const passive = type === 'wheel' || type === 'mousewheel' || type === 'touchstart' || type === 'touchmove'
+    const passive = type === 'touchmove'
     emitter.addEventListener(type, f, passive ? {passive} :false)
   } else if (emitter.attachEvent) {
     emitter.attachEvent("on" + type, f)


### PR DESCRIPTION
Chrome recommends that using `passive` event listeners for wheel, mousewheel, touchstart, and touchmove events ([source](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners?utm_source=lighthouse&utm_medium=devtools))

Including CodeMirror causes this warning in the Chrome audit as well:
<img width="708" alt="Screenshot 2019-08-15 18 12 23" src="https://user-images.githubusercontent.com/8397708/63136804-90f5dc00-bf88-11e9-90fe-38a992dacce4.png">


If this change is not desired, feel free to just close this PR 👍 