### PR TITLE
Stop using the `keypress` event.

### DIFF
--- a/src/edit/CodeMirror.js
+++ b/src/edit/CodeMirror.js
@@ -18,7 +18,7 @@ import { bind, copyObj, Delayed } from "../util/misc.js"
 
 import { clearDragCursor, onDragOver, onDragStart, onDrop } from "./drop_events.js"
 import { ensureGlobalHandlers } from "./global_events.js"
-import { onKeyDown, onKeyPress, onKeyUp } from "./key_events.js"
+import { onKeyDown, onKeyUp } from "./key_events.js"
 import { clickInGutter, onContextMenu, onMouseDown } from "./mouse_events.js"
 import { themeChanged } from "./utils.js"
 import { defaults, optionHandlers, Init } from "./options.js"
@@ -203,7 +203,6 @@ function registerEventHandlers(cm) {
   let inp = d.input.getField()
   on(inp, "keyup", e => onKeyUp.call(cm, e))
   on(inp, "keydown", operation(cm, onKeyDown))
-  on(inp, "keypress", operation(cm, onKeyPress))
   on(inp, "focus", e => onFocus(cm, e))
   on(inp, "blur", e => onBlur(cm, e))
 }

--- a/src/edit/key_events.js
+++ b/src/edit/key_events.js
@@ -123,6 +123,8 @@ export function onKeyDown(e) {
   // Turn mouse into crosshair when Alt is held on Mac.
   if (code == 18 && !/\bCodeMirror-crosshair\b/.test(cm.display.lineDiv.className))
     showCrossHair(cm)
+
+  onKeyPress.call(cm, e)
 }
 
 function showCrossHair(cm) {
@@ -145,13 +147,16 @@ export function onKeyUp(e) {
   signalDOMEvent(this, e)
 }
 
+// We don't handle keypress events from the browser anymore (this is called as
+// part of the handling of keydown events instead). But we keep
+// `CodeMirror.triggerOnKeyPress` for backwards compatibility.
 export function onKeyPress(e) {
   let cm = this
   if (eventInWidget(cm.display, e) || signalDOMEvent(cm, e) || e.ctrlKey && !e.altKey || mac && e.metaKey) return
-  let keyCode = e.keyCode, charCode = e.charCode
+  let keyCode = e.keyCode
   if (presto && keyCode == lastStoppedKey) {lastStoppedKey = null; e_preventDefault(e); return}
-  if ((presto && (!e.which || e.which < 10)) && handleKeyBinding(cm, e)) return
-  let ch = String.fromCharCode(charCode == null ? keyCode : charCode)
+  if (presto && (!e.which || e.which < 10) && handleKeyBinding(cm, e)) return
+  let ch = e.key
   // Some browsers fire keypress events for backspace
   if (ch == "\x08") return
   if (handleCharBinding(cm, e, ch)) return


### PR DESCRIPTION
This change was motivated by noticing that vim-mode behaves differently
on my mac vs linux boxes. In particular, when holding down a movement
key (eg 'j' or 'k') on linux, the movement repeats, so I can move 20
lines with one keypress. However, on my mac, on keypress translates into
one movement, no matter how long I hold the key. Note: I'm running
Chrome 76 on both machines.

I noticed that the actual event handling is being done via the
`keypress` event, which is deprecated, and I believe we should be able
to do the same handling on the `keydown` event.

We kept the `onKeyPress` handler, though it's not triggered by
`keypress` events anymore. This is to maintain backwards compatibility
with `CodeMirror.triggerOnKeyPress` (which could be deprecated).

We now get the character from `e.key` rather than
`String.fromCharCode(charCode == null ? keyCode : charCode)`. In my
testing I saw in instance where I pressed 'j' and
* `e.keyCode == 74` (though `String.fromCharCode(74) == 'J'`, it should
  really be 106 for `j`)
* `e.charCode == 0`
* `e.key == 'j'`

So I decided to just go with `.key`, which is well supported according
to Mozilla
(https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Browser_compatibility).

Testing:
* I ran the test suite (test/index.html) locally. There were three
  failures (core_move_bidi_Όȝǝڪȉۥ״ۺ׆ɀҩۏ ҳ, core_move_bidi_ŌӰтقȤ؁ƥ؅٣ĎȺ١
  Ϛ, and core_issue_4878), but these also appear as failures on master.
* I verified that I can type and that holding movement keys repeats
  movement on the Vim bindings demo (demo/vim.html).
  - Chrome 76 on linux
  - Chrome 76 on mac
  - Firefox 60 on linux
* Ran `bin/lint`