### PR TITLE
Prevent removing textarea.form.submit handler with opts.leaveSubmitMethodAlone

### DIFF
--- a/src/edit/fromTextArea.js
+++ b/src/edit/fromTextArea.js
@@ -48,7 +48,7 @@ export function fromTextArea(textarea, options) {
       textarea.style.display = ""
       if (textarea.form) {
         off(textarea.form, "submit", save)
-        if (typeof textarea.form.submit == "function")
+        if (!options.leaveSubmitMethodAlone && typeof textarea.form.submit == "function")
           textarea.form.submit = realSubmit
       }
     }


### PR DESCRIPTION
When CodeMirror is initialised with `{leaveSubmitMethodAlone: true}`, `realSubmit` is never filled with the original submit handler, leaving it null/void. 

When `finishInit` runs, it then **overwrites** the `submit` method with a null/void value. As a result, the application I'm working with breaks when it tries to save the form CodeMirror is in. 

[As an aside, I had to use `leaveSubmitMethodAlone` in the first place because I ran into some submit issues in another scenario (with moved/removed codemirror instances IIRC). I can't reproduce that now; it might have been an older version.]