### PR TITLE
Fix Kotlin indent for first line in lambda with params

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -685,7 +685,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
         var firstChar = textAfter && textAfter.charAt(0);
         if ((state.prevToken == "}" || state.prevToken == ")") && textAfter == "")
           return state.indented;
-        if (state.prevToken == "operator" && textAfter != "}" ||
+        if ((state.prevToken == "operator" && textAfter != "}" && state.context.type != "}") ||
           state.prevToken == "variable" && firstChar == "." ||
           (state.prevToken == "}" || state.prevToken == ")") && firstChar == ".")
           return indentUnit * 2 + ctx.indented;


### PR DESCRIPTION
Fix `indent` for lambda expression with parameters, [for  example](https://kotlinlang.org/docs/reference/coroutines/cancellation-and-timeouts.html) – in line  `println("job: I'm sleeping $i ...")`:
<img width="721" alt="Screenshot 2019-09-04 at 16 12 20" src="https://user-images.githubusercontent.com/242514/64257850-cb6eeb00-cf2e-11e9-9ac8-3586969d4499.png">
After indent code like:
```kotlin
repeat(1000) { i ->
    println("job: I'm sleeping $i ...")
    delay(500L)
}
```
