### PR TITLE
Schedule a redraw on changes instead of change

### DIFF
--- a/addon/fold/foldgutter.js
+++ b/addon/fold/foldgutter.js
@@ -16,7 +16,7 @@
       cm.clearGutter(cm.state.foldGutter.options.gutter);
       cm.state.foldGutter = null;
       cm.off("gutterClick", onGutterClick);
-      cm.off("change", onChange);
+      cm.off("changes", onChange);
       cm.off("viewportChange", onViewportChange);
       cm.off("fold", onFold);
       cm.off("unfold", onFold);
@@ -26,7 +26,7 @@
       cm.state.foldGutter = new State(parseOptions(val));
       updateInViewport(cm);
       cm.on("gutterClick", onGutterClick);
-      cm.on("change", onChange);
+      cm.on("changes", onChange);
       cm.on("viewportChange", onViewportChange);
       cm.on("fold", onFold);
       cm.on("unfold", onFold);

--- a/addon/scroll/annotatescrollbar.js
+++ b/addon/scroll/annotatescrollbar.js
@@ -43,7 +43,7 @@
     cm.on("markerAdded", this.resizeHandler);
     cm.on("markerCleared", this.resizeHandler);
     if (options.listenForChanges !== false)
-      cm.on("change", this.changeHandler = function() {
+      cm.on("changes", this.changeHandler = function() {
         scheduleRedraw(250);
       });
   }
@@ -116,7 +116,7 @@
     this.cm.off("refresh", this.resizeHandler);
     this.cm.off("markerAdded", this.resizeHandler);
     this.cm.off("markerCleared", this.resizeHandler);
-    if (this.changeHandler) this.cm.off("change", this.changeHandler);
+    if (this.changeHandler) this.cm.off("changes", this.changeHandler);
     this.div.parentNode.removeChild(this.div);
   };
 });


### PR DESCRIPTION
The setTimeout/clearTimeout overhead of re-scheduling on every change in a large operation can be significant. This cuts the time of a particularly large operation I was testing from 5s to 2.5s (replacing some text in ~5000 lines). The majority of the rest of the time coming from rescheduling of the highlight worker inside the startWorker call.