### PR TITLE
[foldgutter] reuse old markers if indicatorOpen/Folded is string

### DIFF
--- a/addon/fold/foldgutter.js
+++ b/addon/fold/foldgutter.js
@@ -71,23 +71,35 @@
   }
 
   function updateFoldInfo(cm, from, to) {
-    var opts = cm.state.foldGutter.options, cur = from;
+    var opts = cm.state.foldGutter.options, cur = from - 1;
     var minSize = cm.foldOption(opts, "minFoldSize");
     var func = cm.foldOption(opts, "rangeFinder");
+    // we can reuse the built-in indicator element if its className matches the new state
+    var clsFolded = typeof opts.indicatorFolded == "string" && classTest(opts.indicatorFolded);
+    var clsOpen = typeof opts.indicatorOpen == "string" && classTest(opts.indicatorOpen);
     cm.eachLine(from, to, function(line) {
+      ++cur;
       var mark = null;
+      var old = line.gutterMarkers;
+      if (old) old = old[opts.gutter];
       if (isFolded(cm, cur)) {
+        if (clsFolded && old && clsFolded.test(old.className)) return;
         mark = marker(opts.indicatorFolded);
       } else {
         var pos = Pos(cur, 0);
         var range = func && func(cm, pos);
-        if (range && range.to.line - range.from.line >= minSize)
+        if (range && range.to.line - range.from.line >= minSize) {
+          if (clsOpen && old && clsOpen.test(old.className)) return;
           mark = marker(opts.indicatorOpen);
+        }
       }
+      if (!mark && !old) return;
       cm.setGutterMarker(line, opts.gutter, mark);
-      ++cur;
     });
   }
+
+  // copied from CodeMirror/src/util/dom.js
+  function classTest(cls) { return new RegExp("(^|\\s)" + cls + "(?:$|\\s)\\s*") }
 
   function updateInViewport(cm) {
     var vp = cm.getViewport(), state = cm.state.foldGutter;


### PR DESCRIPTION
On large documents foldgutter spends a lot of time (0.2s, 0.5s, or even a second) unnecessarily forcing CodeMirror to recreate the unchanged mark elements:

![before](https://user-images.githubusercontent.com/1310400/65419941-7ffe7d00-de08-11e9-81d1-822ce85c7d2d.png)

With this PR on a large document we'll spend 10+ times less on folding+rendering:

![after](https://user-images.githubusercontent.com/1310400/65419956-87be2180-de08-11e9-9679-d20530fe91a0.png)

* The built-in indicator element for open/folded states differs only by its className so we can optimize for this case. This PR leaves the old marker unchanged if its className contains the new class.

* With a user-provided element the only case we can optimize for is to skip removing the marker when there were none. Such a check is implemented in this PR.

* `classTest` function was copied from [/src/util/dom.js](https://github.com/codemirror/CodeMirror/blob/master/src/util/dom.js) because AFAICT we can't use [classList.contains](https://developer.mozilla.org/en-US/docs/Web/API/element/classList) in some browsers still supported by CodeMirror.