### PR TITLE
adjustments for eclipse java

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -470,7 +470,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
                     "do else enum extends final finally for goto if implements import " +
                     "instanceof interface native new package private protected public " +
                     "return static strictfp super switch synchronized this throw throws transient " +
-                    "try volatile while @interface"),
+                    "try void volatile while @interface"),
     types: words("byte short int long float double boolean char void Boolean Byte Character Double Float " +
                  "Integer Long Number Object Short String StringBuffer StringBuilder Void"),
     blockKeywords: words("catch class do else finally for if switch try while"),

--- a/theme/eclipse.css
+++ b/theme/eclipse.css
@@ -1,4 +1,4 @@
-.cm-s-eclipse span.cm-meta { color: #FF1717; }
+.cm-s-eclipse span.cm-meta { color: #646464; }
 .cm-s-eclipse span.cm-keyword { line-height: 1em; font-weight: bold; color: #7F0055; }
 .cm-s-eclipse span.cm-atom { color: #219; }
 .cm-s-eclipse span.cm-number { color: #164; }


### PR DESCRIPTION
- added void as keyword
- used correct color annotations

I haven't found a CSS class telling that it is java - please check the changes and provide advice if where is a better solution.

# Open:
`
.cm-s-eclipse span.cm-type + span.cm-variable {
	color: #00f !important;
}
`
primitive types have a wrong color too:
`
jQuery( ".cm-s-eclipse span.cm-type:contains('boolean')" )
  .css({"color": "#7F0055", "font-weight": "bold"});
});
`
# Result the changes
![image](https://user-images.githubusercontent.com/774984/65814160-8d3bb300-e1de-11e9-8afc-987db07f1fe5.png)

## Fixed
- void has the correct color
- boolean return type has the correct color // JS local fix
## Needs work
- Class name has still the wrong color
- String as a primitive type as still a wrong color
- methods have a wrong color
