### PR TITLE
Add alt attribute to codemirror logo images

### DIFF
--- a/mode/apl/index.html
+++ b/mode/apl/index.html
@@ -12,7 +12,7 @@
 	.CodeMirror { border: 2px inset #dee; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/apl/index.html
+++ b/mode/apl/index.html
@@ -12,7 +12,7 @@
 	.CodeMirror { border: 2px inset #dee; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/asciiarmor/index.html
+++ b/mode/asciiarmor/index.html
@@ -9,7 +9,7 @@
 <script src="asciiarmor.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/asciiarmor/index.html
+++ b/mode/asciiarmor/index.html
@@ -9,7 +9,7 @@
 <script src="asciiarmor.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/asn.1/index.html
+++ b/mode/asn.1/index.html
@@ -16,7 +16,7 @@
 </style>
 <div id=nav>
     <a href="https://codemirror.net"><h1>CodeMirror</h1>
-        <img id=logo src="../../doc/logo.png" alt="CodeMirror logo">
+        <img id=logo src="../../doc/logo.png" alt="">
     </a>
 
     <ul>

--- a/mode/asn.1/index.html
+++ b/mode/asn.1/index.html
@@ -16,7 +16,7 @@
 </style>
 <div id=nav>
     <a href="https://codemirror.net"><h1>CodeMirror</h1>
-        <img id=logo src="../../doc/logo.png">
+        <img id=logo src="../../doc/logo.png" alt="CodeMirror logo">
     </a>
 
     <ul>

--- a/mode/asterisk/index.html
+++ b/mode/asterisk/index.html
@@ -13,7 +13,7 @@
       .cm-s-default span.cm-arrow { color: red; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/asterisk/index.html
+++ b/mode/asterisk/index.html
@@ -13,7 +13,7 @@
       .cm-s-default span.cm-arrow { color: red; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/brainfuck/index.html
+++ b/mode/brainfuck/index.html
@@ -12,7 +12,7 @@
 	.CodeMirror { border: 2px inset #dee; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/brainfuck/index.html
+++ b/mode/brainfuck/index.html
@@ -12,7 +12,7 @@
 	.CodeMirror { border: 2px inset #dee; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/clike/index.html
+++ b/mode/clike/index.html
@@ -12,7 +12,7 @@
 <script src="clike.js"></script>
 <style>.CodeMirror {border: 2px inset #dee;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/clike/index.html
+++ b/mode/clike/index.html
@@ -12,7 +12,7 @@
 <script src="clike.js"></script>
 <style>.CodeMirror {border: 2px inset #dee;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/clike/scala.html
+++ b/mode/clike/scala.html
@@ -10,7 +10,7 @@
 <script src="../../addon/edit/matchbrackets.js"></script>
 <script src="clike.js"></script>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/clike/scala.html
+++ b/mode/clike/scala.html
@@ -10,7 +10,7 @@
 <script src="../../addon/edit/matchbrackets.js"></script>
 <script src="clike.js"></script>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/clojure/index.html
+++ b/mode/clojure/index.html
@@ -11,7 +11,7 @@
 <script src="clojure.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/clojure/index.html
+++ b/mode/clojure/index.html
@@ -11,7 +11,7 @@
 <script src="clojure.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/cmake/index.html
+++ b/mode/cmake/index.html
@@ -13,7 +13,7 @@
       .cm-s-default span.cm-arrow { color: red; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/cmake/index.html
+++ b/mode/cmake/index.html
@@ -13,7 +13,7 @@
       .cm-s-default span.cm-arrow { color: red; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/cobol/index.html
+++ b/mode/cobol/index.html
@@ -39,7 +39,7 @@
         .CodeMirror-activeline-background {background: #555555 !important;}
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/cobol/index.html
+++ b/mode/cobol/index.html
@@ -39,7 +39,7 @@
         .CodeMirror-activeline-background {background: #555555 !important;}
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/coffeescript/index.html
+++ b/mode/coffeescript/index.html
@@ -9,7 +9,7 @@
 <script src="coffeescript.js"></script>
 <style>.CodeMirror {border-top: 1px solid silver; border-bottom: 1px solid silver;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/coffeescript/index.html
+++ b/mode/coffeescript/index.html
@@ -9,7 +9,7 @@
 <script src="coffeescript.js"></script>
 <style>.CodeMirror {border-top: 1px solid silver; border-bottom: 1px solid silver;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/commonlisp/index.html
+++ b/mode/commonlisp/index.html
@@ -9,7 +9,7 @@
 <script src="commonlisp.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/commonlisp/index.html
+++ b/mode/commonlisp/index.html
@@ -9,7 +9,7 @@
 <script src="commonlisp.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/crystal/index.html
+++ b/mode/crystal/index.html
@@ -14,7 +14,7 @@
 </style>
 
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/crystal/index.html
+++ b/mode/crystal/index.html
@@ -14,7 +14,7 @@
 </style>
 
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/css/gss.html
+++ b/mode/css/gss.html
@@ -13,7 +13,7 @@
 <script src="../../addon/hint/css-hint.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/css/gss.html
+++ b/mode/css/gss.html
@@ -13,7 +13,7 @@
 <script src="../../addon/hint/css-hint.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/css/index.html
+++ b/mode/css/index.html
@@ -12,7 +12,7 @@
 <script src="../../addon/hint/css-hint.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/css/index.html
+++ b/mode/css/index.html
@@ -12,7 +12,7 @@
 <script src="../../addon/hint/css-hint.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/css/less.html
+++ b/mode/css/less.html
@@ -10,7 +10,7 @@
 <script src="css.js"></script>
 <style>.CodeMirror {border: 1px solid #ddd; line-height: 1.2;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/css/less.html
+++ b/mode/css/less.html
@@ -10,7 +10,7 @@
 <script src="css.js"></script>
 <style>.CodeMirror {border: 1px solid #ddd; line-height: 1.2;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/css/scss.html
+++ b/mode/css/scss.html
@@ -10,7 +10,7 @@
 <script src="css.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/css/scss.html
+++ b/mode/css/scss.html
@@ -10,7 +10,7 @@
 <script src="css.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/cypher/index.html
+++ b/mode/cypher/index.html
@@ -16,7 +16,7 @@
 }
         </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/cypher/index.html
+++ b/mode/cypher/index.html
@@ -16,7 +16,7 @@
 }
         </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/d/index.html
+++ b/mode/d/index.html
@@ -10,7 +10,7 @@
 <script src="d.js"></script>
 <style>.CodeMirror {border: 2px inset #dee;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/d/index.html
+++ b/mode/d/index.html
@@ -10,7 +10,7 @@
 <script src="d.js"></script>
 <style>.CodeMirror {border: 2px inset #dee;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/dart/index.html
+++ b/mode/dart/index.html
@@ -9,7 +9,7 @@
 <script src="dart.js"></script>
 <style>.CodeMirror {border: 1px solid #dee;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/dart/index.html
+++ b/mode/dart/index.html
@@ -9,7 +9,7 @@
 <script src="dart.js"></script>
 <style>.CodeMirror {border: 1px solid #dee;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/diff/index.html
+++ b/mode/diff/index.html
@@ -15,7 +15,7 @@
       span.cm-error.cm-tag { background-color: #2b2; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/diff/index.html
+++ b/mode/diff/index.html
@@ -15,7 +15,7 @@
       span.cm-error.cm-tag { background-color: #2b2; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/django/index.html
+++ b/mode/django/index.html
@@ -13,7 +13,7 @@
 <script src="django.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/django/index.html
+++ b/mode/django/index.html
@@ -13,7 +13,7 @@
 <script src="django.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/dockerfile/index.html
+++ b/mode/dockerfile/index.html
@@ -10,7 +10,7 @@
 <script src="dockerfile.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/dockerfile/index.html
+++ b/mode/dockerfile/index.html
@@ -10,7 +10,7 @@
 <script src="dockerfile.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/dtd/index.html
+++ b/mode/dtd/index.html
@@ -9,7 +9,7 @@
 <script src="dtd.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/dtd/index.html
+++ b/mode/dtd/index.html
@@ -9,7 +9,7 @@
 <script src="dtd.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/dylan/index.html
+++ b/mode/dylan/index.html
@@ -12,7 +12,7 @@
 <script src="dylan.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/dylan/index.html
+++ b/mode/dylan/index.html
@@ -12,7 +12,7 @@
 <script src="dylan.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/ebnf/index.html
+++ b/mode/ebnf/index.html
@@ -13,7 +13,7 @@
   </head>
   <body>
     <div id=nav>
-      <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+      <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
       <ul>
         <li><a href="../../index.html">Home</a>

--- a/mode/ebnf/index.html
+++ b/mode/ebnf/index.html
@@ -13,7 +13,7 @@
   </head>
   <body>
     <div id=nav>
-      <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+      <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
       <ul>
         <li><a href="../../index.html">Home</a>

--- a/mode/ecl/index.html
+++ b/mode/ecl/index.html
@@ -9,7 +9,7 @@
 <script src="ecl.js"></script>
 <style>.CodeMirror {border: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/ecl/index.html
+++ b/mode/ecl/index.html
@@ -9,7 +9,7 @@
 <script src="ecl.js"></script>
 <style>.CodeMirror {border: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/eiffel/index.html
+++ b/mode/eiffel/index.html
@@ -13,7 +13,7 @@
       .cm-s-default span.cm-arrow { color: red; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/eiffel/index.html
+++ b/mode/eiffel/index.html
@@ -13,7 +13,7 @@
       .cm-s-default span.cm-arrow { color: red; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/elm/index.html
+++ b/mode/elm/index.html
@@ -9,7 +9,7 @@
 <script src="elm.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/elm/index.html
+++ b/mode/elm/index.html
@@ -9,7 +9,7 @@
 <script src="elm.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/erlang/index.html
+++ b/mode/erlang/index.html
@@ -11,7 +11,7 @@
 <script src="erlang.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/erlang/index.html
+++ b/mode/erlang/index.html
@@ -11,7 +11,7 @@
 <script src="erlang.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/factor/index.html
+++ b/mode/factor/index.html
@@ -16,7 +16,7 @@
 }
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/factor/index.html
+++ b/mode/factor/index.html
@@ -16,7 +16,7 @@
 }
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/fcl/index.html
+++ b/mode/fcl/index.html
@@ -11,7 +11,7 @@
 <script src="fcl.js"></script>
 <style>.CodeMirror {border:1px solid #999; background:#ffc}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/fcl/index.html
+++ b/mode/fcl/index.html
@@ -11,7 +11,7 @@
 <script src="fcl.js"></script>
 <style>.CodeMirror {border:1px solid #999; background:#ffc}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/forth/index.html
+++ b/mode/forth/index.html
@@ -16,7 +16,7 @@
 }
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/forth/index.html
+++ b/mode/forth/index.html
@@ -16,7 +16,7 @@
 }
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/fortran/index.html
+++ b/mode/fortran/index.html
@@ -9,7 +9,7 @@
 <script src="fortran.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/fortran/index.html
+++ b/mode/fortran/index.html
@@ -9,7 +9,7 @@
 <script src="fortran.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/gas/index.html
+++ b/mode/gas/index.html
@@ -9,7 +9,7 @@
 <script src="gas.js"></script>
 <style>.CodeMirror {border: 2px inset #dee;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/gas/index.html
+++ b/mode/gas/index.html
@@ -9,7 +9,7 @@
 <script src="gas.js"></script>
 <style>.CodeMirror {border: 2px inset #dee;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/gfm/index.html
+++ b/mode/gfm/index.html
@@ -20,7 +20,7 @@
   .cm-s-default .cm-emoji {color: #009688;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/gfm/index.html
+++ b/mode/gfm/index.html
@@ -20,7 +20,7 @@
   .cm-s-default .cm-emoji {color: #009688;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/gherkin/index.html
+++ b/mode/gherkin/index.html
@@ -9,7 +9,7 @@
 <script src="gherkin.js"></script>
 <style>.CodeMirror { border-top: 1px solid #ddd; border-bottom: 1px solid #ddd; }</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/gherkin/index.html
+++ b/mode/gherkin/index.html
@@ -9,7 +9,7 @@
 <script src="gherkin.js"></script>
 <style>.CodeMirror { border-top: 1px solid #ddd; border-bottom: 1px solid #ddd; }</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/go/index.html
+++ b/mode/go/index.html
@@ -11,7 +11,7 @@
 <script src="go.js"></script>
 <style>.CodeMirror {border:1px solid #999; background:#ffc}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/go/index.html
+++ b/mode/go/index.html
@@ -11,7 +11,7 @@
 <script src="go.js"></script>
 <style>.CodeMirror {border:1px solid #999; background:#ffc}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/groovy/index.html
+++ b/mode/groovy/index.html
@@ -10,7 +10,7 @@
 <script src="groovy.js"></script>
 <style>.CodeMirror {border-top: 1px solid #500; border-bottom: 1px solid #500;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/groovy/index.html
+++ b/mode/groovy/index.html
@@ -10,7 +10,7 @@
 <script src="groovy.js"></script>
 <style>.CodeMirror {border-top: 1px solid #500; border-bottom: 1px solid #500;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/haml/index.html
+++ b/mode/haml/index.html
@@ -13,7 +13,7 @@
 <script src="haml.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/haml/index.html
+++ b/mode/haml/index.html
@@ -13,7 +13,7 @@
 <script src="haml.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/handlebars/index.html
+++ b/mode/handlebars/index.html
@@ -13,7 +13,7 @@
 <script src="handlebars.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/handlebars/index.html
+++ b/mode/handlebars/index.html
@@ -13,7 +13,7 @@
 <script src="handlebars.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/haskell/index.html
+++ b/mode/haskell/index.html
@@ -11,7 +11,7 @@
 <script src="haskell.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/haskell/index.html
+++ b/mode/haskell/index.html
@@ -11,7 +11,7 @@
 <script src="haskell.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/haxe/index.html
+++ b/mode/haxe/index.html
@@ -9,7 +9,7 @@
 <script src="haxe.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/haxe/index.html
+++ b/mode/haxe/index.html
@@ -9,7 +9,7 @@
 <script src="haxe.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/htmlembedded/index.html
+++ b/mode/htmlembedded/index.html
@@ -14,7 +14,7 @@
 <script src="htmlembedded.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/htmlembedded/index.html
+++ b/mode/htmlembedded/index.html
@@ -14,7 +14,7 @@
 <script src="htmlembedded.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/htmlmixed/index.html
+++ b/mode/htmlmixed/index.html
@@ -14,7 +14,7 @@
 <script src="htmlmixed.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/htmlmixed/index.html
+++ b/mode/htmlmixed/index.html
@@ -14,7 +14,7 @@
 <script src="htmlmixed.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/http/index.html
+++ b/mode/http/index.html
@@ -9,7 +9,7 @@
 <script src="http.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/http/index.html
+++ b/mode/http/index.html
@@ -9,7 +9,7 @@
 <script src="http.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/idl/index.html
+++ b/mode/idl/index.html
@@ -10,7 +10,7 @@
 <script src="idl.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/idl/index.html
+++ b/mode/idl/index.html
@@ -10,7 +10,7 @@
 <script src="idl.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/javascript/index.html
+++ b/mode/javascript/index.html
@@ -12,7 +12,7 @@
 <script src="javascript.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/javascript/index.html
+++ b/mode/javascript/index.html
@@ -12,7 +12,7 @@
 <script src="javascript.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/javascript/typescript.html
+++ b/mode/javascript/typescript.html
@@ -10,7 +10,7 @@
 <script src="javascript.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/javascript/typescript.html
+++ b/mode/javascript/typescript.html
@@ -10,7 +10,7 @@
 <script src="javascript.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/jinja2/index.html
+++ b/mode/jinja2/index.html
@@ -9,7 +9,7 @@
 <script src="jinja2.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/jinja2/index.html
+++ b/mode/jinja2/index.html
@@ -9,7 +9,7 @@
 <script src="jinja2.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/jsx/index.html
+++ b/mode/jsx/index.html
@@ -11,7 +11,7 @@
 <script src="jsx.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/jsx/index.html
+++ b/mode/jsx/index.html
@@ -11,7 +11,7 @@
 <script src="jsx.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/julia/index.html
+++ b/mode/julia/index.html
@@ -10,7 +10,7 @@
 <script src="julia.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/julia/index.html
+++ b/mode/julia/index.html
@@ -10,7 +10,7 @@
 <script src="julia.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/livescript/index.html
+++ b/mode/livescript/index.html
@@ -10,7 +10,7 @@
 <script src="livescript.js"></script>
 <style>.CodeMirror {font-size: 80%;border-top: 1px solid silver; border-bottom: 1px solid silver;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/livescript/index.html
+++ b/mode/livescript/index.html
@@ -10,7 +10,7 @@
 <script src="livescript.js"></script>
 <style>.CodeMirror {font-size: 80%;border-top: 1px solid silver; border-bottom: 1px solid silver;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/lua/index.html
+++ b/mode/lua/index.html
@@ -11,7 +11,7 @@
 <script src="lua.js"></script>
 <style>.CodeMirror {border: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/lua/index.html
+++ b/mode/lua/index.html
@@ -11,7 +11,7 @@
 <script src="lua.js"></script>
 <style>.CodeMirror {border: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/markdown/index.html
+++ b/mode/markdown/index.html
@@ -17,7 +17,7 @@
       .cm-s-default .cm-trailing-space-new-line:before {position: absolute; content: "\21B5"; color: #777;}
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/markdown/index.html
+++ b/mode/markdown/index.html
@@ -17,7 +17,7 @@
       .cm-s-default .cm-trailing-space-new-line:before {position: absolute; content: "\21B5"; color: #777;}
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/mathematica/index.html
+++ b/mode/mathematica/index.html
@@ -12,7 +12,7 @@
   .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/mathematica/index.html
+++ b/mode/mathematica/index.html
@@ -12,7 +12,7 @@
   .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/mbox/index.html
+++ b/mode/mbox/index.html
@@ -9,7 +9,7 @@
 <script src="mbox.js"></script>
 <style>.CodeMirror { border-top: 1px solid #ddd; border-bottom: 1px solid #ddd; }</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/mbox/index.html
+++ b/mode/mbox/index.html
@@ -9,7 +9,7 @@
 <script src="mbox.js"></script>
 <style>.CodeMirror { border-top: 1px solid #ddd; border-bottom: 1px solid #ddd; }</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/mirc/index.html
+++ b/mode/mirc/index.html
@@ -11,7 +11,7 @@
 <script src="mirc.js"></script>
 <style>.CodeMirror {border: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/mirc/index.html
+++ b/mode/mirc/index.html
@@ -11,7 +11,7 @@
 <script src="mirc.js"></script>
 <style>.CodeMirror {border: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/mllike/index.html
+++ b/mode/mllike/index.html
@@ -12,7 +12,7 @@
   .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/mllike/index.html
+++ b/mode/mllike/index.html
@@ -12,7 +12,7 @@
   .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/modelica/index.html
+++ b/mode/modelica/index.html
@@ -12,7 +12,7 @@
 <script src="modelica.js"></script>
 <style>.CodeMirror {border: 2px inset #dee;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/modelica/index.html
+++ b/mode/modelica/index.html
@@ -12,7 +12,7 @@
 <script src="modelica.js"></script>
 <style>.CodeMirror {border: 2px inset #dee;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/mscgen/index.html
+++ b/mode/mscgen/index.html
@@ -9,7 +9,7 @@
 <script src="mscgen.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
   <ul>
     <li><a href="../../index.html">Home</a>
     <li><a href="../../doc/manual.html">Manual</a>

--- a/mode/mscgen/index.html
+++ b/mode/mscgen/index.html
@@ -9,7 +9,7 @@
 <script src="mscgen.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
   <ul>
     <li><a href="../../index.html">Home</a>
     <li><a href="../../doc/manual.html">Manual</a>

--- a/mode/mumps/index.html
+++ b/mode/mumps/index.html
@@ -9,7 +9,7 @@
 <script src="mumps.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/mumps/index.html
+++ b/mode/mumps/index.html
@@ -9,7 +9,7 @@
 <script src="mumps.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/nginx/index.html
+++ b/mode/nginx/index.html
@@ -21,7 +21,7 @@
     }
   </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/nginx/index.html
+++ b/mode/nginx/index.html
@@ -21,7 +21,7 @@
     }
   </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/nsis/index.html
+++ b/mode/nsis/index.html
@@ -13,7 +13,7 @@
   .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/nsis/index.html
+++ b/mode/nsis/index.html
@@ -13,7 +13,7 @@
   .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/ntriples/index.html
+++ b/mode/ntriples/index.html
@@ -14,7 +14,7 @@
       }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/ntriples/index.html
+++ b/mode/ntriples/index.html
@@ -14,7 +14,7 @@
       }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/octave/index.html
+++ b/mode/octave/index.html
@@ -10,7 +10,7 @@
 <script src="octave.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/octave/index.html
+++ b/mode/octave/index.html
@@ -10,7 +10,7 @@
 <script src="octave.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/oz/index.html
+++ b/mode/oz/index.html
@@ -12,7 +12,7 @@
   .CodeMirror {border: 1px solid #aaa;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
   <ul>
     <li><a href="../../index.html">Home</a>
     <li><a href="../../doc/manual.html">Manual</a>

--- a/mode/oz/index.html
+++ b/mode/oz/index.html
@@ -12,7 +12,7 @@
   .CodeMirror {border: 1px solid #aaa;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
   <ul>
     <li><a href="../../index.html">Home</a>
     <li><a href="../../doc/manual.html">Manual</a>

--- a/mode/pascal/index.html
+++ b/mode/pascal/index.html
@@ -9,7 +9,7 @@
 <script src="pascal.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/pascal/index.html
+++ b/mode/pascal/index.html
@@ -9,7 +9,7 @@
 <script src="pascal.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/pegjs/index.html
+++ b/mode/pegjs/index.html
@@ -13,7 +13,7 @@
   </head>
   <body>
     <div id=nav>
-      <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+      <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
       <ul>
         <li><a href="../../index.html">Home</a>

--- a/mode/pegjs/index.html
+++ b/mode/pegjs/index.html
@@ -13,7 +13,7 @@
   </head>
   <body>
     <div id=nav>
-      <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+      <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
       <ul>
         <li><a href="../../index.html">Home</a>

--- a/mode/perl/index.html
+++ b/mode/perl/index.html
@@ -9,7 +9,7 @@
 <script src="perl.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/perl/index.html
+++ b/mode/perl/index.html
@@ -9,7 +9,7 @@
 <script src="perl.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/php/index.html
+++ b/mode/php/index.html
@@ -15,7 +15,7 @@
 <script src="php.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/php/index.html
+++ b/mode/php/index.html
@@ -15,7 +15,7 @@
 <script src="php.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/pig/index.html
+++ b/mode/pig/index.html
@@ -8,7 +8,7 @@
 <script src="pig.js"></script>
 <style>.CodeMirror {border: 2px inset #dee;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/pig/index.html
+++ b/mode/pig/index.html
@@ -8,7 +8,7 @@
 <script src="pig.js"></script>
 <style>.CodeMirror {border: 2px inset #dee;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/powershell/index.html
+++ b/mode/powershell/index.html
@@ -12,7 +12,7 @@
   </head>
   <body>
     <div id=nav>
-      <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+      <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
       <ul>
         <li><a href="../../index.html">Home</a>

--- a/mode/powershell/index.html
+++ b/mode/powershell/index.html
@@ -12,7 +12,7 @@
   </head>
   <body>
     <div id=nav>
-      <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+      <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
       <ul>
         <li><a href="../../index.html">Home</a>

--- a/mode/properties/index.html
+++ b/mode/properties/index.html
@@ -9,7 +9,7 @@
 <script src="properties.js"></script>
 <style>.CodeMirror {border-top: 1px solid #ddd; border-bottom: 1px solid #ddd;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/properties/index.html
+++ b/mode/properties/index.html
@@ -9,7 +9,7 @@
 <script src="properties.js"></script>
 <style>.CodeMirror {border-top: 1px solid #ddd; border-bottom: 1px solid #ddd;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/protobuf/index.html
+++ b/mode/protobuf/index.html
@@ -9,7 +9,7 @@
 <script src="protobuf.js"></script>
 <style>.CodeMirror { border-top: 1px solid #ddd; border-bottom: 1px solid #ddd; }</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/protobuf/index.html
+++ b/mode/protobuf/index.html
@@ -9,7 +9,7 @@
 <script src="protobuf.js"></script>
 <style>.CodeMirror { border-top: 1px solid #ddd; border-bottom: 1px solid #ddd; }</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/pug/index.html
+++ b/mode/pug/index.html
@@ -13,7 +13,7 @@
 <script src="pug.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/pug/index.html
+++ b/mode/pug/index.html
@@ -13,7 +13,7 @@
 <script src="pug.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/puppet/index.html
+++ b/mode/puppet/index.html
@@ -13,7 +13,7 @@
       .cm-s-default span.cm-arrow { color: red; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/puppet/index.html
+++ b/mode/puppet/index.html
@@ -13,7 +13,7 @@
       .cm-s-default span.cm-arrow { color: red; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/python/index.html
+++ b/mode/python/index.html
@@ -10,7 +10,7 @@
 <script src="python.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/python/index.html
+++ b/mode/python/index.html
@@ -10,7 +10,7 @@
 <script src="python.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/q/index.html
+++ b/mode/q/index.html
@@ -10,7 +10,7 @@
 <script src="q.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/q/index.html
+++ b/mode/q/index.html
@@ -10,7 +10,7 @@
 <script src="q.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/r/index.html
+++ b/mode/r/index.html
@@ -15,7 +15,7 @@
       .cm-s-default span.cm-arg-is { color: brown; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/r/index.html
+++ b/mode/r/index.html
@@ -15,7 +15,7 @@
       .cm-s-default span.cm-arg-is { color: brown; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/rpm/index.html
+++ b/mode/rpm/index.html
@@ -11,7 +11,7 @@
     <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/rpm/index.html
+++ b/mode/rpm/index.html
@@ -11,7 +11,7 @@
     <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/rst/index.html
+++ b/mode/rst/index.html
@@ -10,7 +10,7 @@
 <script src="rst.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/rst/index.html
+++ b/mode/rst/index.html
@@ -10,7 +10,7 @@
 <script src="rst.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/ruby/index.html
+++ b/mode/ruby/index.html
@@ -13,7 +13,7 @@
       .cm-s-default span.cm-arrow { color: red; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/ruby/index.html
+++ b/mode/ruby/index.html
@@ -13,7 +13,7 @@
       .cm-s-default span.cm-arrow { color: red; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/rust/index.html
+++ b/mode/rust/index.html
@@ -10,7 +10,7 @@
 <script src="rust.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/rust/index.html
+++ b/mode/rust/index.html
@@ -10,7 +10,7 @@
 <script src="rust.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/sas/index.html
+++ b/mode/sas/index.html
@@ -15,7 +15,7 @@
   .cm-s-default .cm-trailing-space-new-line:before {position: absolute; content: "\21B5"; color: #777;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/sas/index.html
+++ b/mode/sas/index.html
@@ -15,7 +15,7 @@
   .cm-s-default .cm-trailing-space-new-line:before {position: absolute; content: "\21B5"; color: #777;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/sass/index.html
+++ b/mode/sass/index.html
@@ -11,7 +11,7 @@
 <script src="sass.js"></script>
 <style>.CodeMirror {border: 1px solid #ddd; font-size:12px; height: 400px}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/sass/index.html
+++ b/mode/sass/index.html
@@ -11,7 +11,7 @@
 <script src="sass.js"></script>
 <style>.CodeMirror {border: 1px solid #ddd; font-size:12px; height: 400px}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/scheme/index.html
+++ b/mode/scheme/index.html
@@ -9,7 +9,7 @@
 <script src="scheme.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/scheme/index.html
+++ b/mode/scheme/index.html
@@ -9,7 +9,7 @@
 <script src="scheme.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/shell/index.html
+++ b/mode/shell/index.html
@@ -12,7 +12,7 @@
   .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/shell/index.html
+++ b/mode/shell/index.html
@@ -12,7 +12,7 @@
   .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/sieve/index.html
+++ b/mode/sieve/index.html
@@ -9,7 +9,7 @@
 <script src="sieve.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/sieve/index.html
+++ b/mode/sieve/index.html
@@ -9,7 +9,7 @@
 <script src="sieve.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/slim/index.html
+++ b/mode/slim/index.html
@@ -20,7 +20,7 @@
 <script src="slim.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/slim/index.html
+++ b/mode/slim/index.html
@@ -20,7 +20,7 @@
 <script src="slim.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/smalltalk/index.html
+++ b/mode/smalltalk/index.html
@@ -14,7 +14,7 @@
       .CodeMirror-gutter pre {color: white; font-weight: bold;}
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/smalltalk/index.html
+++ b/mode/smalltalk/index.html
@@ -14,7 +14,7 @@
       .CodeMirror-gutter pre {color: white; font-weight: bold;}
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/smarty/index.html
+++ b/mode/smarty/index.html
@@ -10,7 +10,7 @@
 <script src="smarty.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/smarty/index.html
+++ b/mode/smarty/index.html
@@ -10,7 +10,7 @@
 <script src="smarty.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/solr/index.html
+++ b/mode/solr/index.html
@@ -18,7 +18,7 @@
   }
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/solr/index.html
+++ b/mode/solr/index.html
@@ -18,7 +18,7 @@
   }
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/soy/index.html
+++ b/mode/soy/index.html
@@ -14,7 +14,7 @@
 <script src="soy.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/soy/index.html
+++ b/mode/soy/index.html
@@ -14,7 +14,7 @@
 <script src="soy.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/sparql/index.html
+++ b/mode/sparql/index.html
@@ -10,7 +10,7 @@
 <script src="sparql.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/sparql/index.html
+++ b/mode/sparql/index.html
@@ -10,7 +10,7 @@
 <script src="sparql.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/spreadsheet/index.html
+++ b/mode/spreadsheet/index.html
@@ -10,7 +10,7 @@
 <script src="spreadsheet.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/spreadsheet/index.html
+++ b/mode/spreadsheet/index.html
@@ -10,7 +10,7 @@
 <script src="spreadsheet.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/sql/index.html
+++ b/mode/sql/index.html
@@ -18,7 +18,7 @@
 }
         </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/sql/index.html
+++ b/mode/sql/index.html
@@ -18,7 +18,7 @@
 }
         </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/stex/index.html
+++ b/mode/stex/index.html
@@ -9,7 +9,7 @@
 <script src="stex.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/stex/index.html
+++ b/mode/stex/index.html
@@ -9,7 +9,7 @@
 <script src="stex.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/stylus/index.html
+++ b/mode/stylus/index.html
@@ -11,7 +11,7 @@
 <script src="../../addon/hint/css-hint.js"></script>
 <style>.CodeMirror {background: #f8f8f8;} form{margin-bottom: .7em;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/stylus/index.html
+++ b/mode/stylus/index.html
@@ -11,7 +11,7 @@
 <script src="../../addon/hint/css-hint.js"></script>
 <style>.CodeMirror {background: #f8f8f8;} form{margin-bottom: .7em;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/swift/index.html
+++ b/mode/swift/index.html
@@ -12,7 +12,7 @@
 	.CodeMirror { border: 2px inset #dee; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/swift/index.html
+++ b/mode/swift/index.html
@@ -12,7 +12,7 @@
 	.CodeMirror { border: 2px inset #dee; }
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/tcl/index.html
+++ b/mode/tcl/index.html
@@ -10,7 +10,7 @@
 <script src="tcl.js"></script>
 <script src="../../addon/scroll/scrollpastend.js"></script>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/tcl/index.html
+++ b/mode/tcl/index.html
@@ -10,7 +10,7 @@
 <script src="tcl.js"></script>
 <script src="../../addon/scroll/scrollpastend.js"></script>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/textile/index.html
+++ b/mode/textile/index.html
@@ -9,7 +9,7 @@
 <script src="textile.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/textile/index.html
+++ b/mode/textile/index.html
@@ -9,7 +9,7 @@
 <script src="textile.js"></script>
 <style>.CodeMirror {background: #f8f8f8;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/tiddlywiki/index.html
+++ b/mode/tiddlywiki/index.html
@@ -11,7 +11,7 @@
 <script src="tiddlywiki.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/tiddlywiki/index.html
+++ b/mode/tiddlywiki/index.html
@@ -11,7 +11,7 @@
 <script src="tiddlywiki.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/tiki/index.html
+++ b/mode/tiki/index.html
@@ -10,7 +10,7 @@
 <script src="tiki.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/tiki/index.html
+++ b/mode/tiki/index.html
@@ -10,7 +10,7 @@
 <script src="tiki.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/toml/index.html
+++ b/mode/toml/index.html
@@ -9,7 +9,7 @@
 <script src="toml.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/toml/index.html
+++ b/mode/toml/index.html
@@ -9,7 +9,7 @@
 <script src="toml.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/tornado/index.html
+++ b/mode/tornado/index.html
@@ -12,7 +12,7 @@
 <script src="tornado.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/tornado/index.html
+++ b/mode/tornado/index.html
@@ -12,7 +12,7 @@
 <script src="tornado.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/troff/index.html
+++ b/mode/troff/index.html
@@ -12,7 +12,7 @@
   .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/troff/index.html
+++ b/mode/troff/index.html
@@ -12,7 +12,7 @@
   .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/ttcn-cfg/index.html
+++ b/mode/ttcn-cfg/index.html
@@ -16,7 +16,7 @@
 </style>
 <div id=nav>
     <a href="https://codemirror.net"><h1>CodeMirror</h1>
-        <img id=logo src="../../doc/logo.png" alt="CodeMirror logo">
+        <img id=logo src="../../doc/logo.png" alt="">
     </a>
 
     <ul>

--- a/mode/ttcn-cfg/index.html
+++ b/mode/ttcn-cfg/index.html
@@ -16,7 +16,7 @@
 </style>
 <div id=nav>
     <a href="https://codemirror.net"><h1>CodeMirror</h1>
-        <img id=logo src="../../doc/logo.png">
+        <img id=logo src="../../doc/logo.png" alt="CodeMirror logo">
     </a>
 
     <ul>

--- a/mode/ttcn/index.html
+++ b/mode/ttcn/index.html
@@ -16,7 +16,7 @@
 </style>
 <div id=nav>
     <a href="https://codemirror.net"><h1>CodeMirror</h1>
-        <img id=logo src="../../doc/logo.png" alt="CodeMirror logo">
+        <img id=logo src="../../doc/logo.png" alt="">
     </a>
 
     <ul>

--- a/mode/ttcn/index.html
+++ b/mode/ttcn/index.html
@@ -16,7 +16,7 @@
 </style>
 <div id=nav>
     <a href="https://codemirror.net"><h1>CodeMirror</h1>
-        <img id=logo src="../../doc/logo.png">
+        <img id=logo src="../../doc/logo.png" alt="CodeMirror logo">
     </a>
 
     <ul>

--- a/mode/turtle/index.html
+++ b/mode/turtle/index.html
@@ -10,7 +10,7 @@
 <script src="turtle.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/turtle/index.html
+++ b/mode/turtle/index.html
@@ -10,7 +10,7 @@
 <script src="turtle.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/twig/index.html
+++ b/mode/twig/index.html
@@ -9,7 +9,7 @@
 <script src="twig.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/twig/index.html
+++ b/mode/twig/index.html
@@ -9,7 +9,7 @@
 <script src="twig.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/vb/index.html
+++ b/mode/vb/index.html
@@ -15,7 +15,7 @@
       .CodeMirror pre { font-family: Inconsolata; font-size: 14px}
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/vb/index.html
+++ b/mode/vb/index.html
@@ -15,7 +15,7 @@
       .CodeMirror pre { font-family: Inconsolata; font-size: 14px}
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/vbscript/index.html
+++ b/mode/vbscript/index.html
@@ -9,7 +9,7 @@
 <script src="vbscript.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/vbscript/index.html
+++ b/mode/vbscript/index.html
@@ -9,7 +9,7 @@
 <script src="vbscript.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/velocity/index.html
+++ b/mode/velocity/index.html
@@ -10,7 +10,7 @@
 <script src="velocity.js"></script>
 <style>.CodeMirror {border: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/velocity/index.html
+++ b/mode/velocity/index.html
@@ -10,7 +10,7 @@
 <script src="velocity.js"></script>
 <style>.CodeMirror {border: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/verilog/index.html
+++ b/mode/verilog/index.html
@@ -10,7 +10,7 @@
 <script src="verilog.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/verilog/index.html
+++ b/mode/verilog/index.html
@@ -10,7 +10,7 @@
 <script src="verilog.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/vhdl/index.html
+++ b/mode/vhdl/index.html
@@ -10,7 +10,7 @@
 <script src="vhdl.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/vhdl/index.html
+++ b/mode/vhdl/index.html
@@ -10,7 +10,7 @@
 <script src="vhdl.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/vue/index.html
+++ b/mode/vue/index.html
@@ -21,7 +21,7 @@
 <script src="vue.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/vue/index.html
+++ b/mode/vue/index.html
@@ -21,7 +21,7 @@
 <script src="vue.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/xml/index.html
+++ b/mode/xml/index.html
@@ -9,7 +9,7 @@
 <script src="xml.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/xml/index.html
+++ b/mode/xml/index.html
@@ -9,7 +9,7 @@
 <script src="xml.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/xquery/index.html
+++ b/mode/xquery/index.html
@@ -16,7 +16,7 @@
 	}
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/xquery/index.html
+++ b/mode/xquery/index.html
@@ -16,7 +16,7 @@
 	}
     </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/yacas/index.html
+++ b/mode/yacas/index.html
@@ -12,7 +12,7 @@
   .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/yacas/index.html
+++ b/mode/yacas/index.html
@@ -12,7 +12,7 @@
   .CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}
 </style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/yaml-frontmatter/index.html
+++ b/mode/yaml-frontmatter/index.html
@@ -13,7 +13,7 @@
 <script src="yaml-frontmatter.js"></script>
 <style>.CodeMirror { border-top: 1px solid #ddd; border-bottom: 1px solid #ddd; }</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/yaml-frontmatter/index.html
+++ b/mode/yaml-frontmatter/index.html
@@ -13,7 +13,7 @@
 <script src="yaml-frontmatter.js"></script>
 <style>.CodeMirror { border-top: 1px solid #ddd; border-bottom: 1px solid #ddd; }</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/yaml/index.html
+++ b/mode/yaml/index.html
@@ -9,7 +9,7 @@
 <script src="yaml.js"></script>
 <style>.CodeMirror { border-top: 1px solid #ddd; border-bottom: 1px solid #ddd; }</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/yaml/index.html
+++ b/mode/yaml/index.html
@@ -9,7 +9,7 @@
 <script src="yaml.js"></script>
 <style>.CodeMirror { border-top: 1px solid #ddd; border-bottom: 1px solid #ddd; }</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/z80/index.html
+++ b/mode/z80/index.html
@@ -9,7 +9,7 @@
 <script src="z80.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt=""></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>

--- a/mode/z80/index.html
+++ b/mode/z80/index.html
@@ -9,7 +9,7 @@
 <script src="z80.js"></script>
 <style>.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>
 <div id=nav>
-  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png"></a>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="CodeMirror logo"></a>
 
   <ul>
     <li><a href="../../index.html">Home</a>


### PR DESCRIPTION
Having images without an "alt" causes bug reports from certain scanning tools such as SonarQube. Adding an alt is a small effort to fix this bug, this fixes all instances related to the CodeMirror logo.