### PR TITLE
[yaml-frontmatter mode] Allow pandoc-style closing with `...`

### DIFF
--- a/mode/yaml-frontmatter/yaml-frontmatter.js
+++ b/mode/yaml-frontmatter/yaml-frontmatter.js
@@ -45,7 +45,7 @@
             return innerMode.token(stream, state.inner)
           }
         } else if (state.state == FRONTMATTER) {
-          var end = stream.sol() && stream.match(/---/, false)
+          var end = stream.sol() && stream.match(/(---|\.\.\.)/, false)
           var style = yamlMode.token(stream, state.inner)
           if (end) {
             state.state = BODY


### PR DESCRIPTION
This allows to end yaml-frontmatters with either `---` or `...`, as
suggested [on the discussion board][1]. The old behaviour was to just
accept `---`.

[1]: https://discuss.codemirror.net/t/pandoc-markdown-style-yaml-frontmatter/2182