### PR TITLE
Fix number of arguments in function calls

### DIFF
--- a/mode/pug/pug.js
+++ b/mode/pug/pug.js
@@ -545,12 +545,12 @@ CodeMirror.defineMode("pug", function (config) {
       || javaScriptArguments(stream, state)
       || callArguments(stream, state)
 
-      || yieldStatement(stream, state)
-      || doctype(stream, state)
+      || yieldStatement(stream)
+      || doctype(stream)
       || interpolation(stream, state)
       || caseStatement(stream, state)
       || when(stream, state)
-      || defaultStatement(stream, state)
+      || defaultStatement(stream)
       || extendsStatement(stream, state)
       || append(stream, state)
       || prepend(stream, state)
@@ -565,16 +565,16 @@ CodeMirror.defineMode("pug", function (config) {
       || tag(stream, state)
       || filter(stream, state)
       || code(stream, state)
-      || id(stream, state)
-      || className(stream, state)
+      || id(stream)
+      || className(stream)
       || attrs(stream, state)
       || attributesBlock(stream, state)
-      || indent(stream, state)
+      || indent(stream)
       || text(stream, state)
       || comment(stream, state)
-      || colon(stream, state)
+      || colon(stream)
       || dot(stream, state)
-      || fail(stream, state);
+      || fail(stream);
 
     return tok === true ? null : tok;
   }


### PR DESCRIPTION
Fixes #6021.
Correct number of arguments in function calls to match function definitions.

E.g.
https://github.com/codemirror/CodeMirror/blob/268de539a8be79b59a518cfc0c00c22ad98739f6/mode/pug/pug.js#L143
https://github.com/codemirror/CodeMirror/blob/268de539a8be79b59a518cfc0c00c22ad98739f6/mode/pug/pug.js#L548
Becomes
`      || yieldStatement(stream)`