### PR TITLE
Add Objective-C++ Support

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -270,6 +270,25 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     "static else struct switch extern typedef union for goto while enum const " +
     "volatile inline restrict asm fortran";
 
+  // Keywords from https://en.cppreference.com/w/cpp/keyword includes C++20.
+  var cppKeywords = "alignas alignof and and_eq audit axiom bitand bitor catch " +
+  "class compl concept constexpr const_cast decltype delete dynamic_cast " +
+  "explicit export final friend import module mutable namespace new noexcept " +
+  "not not_eq operator or or_eq override private protected public " +
+  "reinterpret_cast requires static_assert static_cast template this " +
+  "thread_local throw try typeid typename using virtual xor xor_eq";
+
+  var objCKeywords = "bycopy byref in inout oneway out self super atomic nonatomic retain copy " +
+  "readwrite readonly strong weak assign typeof nullable nonnull null_resettable _cmd " +
+  "@interface @implementation @end @protocol @encode @property @synthesize @dynamic @class " +
+  "@public @package @private @protected @required @optional @try @catch @finally @import " +
+  "@selector @encode @defs @synchronized @autoreleasepool @compatibility_alias @available";
+
+  var objCBuiltins = "FOUNDATION_EXPORT FOUNDATION_EXTERN NS_INLINE NS_FORMAT_FUNCTION " +
+  " NS_RETURNS_RETAINEDNS_ERROR_ENUM NS_RETURNS_NOT_RETAINED NS_RETURNS_INNER_POINTER " +
+  "NS_DESIGNATED_INITIALIZER NS_ENUM NS_OPTIONS NS_REQUIRES_NIL_TERMINATION " +
+  "NS_ASSUME_NONNULL_BEGIN NS_ASSUME_NONNULL_END NS_SWIFT_NAME NS_REFINED_FOR_SWIFT"
+
   // Do not use this. Use the cTypes function below. This is global just to avoid
   // excessive calls when cTypes is being called multiple times during a parse.
   var basicCTypes = words("int long char short double float unsigned signed " +
@@ -420,13 +439,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
 
   def(["text/x-c++src", "text/x-c++hdr"], {
     name: "clike",
-    // Keywords from https://en.cppreference.com/w/cpp/keyword includes C++20.
-    keywords: words(cKeywords + "alignas alignof and and_eq audit axiom bitand bitor catch " +
-                    "class compl concept constexpr const_cast decltype delete dynamic_cast " +
-                    "explicit export final friend import module mutable namespace new noexcept " +
-                    "not not_eq operator or or_eq override private protected public " +
-                    "reinterpret_cast requires static_assert static_cast template this " +
-                    "thread_local throw try typeid typename using virtual xor xor_eq"),
+    keywords: words(cKeywords + " " + cppKeywords),
     types: cTypes,
     blockKeywords: words(cBlockKeywords + " class try catch"),
     defKeywords: words(cDefKeywords + " class namespace"),
@@ -769,16 +782,9 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
 
   def("text/x-objectivec", {
     name: "clike",
-    keywords: words(cKeywords + " bycopy byref in inout oneway out self super atomic nonatomic retain copy " +
-                    "readwrite readonly strong weak assign typeof nullable nonnull null_resettable _cmd " +
-                    "@interface @implementation @end @protocol @encode @property @synthesize @dynamic @class " +
-                    "@public @package @private @protected @required @optional @try @catch @finally @import " +
-                    "@selector @encode @defs @synchronized @autoreleasepool @compatibility_alias @available"),
+    keywords: words(cKeywords + " " + objCKeywords),
     types: objCTypes,
-    builtin: words("FOUNDATION_EXPORT FOUNDATION_EXTERN NS_INLINE NS_FORMAT_FUNCTION NS_RETURNS_RETAINED " +
-                   "NS_ERROR_ENUM NS_RETURNS_NOT_RETAINED NS_RETURNS_INNER_POINTER NS_DESIGNATED_INITIALIZER " +
-                   "NS_ENUM NS_OPTIONS NS_REQUIRES_NIL_TERMINATION NS_ASSUME_NONNULL_BEGIN " +
-                   "NS_ASSUME_NONNULL_END NS_SWIFT_NAME NS_REFINED_FOR_SWIFT"),
+    builtin: words(objCBuiltins),
     blockKeywords: words(cBlockKeywords + " @synthesize @try @catch @finally @autoreleasepool @synchronized"),
     defKeywords: words(cDefKeywords + " @interface @implementation @protocol @class"),
     dontIndentStatements: /^@.*$/,
@@ -789,6 +795,46 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
       "#": cppHook,
       "*": pointerHook,
     },
+    modeProps: {fold: ["brace", "include"]}
+  });
+
+  def("text/x-objectivec++", {
+    name: "clike",
+    keywords: words(cKeywords + " " + objCKeywords + " " + cppKeywords),
+    types: objCTypes,
+    builtin: words(objCBuiltins),
+    blockKeywords: words(cBlockKeywords + " @synthesize @try @catch @finally @autoreleasepool @synchronized class try catch"),
+    defKeywords: words(cDefKeywords + " @interface @implementation @protocol @class class namespace"),
+    dontIndentStatements: /^@.*$|^template$/,
+    typeFirstDefinitions: true,
+    atoms: words("YES NO NULL Nil nil true false nullptr"),
+    isReservedIdentifier: cIsReservedIdentifier,
+    hooks: {
+      "#": cppHook,
+      "*": pointerHook,
+      "u": cpp11StringHook,
+      "U": cpp11StringHook,
+      "L": cpp11StringHook,
+      "R": cpp11StringHook,
+      "0": cpp14Literal,
+      "1": cpp14Literal,
+      "2": cpp14Literal,
+      "3": cpp14Literal,
+      "4": cpp14Literal,
+      "5": cpp14Literal,
+      "6": cpp14Literal,
+      "7": cpp14Literal,
+      "8": cpp14Literal,
+      "9": cpp14Literal,
+      token: function(stream, state, style) {
+        if (style == "variable" && stream.peek() == "(" &&
+            (state.prevToken == ";" || state.prevToken == null ||
+             state.prevToken == "}") &&
+            cppLooksLikeConstructor(stream.current()))
+          return "def";
+      }
+    },
+    namespaceSeparator: "::",
     modeProps: {fold: ["brace", "include"]}
   });
 


### PR DESCRIPTION
Objective-C++ is a superset of Objective-C and C++, so adding syntax support for it just requires combining both rulesets. I separated out some of the larger string constants to avoid some of the most egregious duplication (keywords, builtins, etc.)