### PR TITLE
Useless/bad string escapes

### DIFF
--- a/addon/fold/xml-fold.js
+++ b/addon/fold/xml-fold.js
@@ -15,7 +15,7 @@
   function cmp(a, b) { return a.line - b.line || a.ch - b.ch; }
 
   var nameStartChar = "A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD";
-  var nameChar = nameStartChar + "\-\:\.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040";
+  var nameChar = nameStartChar + "\\-\:\\.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040";
   var xmlTagStart = new RegExp("<(/?)([" + nameStartChar + "][" + nameChar + "]*)", "g");
 
   function Iter(cm, line, ch, range) {

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -4905,7 +4905,7 @@
             if (getOption('pcre')) {
                regexPart = regexPart + '/' + flagsPart;
             } else {
-               regexPart = regexPart.replace(/\//g, "\\/") + '/' + flagsPart;
+               regexPart = regexPart.replace(/\\/g, '\\\\').replace(/\//g, "\\/") + '/' + flagsPart;
             }
           }
         }

--- a/mode/fortran/fortran.js
+++ b/mode/fortran/fortran.js
@@ -112,7 +112,7 @@ CodeMirror.defineMode("fortran", function() {
                      "c_short", "c_signed_char", "c_size_t", "character",
                      "complex", "double", "integer", "logical", "real"]);
   var isOperatorChar = /[+\-*&=<>\/\:]/;
-  var litOperator = new RegExp("(\.and\.|\.or\.|\.eq\.|\.lt\.|\.le\.|\.gt\.|\.ge\.|\.ne\.|\.not\.|\.eqv\.|\.neqv\.)", "i");
+  var litOperator = new RegExp("(\\.and\\.|\\.or\\.|\\.eq\\.|\\.lt\\.|\\.le\\.|\\.gt\\.|\\.ge\\.|\\.ne\\.|\\.not\\.|\\.eqv\\.|\\.neqv\\.)", "i");
 
   function tokenBase(stream, state) {
 

--- a/mode/htmlmixed/htmlmixed.js
+++ b/mode/htmlmixed/htmlmixed.js
@@ -50,7 +50,7 @@
   }
 
   function getTagRegexp(tagName, anchored) {
-    return new RegExp((anchored ? "^" : "") + "<\/\s*" + tagName + "\s*>", "i");
+    return new RegExp((anchored ? "^" : "") + "<\/\\s*" + tagName + "\\s*>", "i");
   }
 
   function addTags(from, to) {

--- a/mode/julia/julia.js
+++ b/mode/julia/julia.js
@@ -28,7 +28,7 @@ CodeMirror.defineMode("julia", function(config, parserConf) {
         "\\u00D7", "\\u2208", "\\u2209", "\\u220B", "\\u220C", "\\u2218",
         "\\u221A", "\\u221B", "\\u2229", "\\u222A", "\\u2260", "\\u2264",
         "\\u2265", "\\u2286", "\\u2288", "\\u228A", "\\u22C5",
-        "\\b(in|isa)\\b(?!\.?\\()"], "");
+        "\\b(in|isa)\\b(?!\\.?\\()"], "");
   var delimiters = parserConf.delimiters || /^[;,()[\]{}]/;
   var identifiers = parserConf.identifiers ||
         /^[_A-Za-z\u00A1-\u2217\u2219-\uFFFF][\w\u00A1-\u2217\u2219-\uFFFF]*!*/;

--- a/mode/troff/troff.js
+++ b/mode/troff/troff.js
@@ -36,7 +36,7 @@ CodeMirror.defineMode('troff', function() {
         stream.eatWhile(/[\d-]/);
         return 'string';
       }
-      if (stream.match('\(') || stream.match('*\(')) {
+      if (stream.match('\\(') || stream.match('*\\(')) {
         stream.eatWhile(/[\w-]/);
         return 'string';
       }

--- a/src/line/highlight.js
+++ b/src/line/highlight.js
@@ -198,7 +198,7 @@ function extractLineClasses(type, output) {
     let prop = lineClass[1] ? "bgClass" : "textClass"
     if (output[prop] == null)
       output[prop] = lineClass[2]
-    else if (!(new RegExp("(?:^|\s)" + lineClass[2] + "(?:$|\s)")).test(output[prop]))
+    else if (!(new RegExp("(?:^|\\s)" + lineClass[2] + "(?:$|\\s)")).test(output[prop]))
       output[prop] += " " + lineClass[2]
   }
   return type


### PR DESCRIPTION
lgtm.com-inspired fixes: Change useless string escapes into useful or non-confusing ones; escape backslashes when performing an escape that adds backslashes