### PR TITLE
makes findModeByExtension case insensitive

### DIFF
--- a/mode/meta.js
+++ b/mode/meta.js
@@ -190,6 +190,7 @@
   };
 
   CodeMirror.findModeByExtension = function(ext) {
+    ext = ext.toLowerCase();
     for (var i = 0; i < CodeMirror.modeInfo.length; i++) {
       var info = CodeMirror.modeInfo[i];
       if (info.ext) for (var j = 0; j < info.ext.length; j++)


### PR DESCRIPTION
Fixes a bug where findModeByExtension does not return a result for me. This is when the filename for which I want to derive the mode is uppercase. For some programming languages like R it is common to write the filename extension in uppercase. The extensions in the info structure of CodeMirror are however stored in lowercase, i.e. in this case there wasn't a match... 

Since findModeByName and findModeByMIME are both case insensitive, I suggest to make findModeByExtension  (and thus findModeByFileName) also behave that way, so that it is consistent.