### PR TITLE
Show item count in fold widget for JSON

### DIFF
--- a/addon/fold/brace-fold.js
+++ b/addon/fold/brace-fold.js
@@ -70,7 +70,7 @@ CodeMirror.registerHelper("fold", "brace", function(cm, start) {
     } catch(e) { }
   }
 
-  return {from: from, to: to, count: count};
+  return {from, to, count};
 });
 
 CodeMirror.registerHelper("fold", "import", function(cm, start) {

--- a/addon/fold/brace-fold.js
+++ b/addon/fold/brace-fold.js
@@ -59,7 +59,7 @@ CodeMirror.registerHelper("fold", "brace", function(cm, start) {
   var from = CodeMirror.Pos(line, startCh), to = CodeMirror.Pos(end, endCh);
   var count = undefined;
 
-  if (typeof cm.foldOption(cm.options, 'widget') == "function")
+  if (cm.foldOption(cm.options, 'itemsWidget'))
   {
     var internal = cm.doc.getRange(from, to);
     var toParse = `${startToken}${internal}${endToken}`;

--- a/addon/fold/brace-fold.js
+++ b/addon/fold/brace-fold.js
@@ -56,7 +56,26 @@ CodeMirror.registerHelper("fold", "brace", function(cm, start) {
   }
   if (end == null || line == end) return;
   return {from: CodeMirror.Pos(line, startCh),
-          to: CodeMirror.Pos(end, endCh)};
+          to: CodeMirror.Pos(end, endCh),
+          startToken,
+          endToken};
+});
+
+CodeMirror.registerHelper("fold", "json", function(cm, start) {
+  var helpers = cm.getHelpers(start, "fold", "brace");
+  for (var i = 0; i < helpers.length; i++) {
+    var cur = helpers[i](cm, start);
+    
+    if (cur) {
+      const internal = cm.doc.getRange(cur.from, cur.to);
+      const toParse = `${cur.startToken}${internal}${cur.endToken}`;
+    
+      var items = undefined;
+      try { items = Object.keys(JSON.parse(toParse)).length; } catch {}
+      
+      return {from: cur.from, to: cur.to, items};
+    };
+  }
 });
 
 CodeMirror.registerHelper("fold", "import", function(cm, start) {

--- a/addon/fold/brace-fold.js
+++ b/addon/fold/brace-fold.js
@@ -62,15 +62,15 @@ CodeMirror.registerHelper("fold", "brace", function(cm, start) {
   if (cm.foldOption(cm.options, 'itemsWidget'))
   {
     var internal = cm.doc.getRange(from, to);
-    var toParse = `${startToken}${internal}${endToken}`;
+    var toParse = startToken + internal + endToken;
 
     try {
       var parsed = JSON.parse(toParse);
-      count = Object.keys(parsed).length; 
-    } catch {}    
+      count = Object.keys(parsed).length;
+    } catch(e) { }
   }
 
-  return {from, to, count};
+  return {from: from, to: to, count: count};
 });
 
 CodeMirror.registerHelper("fold", "import", function(cm, start) {

--- a/addon/fold/brace-fold.js
+++ b/addon/fold/brace-fold.js
@@ -59,7 +59,7 @@ CodeMirror.registerHelper("fold", "brace", function(cm, start) {
   var from = CodeMirror.Pos(line, startCh), to = CodeMirror.Pos(end, endCh);
   var count = undefined;
 
-  if (cm.foldOption(cm.options, 'itemsWidget'))
+  if (cm.foldOption(cm.options, 'jsonCountWidget'))
   {
     var internal = cm.doc.getRange(from, to);
     var toParse = startToken + internal + endToken;

--- a/addon/fold/brace-fold.js
+++ b/addon/fold/brace-fold.js
@@ -55,27 +55,22 @@ CodeMirror.registerHelper("fold", "brace", function(cm, start) {
     }
   }
   if (end == null || line == end) return;
-  return {from: CodeMirror.Pos(line, startCh),
-          to: CodeMirror.Pos(end, endCh),
-          startToken,
-          endToken};
-});
 
-CodeMirror.registerHelper("fold", "json", function(cm, start) {
-  var helpers = cm.getHelpers(start, "fold", "brace");
-  for (var i = 0; i < helpers.length; i++) {
-    var cur = helpers[i](cm, start);
-    
-    if (cur) {
-      const internal = cm.doc.getRange(cur.from, cur.to);
-      const toParse = `${cur.startToken}${internal}${cur.endToken}`;
-    
-      var items = undefined;
-      try { items = Object.keys(JSON.parse(toParse)).length; } catch {}
-      
-      return {from: cur.from, to: cur.to, items};
-    };
+  var from = CodeMirror.Pos(line, startCh), to = CodeMirror.Pos(end, endCh);
+  var count = undefined;
+
+  if (typeof cm.foldOption(cm.options, 'widget') == "function")
+  {
+    var internal = cm.doc.getRange(from, to);
+    var toParse = `${startToken}${internal}${endToken}`;
+
+    try {
+      var parsed = JSON.parse(toParse);
+      count = Object.keys(parsed).length; 
+    } catch {}    
   }
+
+  return {from, to, count};
 });
 
 CodeMirror.registerHelper("fold", "import", function(cm, start) {

--- a/addon/fold/foldcode.js
+++ b/addon/fold/foldcode.js
@@ -62,10 +62,13 @@
 
   function makeWidget(cm, options, items) {
     var widget = getOption(cm, options, "widget");
+    var itemsWidget = getOption(cm, options, "itemsWidget");
 
-    if (typeof widget == "function") {
-      widget = widget(items);
+    if (typeof itemsWidget == "function") {
+      itemsWidget = itemsWidget(items);
     }
+
+    widget = itemsWidget || widget;
 
     if (typeof widget == "string") {
       var text = document.createTextNode(widget);
@@ -137,6 +140,7 @@
   var defaultOptions = {
     rangeFinder: CodeMirror.fold.auto,
     widget: "\u2194",
+    itemsWidget: undefined,
     minFoldSize: 0,
     scanUp: false,
     clearOnEnter: true

--- a/addon/fold/foldcode.js
+++ b/addon/fold/foldcode.js
@@ -60,13 +60,13 @@
 
   function makeWidget(cm, options, count) {
     var widget = getOption(cm, options, "widget");
-    var jsonCountWidget = getOption(cm, options, "jsonCountWidget");
 
-    if (typeof jsonCountWidget == "function") {
+    if (count) {
+      var jsonCountWidget = getOption(cm, options, "jsonCountWidget");
       jsonCountWidget = jsonCountWidget(count);
-    }
 
-    widget = jsonCountWidget || widget;
+      widget = jsonCountWidget || widget;
+    }
 
     if (typeof widget == "string") {
       var text = document.createTextNode(widget);

--- a/addon/fold/foldcode.js
+++ b/addon/fold/foldcode.js
@@ -138,6 +138,7 @@
   var defaultOptions = {
     rangeFinder: CodeMirror.fold.auto,
     widget: "\u2194",
+    jsonCountWidget: undefined,
     minFoldSize: 0,
     scanUp: false,
     clearOnEnter: true

--- a/addon/fold/foldcode.js
+++ b/addon/fold/foldcode.js
@@ -47,13 +47,11 @@
       myRange.clear();
       CodeMirror.e_preventDefault(e);
     });
-
     var myRange = cm.markText(range.from, range.to, {
       replacedWith: myWidget,
       clearOnEnter: getOption(cm, options, "clearOnEnter"),
       __isFold: true
     });
-
     myRange.on("clear", function(from, to) {
       CodeMirror.signal(cm, "unfold", cm, from, to);
     });
@@ -62,13 +60,13 @@
 
   function makeWidget(cm, options, items) {
     var widget = getOption(cm, options, "widget");
-    var itemsWidget = getOption(cm, options, "itemsWidget");
+    var jsonCountWidget = getOption(cm, options, "jsonCountWidget");
 
-    if (typeof itemsWidget == "function") {
-      itemsWidget = itemsWidget(items);
+    if (typeof jsonCountWidget == "function") {
+      jsonCountWidget = jsonCountWidget(items);
     }
 
-    widget = itemsWidget || widget;
+    widget = jsonCountWidget || widget;
 
     if (typeof widget == "string") {
       var text = document.createTextNode(widget);
@@ -140,7 +138,6 @@
   var defaultOptions = {
     rangeFinder: CodeMirror.fold.auto,
     widget: "\u2194",
-    itemsWidget: undefined,
     minFoldSize: 0,
     scanUp: false,
     clearOnEnter: true

--- a/addon/fold/foldcode.js
+++ b/addon/fold/foldcode.js
@@ -42,7 +42,7 @@
     }
     if (!range || range.cleared || force === "unfold") return;
 
-    var myWidget = makeWidget(cm, options, range.items);
+    var myWidget = makeWidget(cm, options, range.count);
     CodeMirror.on(myWidget, "mousedown", function(e) {
       myRange.clear();
       CodeMirror.e_preventDefault(e);
@@ -62,13 +62,13 @@
 
   function makeWidget(cm, options, items) {
     var widget = getOption(cm, options, "widget");
+
+    if (typeof widget == "function") {
+      widget = widget(items);
+    }
+
     if (typeof widget == "string") {
       var text = document.createTextNode(widget);
-      widget = document.createElement("span");
-      widget.appendChild(text);
-      widget.className = "CodeMirror-foldmarker";
-    } else if (typeof widget == "function") {
-      var text = document.createTextNode(widget(items));
       widget = document.createElement("span");
       widget.appendChild(text);
       widget.className = "CodeMirror-foldmarker";

--- a/addon/fold/foldcode.js
+++ b/addon/fold/foldcode.js
@@ -58,12 +58,12 @@
     CodeMirror.signal(cm, "fold", cm, range.from, range.to);
   }
 
-  function makeWidget(cm, options, items) {
+  function makeWidget(cm, options, count) {
     var widget = getOption(cm, options, "widget");
     var jsonCountWidget = getOption(cm, options, "jsonCountWidget");
 
     if (typeof jsonCountWidget == "function") {
-      jsonCountWidget = jsonCountWidget(items);
+      jsonCountWidget = jsonCountWidget(count);
     }
 
     widget = jsonCountWidget || widget;

--- a/addon/fold/foldcode.js
+++ b/addon/fold/foldcode.js
@@ -47,7 +47,7 @@
       myRange.clear();
       CodeMirror.e_preventDefault(e);
     });
-    
+
     var myRange = cm.markText(range.from, range.to, {
       replacedWith: myWidget,
       clearOnEnter: getOption(cm, options, "clearOnEnter"),
@@ -135,7 +135,7 @@
       var cur = helpers[i](cm, start);
       if (cur) return cur;
     }
-  });  
+  });
 
   var defaultOptions = {
     rangeFinder: CodeMirror.fold.auto,

--- a/addon/fold/foldcode.js
+++ b/addon/fold/foldcode.js
@@ -42,26 +42,33 @@
     }
     if (!range || range.cleared || force === "unfold") return;
 
-    var myWidget = makeWidget(cm, options);
+    var myWidget = makeWidget(cm, options, range.items);
     CodeMirror.on(myWidget, "mousedown", function(e) {
       myRange.clear();
       CodeMirror.e_preventDefault(e);
     });
+    
     var myRange = cm.markText(range.from, range.to, {
       replacedWith: myWidget,
       clearOnEnter: getOption(cm, options, "clearOnEnter"),
       __isFold: true
     });
+
     myRange.on("clear", function(from, to) {
       CodeMirror.signal(cm, "unfold", cm, from, to);
     });
     CodeMirror.signal(cm, "fold", cm, range.from, range.to);
   }
 
-  function makeWidget(cm, options) {
+  function makeWidget(cm, options, items) {
     var widget = getOption(cm, options, "widget");
     if (typeof widget == "string") {
       var text = document.createTextNode(widget);
+      widget = document.createElement("span");
+      widget.appendChild(text);
+      widget.className = "CodeMirror-foldmarker";
+    } else if (typeof widget == "function") {
+      var text = document.createTextNode(widget(items));
       widget = document.createElement("span");
       widget.appendChild(text);
       widget.className = "CodeMirror-foldmarker";
@@ -125,7 +132,7 @@
       var cur = helpers[i](cm, start);
       if (cur) return cur;
     }
-  });
+  });  
 
   var defaultOptions = {
     rangeFinder: CodeMirror.fold.auto,

--- a/demo/folding.html
+++ b/demo/folding.html
@@ -123,7 +123,7 @@ window.onload = function() {
     foldGutter: true,
     gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
     foldOptions: {
-      widget: items => items ? `\u21A4${items}\u21A6` : '\u2194'
+      itemsWidget: items => items && `\u21A4${items}\u21A6`
     }
   });
   editor_json.foldCode(CodeMirror.Pos(4, 0));

--- a/demo/folding.html
+++ b/demo/folding.html
@@ -53,7 +53,21 @@
     <div style="max-width: 50em; margin-bottom: 1em">JavaScript:<br>
     <textarea id="code" name="code"></textarea></div>
     <div style="max-width: 50em; margin-bottom: 1em">HTML:<br>
-    <textarea id="code-html" name="code-html"></textarea></div>
+    <textarea id="code-html" name="code-html"></textarea></div>    
+    <div style="max-width: 50em; margin-bottom: 1em">JSON:<br>
+    <textarea id="code-json" name="code-json">
+{"menu": {
+  "id": "file",
+  "value": "File",
+  "popup": {
+    "menuitem": [
+      {"value": "New", "onclick": "CreateNewDoc()"},
+      {"value": "Open", "onclick": "OpenDoc()"},
+      {"value": "Close", "onclick": "CloseDoc()"}
+    ]
+  }
+}}
+    </textarea></div>
     <div style="max-width: 50em">Python:<br>
     <textarea id="code-python" name="code">
 def foo():
@@ -89,6 +103,7 @@ window.onload = function() {
   var te_python = document.getElementById("code-python");
   var te_markdown = document.getElementById("code-markdown");
   te_markdown.value = "# Foo\n## Bar\n\nblah blah\n\n## Baz\n\nblah blah\n\n# Quux\n\nblah blah\n"
+  var te_json = document.getElementById("code-json");
 
   window.editor = CodeMirror.fromTextArea(te, {
     mode: "javascript",
@@ -99,6 +114,19 @@ window.onload = function() {
     gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
   });
   editor.foldCode(CodeMirror.Pos(13, 0));
+
+  window.editor_json = CodeMirror.fromTextArea(te_json, {
+    mode: "javascript",
+    lineNumbers: true,
+    lineWrapping: true,
+    extraKeys: {"Ctrl-Q": function(cm){ cm.foldCode(cm.getCursor()); }},
+    foldGutter: true,
+    gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
+    foldOptions: {
+      rangeFinder: CodeMirror.fold.json, widget: items => `...${items}...` || '...'
+    }
+  });
+  editor_json.foldCode(CodeMirror.Pos(4, 0));
 
   window.editor_html = CodeMirror.fromTextArea(te_html, {
     mode: "text/html",

--- a/demo/folding.html
+++ b/demo/folding.html
@@ -56,17 +56,19 @@
     <textarea id="code-html" name="code-html"></textarea></div>    
     <div style="max-width: 50em; margin-bottom: 1em">JSON:<br>
     <textarea id="code-json" name="code-json">
-{"menu": {
-  "id": "file",
-  "value": "File",
-  "popup": {
-    "menuitem": [
-      {"value": "New", "onclick": "CreateNewDoc()"},
-      {"value": "Open", "onclick": "OpenDoc()"},
-      {"value": "Close", "onclick": "CloseDoc()"}
-    ]
+{
+  "menu": {
+    "id": "file",
+    "value": "File",
+    "popup": {
+      "menuitem": [
+        {"value": "New", "onclick": "CreateNewDoc()"},
+        {"value": "Open", "onclick": "OpenDoc()"},
+        {"value": "Close", "onclick": "CloseDoc()"}
+      ]
+    }
   }
-}}
+}
     </textarea></div>
     <div style="max-width: 50em">Python:<br>
     <textarea id="code-python" name="code">
@@ -116,14 +118,14 @@ window.onload = function() {
   editor.foldCode(CodeMirror.Pos(13, 0));
 
   window.editor_json = CodeMirror.fromTextArea(te_json, {
-    mode: "javascript",
+    mode: {name: "javascript", json: true},
     lineNumbers: true,
     lineWrapping: true,
     extraKeys: {"Ctrl-Q": function(cm){ cm.foldCode(cm.getCursor()); }},
     foldGutter: true,
     gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
     foldOptions: {
-      itemsWidget: items => items && `\u21A4${items}\u21A6`
+      jsonCountWidget: count => count && `\u21A4${count}\u21A6`
     }
   });
   editor_json.foldCode(CodeMirror.Pos(4, 0));

--- a/demo/folding.html
+++ b/demo/folding.html
@@ -125,7 +125,7 @@ window.onload = function() {
     foldGutter: true,
     gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
     foldOptions: {
-      jsonCountWidget: count => count && `\u21A4${count}\u21A6`
+      jsonCountWidget: count => `\u21A4${count}\u21A6`
     }
   });
   editor_json.foldCode(CodeMirror.Pos(4, 0));

--- a/demo/folding.html
+++ b/demo/folding.html
@@ -123,7 +123,7 @@ window.onload = function() {
     foldGutter: true,
     gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
     foldOptions: {
-      rangeFinder: CodeMirror.fold.json, widget: items => `...${items}...` || '...'
+      widget: items => items ? `\u21A4${items}\u21A6` : '\u2194'
     }
   });
   editor_json.foldCode(CodeMirror.Pos(4, 0));

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2568,13 +2568,13 @@ editor.setOption("extraKeys", {
         <dd>The widget to show for folded ranges. Can be either a
         string, in which case it'll become a span with
         class <code>CodeMirror-foldmarker</code>, or a DOM node.</dd>
-        <dt><code><strong>jsonCountWidget</strong>: fn(number): string|Element|undefined</code></dt>
+        <dt><code><strong>jsonCountWidget</strong>: fn(number): string|Element</code></dt>
         <dd>The widget to show for folded JSON ranges where a count 
         can be determined. This is a callback function that recieves 
         a count. It can return either a string, in which case it'll
         become a span with class <code>CodeMirror-foldmarker</code>,
-        or a DOM node. If it returns <code>undefined</code>, the
-        <code>widget</code> is used as a fallback.</dd>
+        or a DOM node. The <code>widget</code> is used as a fallback
+        if there is no count to show.</dd>
         <dt><code><strong>scanUp</strong>: boolean</code></dt>
         <dd>When true (default is false), the addon will try to find
         foldable ranges on the lines above the current one if there

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2568,6 +2568,13 @@ editor.setOption("extraKeys", {
         <dd>The widget to show for folded ranges. Can be either a
         string, in which case it'll become a span with
         class <code>CodeMirror-foldmarker</code>, or a DOM node.</dd>
+        <dt><code><strong>jsonCountWidget</strong>: fn(number): string|Element|undefined</code></dt>
+        <dd>The widget to show for folded JSON ranges where a count 
+        can be determined. This is a callback function that recieves 
+        a count. It can return either a string, in which case it'll
+        become a span with class <code>CodeMirror-foldmarker</code>,
+        or a DOM node. If it returns <code>undefined</code>, the
+        <code>widget</code> is used as a fallback.</dd>
         <dt><code><strong>scanUp</strong>: boolean</code></dt>
         <dd>When true (default is false), the addon will try to find
         foldable ranges on the lines above the current one if there


### PR DESCRIPTION
## Feature
There is a [feature request](https://github.com/getinsomnia/insomnia/issues/1799) in a consuming project to show the JSON array size when a node has been folded.

This seems like a reasonable request, given the user currently copy-pastes into a separate window to see the count. I looked for an existing issue/request but couldn't find one. Instead of creating a request, I have attempted an implementation after understanding some of the structure.

## Feedback requested
- I tried to decouple the `JSON.Parse` -> `Object.keys` from the `fold.brace` helper, however I still need all the logic within `fold.brace`. If I decouple, I would still have to load the `fold.brace` helper, return extra data (the brace type), to then run with the counting logic. Thoughts?
- Given the existing `widget` can be overridden, I decided to allow the `jsonCountWidget` to also be overridden. It is up to the user how they want to show it. It is `undefined` by default, meaning the behavior is switched off. Thoughts on configuration?

## Demo

Code folding demo within CodeMirror:
![](http://g.recordit.co/77po7tiLIC.gif)

Gif from the consuming application:
![](http://g.recordit.co/CERVzRaFoH.gif)

Behavior with invalid JSON (reverts to `widget`):
![](http://g.recordit.co/WeedYIqJkh.gif)

## Final words
I loved the fact that there is no need to spin up a web server. Very vanilla, very nice. 🍦 

Do you have any ideas why these tests fail on my W10 machine? They fail on master, but pass in CI. I am using Node v8.11.1 locally.

![image](https://user-images.githubusercontent.com/4312346/69490350-5981be80-0eeb-11ea-878d-389011a96209.png)

Open to suggestions and feedback 😄 