### PR TITLE
Fix syntax highlight for pgsql mode for backslash and escape constant

### DIFF
--- a/mode/sql/sql.js
+++ b/mode/sql/sql.js
@@ -22,8 +22,7 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
       dateSQL        = parserConfig.dateSQL || {"date" : true, "time" : true, "timestamp" : true},
       backslashStringEscapes = parserConfig.backslashStringEscapes !== false,
       brackets       = parserConfig.brackets || /^[\{}\(\)\[\]]/,
-      punctuation    = parserConfig.punctuation || /^[;.,:]/,
-      escapeConstSet = false;
+      punctuation    = parserConfig.punctuation || /^[;.,:]/
 
   function tokenBase(stream, state) {
     var ch = stream.next();
@@ -68,7 +67,7 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
       // ref: http://dev.mysql.com/doc/refman/5.5/en/string-literals.html
       // escape constant: E'str', e'str'
       // ref: https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS-ESCAPE
-      escapeConstSet = true;
+      state.escapeConstSet = true;
       return "keyword";
     } else if (support.commentSlashSlash && ch == "/" && stream.eat("/")) {
       // 1-line comment
@@ -135,9 +134,9 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
           state.tokenize = tokenBase;
           break;
         }
-        escaped = (backslashStringEscapes || escapeConstSet) && !escaped && ch == "\\";
+        escaped = (backslashStringEscapes || state.escapeConstSet) && !escaped && ch == "\\";
       }
-      escapeConstSet = false;
+      state.escapeConstSet = false;
       return "string";
     };
   }
@@ -168,7 +167,7 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
 
   return {
     startState: function() {
-      return {tokenize: tokenBase, context: null};
+      return {tokenize: tokenBase, context: null, escapeConstSet: false};
     },
 
     token: function(stream, state) {


### PR DESCRIPTION
Fix syntax highlight for pgsql mode as PostgreSQL does not require backslash to be escaped.
Add support for escape constant as mentioned with ref to:
https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS-ESCAPE

Below are the sample queries to test:
SELECT 'select c:\data\out\'||oid||'.csv' from pg_class;
select E'\'', '123\';

Attached are the screenshots of working example where the above queries works fine - pgAdmin4.
<img width="463" alt="Screenshot 2019-12-06 at 12 54 36" src="https://user-images.githubusercontent.com/31855755/70304479-04697500-1828-11ea-90bf-2a085c0941ec.png">
<img width="685" alt="Screenshot 2019-12-06 at 12 53 51" src="https://user-images.githubusercontent.com/31855755/70304481-05020b80-1828-11ea-8828-6c5e432669c1.png">




