### PR TITLE
Add indentSelection doc

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2131,6 +2131,10 @@ editor.setOption("extraKeys", {
           <dd>Add (positive number) or reduce (negative number) the
           indentation by the given amount of spaces.</dd>
         </dl></dd>
+      
+      <dt id="indentSelection"><code><strong>cm.indentSelection</strong>(?how: string|integer)</code></dt>
+      <dd>Adjust the indentation of the selected code. The optional <code>how</code> argument
+      works same as <code>dir</code> in <a href="#indentLine"><code>indentLine</code></a>.</dd>
 
       <dt id="toggleOverwrite"><code><strong>cm.toggleOverwrite</strong>(?value: boolean)</code></dt>
       <dd>Switches between overwrite and normal insert mode (when not


### PR DESCRIPTION
indentSelecton is missing in manual.
https://codemirror.net/doc/manual.html#indentLine
https://github.com/codemirror/CodeMirror/blob/5.49.2/src/edit/methods.js#L97-L116