### PR TITLE
If valid and invalid files are drag n dropped, paste all valid files

### DIFF
--- a/src/edit/drop_events.js
+++ b/src/edit/drop_events.js
@@ -28,20 +28,21 @@ export function onDrop(e) {
   // Might be a file drop, in which case we simply extract the text
   // and insert it.
   if (files && files.length && window.FileReader && window.File) {
-    let readFiles = 0, text = []
+    let n = files.length, text = Array(n), read = 0
     const markAsReadAndPasteIfAllFilesAreRead = () => {
-      if (++readFiles == files.length) {
+      if (++read == n) {
         operation(cm, () => {
           pos = clipPos(cm.doc, pos)
           let change = {from: pos, to: pos,
-                        text: cm.doc.splitLines(text.join(cm.doc.lineSeparator())),
+                        text: cm.doc.splitLines(
+                            text.filter(t => t != null).join(cm.doc.lineSeparator())),
                         origin: "paste"}
           makeChange(cm.doc, change)
           setSelectionReplaceHistory(cm.doc, simpleSelection(pos, changeEnd(change)))
         })()
       }
     }
-    const readTextFromFile = (file) => {
+    const readTextFromFile = (file, i) => {
       if (cm.options.allowDropFileTypes &&
           indexOf(cm.options.allowDropFileTypes, file.type) == -1) {
         markAsReadAndPasteIfAllFilesAreRead()
@@ -55,12 +56,12 @@ export function onDrop(e) {
           markAsReadAndPasteIfAllFilesAreRead()
           return
         }
-        text.push(content)
+        text[i] = content;
         markAsReadAndPasteIfAllFilesAreRead()
       }
       reader.readAsText(file)
     }
-    for (let i = 0; i < files.length; i++) readTextFromFile(files[i])
+    for (let i = 0; i < files.length; i++) readTextFromFile(files[i], i)
   } else { // Normal drop
     // Don't do a replace if the drop happened inside of the selected text.
     if (cm.state.draggingText && cm.doc.sel.contains(pos) > -1) {

--- a/src/edit/drop_events.js
+++ b/src/edit/drop_events.js
@@ -40,7 +40,7 @@ export function onDrop(e) {
         reader.onerror = () => reject(reader.error)
         reader.onload = () => {
           let content = reader.result
-          if (/[\x00-\x08\x0e-\x1f]{2}/.test(content)) Promise.reject('Bad content.')
+          if (/[\x00-\x08\x0e-\x1f]{2}/.test(content)) reject('Bad content.')
           resolve(content)
         }
         reader.readAsText(file)

--- a/src/edit/drop_events.js
+++ b/src/edit/drop_events.js
@@ -28,35 +28,39 @@ export function onDrop(e) {
   // Might be a file drop, in which case we simply extract the text
   // and insert it.
   if (files && files.length && window.FileReader && window.File) {
+    let readFiles = 0, text = []
+    const markAsReadAndPasteIfAllFilesAreRead = () => {
+      if (++readFiles == files.length) {
+        operation(cm, () => {
+          pos = clipPos(cm.doc, pos)
+          let change = {from: pos, to: pos,
+                        text: cm.doc.splitLines(text.join(cm.doc.lineSeparator())),
+                        origin: "paste"}
+          makeChange(cm.doc, change)
+          setSelectionReplaceHistory(cm.doc, simpleSelection(pos, changeEnd(change)))
+        })()
+      }
+    }
     const readTextFromFile = (file) => {
-      return new Promise((resolve, reject) => {
-        if (cm.options.allowDropFileTypes &&
-            indexOf(cm.options.allowDropFileTypes, file.type) == -1) {
-          reject('File type not allowed: ' + file.type)
+      if (cm.options.allowDropFileTypes &&
+          indexOf(cm.options.allowDropFileTypes, file.type) == -1) {
+        markAsReadAndPasteIfAllFilesAreRead()
+        return
+      }
+      let reader = new FileReader
+      reader.onerror = () => markAsReadAndPasteIfAllFilesAreRead()
+      reader.onload = () => {
+        let content = reader.result
+        if (/[\x00-\x08\x0e-\x1f]{2}/.test(content)) {
+          markAsReadAndPasteIfAllFilesAreRead()
           return
         }
-
-        let reader = new FileReader
-        reader.onerror = () => reject(reader.error)
-        reader.onload = () => {
-          let content = reader.result
-          if (/[\x00-\x08\x0e-\x1f]{2}/.test(content)) reject('Bad content.')
-          resolve(content)
-        }
-        reader.readAsText(file)
-      })
+        text.push(content)
+        markAsReadAndPasteIfAllFilesAreRead()
+      }
+      reader.readAsText(file)
     }
-    Promise.allSettled(Array.from(files).map((file) => readTextFromFile(file))).then((results) => {
-      const text = results.filter((res) => res.status == "fulfilled").map(res => res.value)
-      operation(cm, () => {
-        pos = clipPos(cm.doc, pos)
-        let change = {from: pos, to: pos,
-                      text: cm.doc.splitLines(text.join(cm.doc.lineSeparator())),
-                      origin: "paste"}
-        makeChange(cm.doc, change)
-        setSelectionReplaceHistory(cm.doc, simpleSelection(pos, changeEnd(change)))
-      })()
-    })
+    for (let i = 0; i < files.length; i++) readTextFromFile(files[i])
   } else { // Normal drop
     // Don't do a replace if the drop happened inside of the selected text.
     if (cm.state.draggingText && cm.doc.sel.contains(pos) > -1) {


### PR DESCRIPTION
Fix for issue [#6098](https://github.com/codemirror/CodeMirror/issues/6098). When multiple files are dropped into the editor and any of these are invalid, then none of the files content is pasted.

With this patch all valid files will be pasted and all invalid rejected.