### PR TITLE
[Julia mode] Restore indentation when closing an array or generator.

### DIFF
--- a/mode/julia/julia.js
+++ b/mode/julia/julia.js
@@ -127,16 +127,14 @@ CodeMirror.defineMode("julia", function(config, parserConf) {
     }
 
     if (inArray(state) && ch === ']') {
-      if (currentScope(state) === "if") { state.scopes.pop(); }
-      while (currentScope(state) === "for") { state.scopes.pop(); }
+      while (currentScope(state) !== "[") { state.scopes.pop(); }
       state.scopes.pop();
       state.nestedArrays--;
       state.leavingExpr = true;
     }
 
     if (inGenerator(state) && ch === ')') {
-      if (currentScope(state) === "if") { state.scopes.pop(); }
-      while (currentScope(state) === "for") { state.scopes.pop(); }
+      while (currentScope(state) !== "(") { state.scopes.pop(); }
       state.scopes.pop();
       state.nestedGenerators--;
       state.leavingExpr = true;


### PR DESCRIPTION
Fix for issue [#6071](https://github.com/codemirror/CodeMirror/issues/6071), Julia mode has a indent problem.

This patch fixes the problem by closing all scopes which has been opened inside an array or generator when the closing char is found.