### PR TITLE
Fix broken link in manual

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -3178,14 +3178,14 @@ editor.setOption("extraKeys", {
 
       <dt id="addon_tern"><a href="../addon/tern/tern.js"><code>tern/tern.js</code></a></dt>
       <dd>Provides integration with
-      the <a href="http://ternjs.net">Tern</a> JavaScript analysis
+      the <a href="https://ternjs.net">Tern</a> JavaScript analysis
       engine, for completion, definition finding, and minor
       refactoring help. See the <a href="../demo/tern.html">demo</a>
       for a very simple integration. For more involved scenarios, see
       the comments at the top of
       the <a href="../addon/tern/tern.js">addon</a> and the
       implementation of the
-      (multi-file) <a href="http://ternjs.net/doc/demo.html">demonstration
+      (multi-file) <a href="https://ternjs.net/doc/demo/index.html">demonstration
       on the Tern website</a>.</dd>
     </dl>
 </section>


### PR DESCRIPTION
The external link to the ternjs.net demo page returns a 404 error; this PR corrects it.