### PR TITLE
Add Elixir mode

### DIFF
--- a/mode/elixir/elixir.js
+++ b/mode/elixir/elixir.js
@@ -1,0 +1,262 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+(function(mod) {
+    if (typeof exports == "object" && typeof module == "object") // CommonJS
+      mod(require("../../lib/codemirror"));
+    else if (typeof define == "function" && define.amd) // AMD
+      define(["../../lib/codemirror"], mod);
+    else // Plain browser env
+      mod(CodeMirror);
+  })(function(CodeMirror) {
+    "use strict";
+
+    CodeMirror.defineMode("elixir", function (_config, modeConfig) {
+
+      function switchState(source, setState, f)
+      {
+        setState(f);
+        return f(source, setState);
+      }
+
+      function switchStateWithTrigger(source, setState, f, trigger) {
+        setState(f);
+        return f(source, setState, trigger);
+      }
+
+      var smallRE = /[a-z_]/;
+      var largeRE = /[A-Z]/;
+      var digitRE = /[\d_]*(?:\.[\d_]+)?(?:[e][+\-]?[\d_]+)?/;
+      var hexRE = /[\da-fA-F]/;
+      var binRE = /[01]/;
+      var wordRE = /[a-z_A-Z0-9'\xa1-\uffff?!]/;
+      var exprRE = /^@?[\w\xa1-\uffff]/;
+      var symbolRE = /[-!#$%&*+.\/<=>?\\^|~:]/;
+      var sigilRE = /[wscrSDNTURWC]/;
+      var whiteCharRE = /[ \t\v\f]/; // newlines are handled in tokenizer
+
+      function normal()
+      {
+        return function(source, setState)
+        {
+          if (source.eatWhile(whiteCharRE))
+          {
+            return null;
+          }
+
+          var ch = source.next();
+
+          if (ch === '#') {
+            source.skipToEnd()
+            return 'comment'
+          }
+
+          if (ch === '"') {
+            return maybeMultiLine(source, setState)
+          }
+
+          if (ch === '_') {
+            source.eatWhile(/\w/)
+            return 'comment'
+          }
+
+          if (ch === '@' && source.match(exprRE)) {
+            source.eat('@')
+            source.eatWhile(wordRE)
+            return 'variable-2'
+          }
+
+          if (largeRE.test(ch)) {
+            source.eatWhile(wordRE);
+            return "variable-2";
+          }
+
+          if (ch === '~') {
+            if (source.eat(sigilRE)) {
+              if (source.eat('"')) {
+                return maybeMultiLine(source, setState)
+              }
+
+              if (source.eat("(")) {
+                return switchStateWithTrigger(source, setState, stringLiteral, ")");
+              } else if (source.eat("/")) {
+                return switchStateWithTrigger(source, setState, stringLiteral, "/");
+              } else if (source.eat("[")) {
+                return switchStateWithTrigger(source, setState, stringLiteral, "]");
+              } else if (source.eat("|")) {
+                return switchStateWithTrigger(source, setState, stringLiteral, "|");
+              } else if (source.eat("\"")) {
+                return switchStateWithTrigger(source, setState, stringLiteral, "\"");
+              } else if (source.eat("\'")) {
+                return switchStateWithTrigger(source, setState, stringLiteral, "\'");
+              } else if (source.eat("{")) {
+                return switchStateWithTrigger(source, setState, stringLiteral, "}");
+              }
+            }
+          }
+
+          if (ch == "\'") {
+            return switchStateWithTrigger(source, setState, stringLiteral, ch);
+          }
+
+          if (smallRE.test(ch)) {
+            source.eatWhile(wordRE);
+            if (source.eat(":")) {
+              return "atom";
+            }
+            return "variable";
+          }
+
+          if (ch == "0") {
+            if (source.eat('x')) {
+              source.eatWhile(hexRE)
+            } else if (source.eat('b')) {
+              source.eatWhile(binRE)
+            }
+          }
+
+          if (/\d/.test(ch)) {
+            source.match(digitRE);
+            return "number";
+          }
+
+          if (ch == ":") {
+            if (source.eat('"')) {
+              return switchStateWithTrigger(source, setState, atom, '"');
+            }
+            if (source.eat("\'")) {
+              return switchStateWithTrigger(source, setState, atom, "\'");
+            }
+            source.eatWhile(wordRE);
+            return "atom";
+          }
+
+          if (symbolRE.test(ch)) {
+            source.eatWhile(symbolRE);
+            return "keyword";
+          }
+
+          return null;
+        }
+      }
+
+      function maybeMultiLine(source, setState) {
+        return source.eat('"')
+          ? source.eat('"')
+            ? switchState(source, setState, chompMultiString)
+            : 'string'
+          : switchState(source, setState, chompSingleString);
+      }
+
+      function chompMultiString(source, setState)
+      {
+        while (!source.eol())
+        {
+          var char = source.next();
+          if (char === '"' && source.eat('"') && source.eat('"'))
+          {
+            setState(normal());
+            return 'string';
+          }
+        }
+        return 'string';
+      }
+
+      function chompSingleString(source, setState)
+      {
+        while (source.skipTo('\\"')) { source.next(); source.next(); }
+        if (source.skipTo('"'))
+        {
+          source.next();
+          setState(normal());
+          return 'string';
+        }
+        source.skipToEnd();
+        setState(normal());
+        return 'string';
+      }
+
+      function stringLiteral(source, setState, trigger) {
+        return processEOLState(source, setState, trigger, "string")
+      }
+
+      function atom(source, setState, trigger) {
+        return processEOLState(source, setState, trigger, "atom")
+      }
+
+      function processEOLState(source, setState, trigger, stateName) {
+        while (!source.eol()) {
+          var ch = source.next();
+          if (ch == trigger) {
+            setState(normal());
+            return stateName;
+          }
+        }
+        setState(normal());
+        return stateName;
+      }
+
+      var wellKnownWords = (function () {
+        var wkw = {};
+        function setType(t) {
+          return function () {
+            for (var i = 0; i < arguments.length; i++)
+              wkw[arguments[i]] = t;
+          };
+        }
+
+        setType("keyword")(
+          'alias', 'case', 'cond', 'quote', 'unquote', 'receive', 'fn',
+          'do', 'else', 'else if', 'end', 'false', 'if', 'in', 'not', 'rescue',
+          'for', 'true', 'when', 'nil', 'try', 'catch',
+          'after', 'with', 'require', 'use', '__MODULE__', '__FILE__', '__DIR__',
+          '__ENV__', '__CALLER__');
+
+        setType("keyword")("..", ":", "::", "=", "<-", "->", "=>");
+
+        setType("builtin")(
+          "!!", "&&", "+", "++", "--", "-", ".", "<", "<<<", ">>>", "^^^", "~~~", "<=", "=~",
+          "==", ">", ">=", "<=", ">=", "<>", "||", "*", "&&&", "!==", "/", "===", "|>");
+
+        setType("builtin")(
+          'abs', 'and', 'binary_part', 'bit_size', 'byte_size', 'ceil', 'div', 'elem', 'floor',
+          'hd', 'in', 'is_atom', 'is_binary', 'is_bitstring', 'is_boolean', 'is_float',
+          'is_function', 'is_integer', 'is_list', 'is_map', 'is_nil', 'is_number', 'is_pid',
+          'is_port', 'is_reference', 'is_tuple', 'length', 'map_size', 'node', 'not', 'or', 'rem',
+          'round', 'self', 'tl', 'trunc', 'tuple_size');
+
+        setType("builtin")(
+          'alias!', 'apply', 'binding', 'destructure', 'exit', 'function_exported?',
+          'get_and_update_in', 'get_in', 'inspect', 'macro_exported?', 'make_ref', 'match?',
+          'max', 'min', 'pop_in', 'put_elem', 'put_in', 'raise', 'reraise', 'send', 'sigil_C', 'sigil_D',
+          'sigil_N', 'sigil_R', 'sigil_S', 'sigil_T', 'sigil_U', 'sigil_W', 'sigil_c', 'sigil_r',
+          'sigil_s', 'sigil_w', 'spawn', 'spawn_link', 'spawn_monitor', 'struct', 'struct!',
+          'throw', 'to_charlist', 'to_string', 'unless', 'update_in', 'var!');
+
+        setType("def")(
+          'def', 'defdelegate', 'defexception', 'defguard',
+          'defguardp', 'defimpl', 'defmacro', 'defmacrop', 'defmodule', 'defoverridable',
+          'defp', 'defprotocol', 'defstruct');
+
+        var override = modeConfig.overrideKeywords;
+        if (override) for (var word in override) if (override.hasOwnProperty(word))
+          wkw[word] = override[word];
+
+        return wkw;
+      })();
+
+      return {
+        startState: function ()  { return { f: normal() }; },
+        copyState:  function (s) { return { f: s.f }; },
+
+        token: function(stream, state) {
+          var type = state.f(stream, function(s) { state.f = s; });
+          var word = stream.current();
+          return wellKnownWords.hasOwnProperty(word) ? wellKnownWords[word] : type;
+        }
+      };
+
+    });
+
+    CodeMirror.defineMIME("text/x-elixir", "elixir");
+  });

--- a/mode/elixir/index.html
+++ b/mode/elixir/index.html
@@ -1,0 +1,147 @@
+<!doctype html>
+
+<title>CodeMirror: Elixir mode</title>
+<meta charset="utf-8" />
+<link rel=stylesheet href="../../doc/docs.css">
+
+<link rel="stylesheet" href="../../lib/codemirror.css">
+<script src="../../lib/codemirror.js"></script>
+<script src="../../addon/edit/matchbrackets.js"></script>
+<link rel="stylesheet" href="../../addon/hint/show-hint.css">
+<script src="../../addon/hint/show-hint.js"></script>
+<script src="elixir.js"></script>
+<style>
+  .CodeMirror {
+      border: 2px inset #dee;
+  }
+</style>
+<div id=nav>
+  <a href="https://codemirror.net">
+    <h1>CodeMirror</h1><img id=logo src="../../doc/logo.png" alt="">
+  </a>
+
+  <ul>
+    <li><a href="../../index.html">Home</a>
+    <li><a href="../../doc/manual.html">Manual</a>
+    <li><a href="https://github.com/codemirror/codemirror">Code</a>
+  </ul>
+  <ul>
+    <li><a href="../index.html">Language modes</a>
+    <li><a class=active href="#">Elixir</a>
+  </ul>
+</div>
+
+<article>
+  <h2>Elixir mode</h2>
+  <form>
+    <textarea id="code" name="code">
+# Some code examples borrowed from https://learnxinyminutes.com/docs/elixir/
+defmodule MyModule do
+  @moduledoc """
+  This is a built-in attribute on a example module.
+  """
+
+  use Bitwise
+
+  @type doubled_even_list() :: list(number())
+
+  # Struct
+  defstruct name: nil, age: 0, height: 0, tags: nil
+
+  @doc ~s"oneline sigil"
+  # Function
+  def function_one do
+    mm_struct = %MyModule{name: "a", age: 3, height: 40, tags: ~w(foo bar bat)}
+    list = [~D[2020-01-12], 1_000_000, :'🌢 Elixir', ~s/f#{"o"}o/, 0x1F, 0b1010, 1.0e-10]
+    map = %{one: mm_struct, two: 'two', "three" => list}
+    {:ok, map["three"]}
+  end
+
+  @doc ~S"oneline capital S sigil"
+  # Pattern matching
+  def function_two do
+    {:ok, msg} = function_one
+    IO.puts(msg)
+  end
+
+  # Try/Rescue block
+  def function_three do
+    a = "a"
+    try do
+      raise "some error" <> """
+      something
+      """ <> a
+    rescue
+      RuntimeError -> "rescued a runtime error"
+      _error -> "this will rescue any error"
+    end
+  end
+
+  def function_four do
+    raise "some other error"
+  rescue
+    RuntimeError -> "rescued a runtime error"
+    _error -> "this will rescue any error"
+  end
+
+  def even?(n) when is_number(n), do: rem(n, 2) == 0
+
+  # Pipes
+  @spec function_five(number(), number()) :: doubled_even_list()
+  def function_five(start, finish, _third, _) do
+    with true <- is_number(start),
+      true <- is_number(finish),
+      true <- finish >= start
+    do
+      Range.new(start, finish)
+      |> Enum.map(fn x -> x * x end)
+      |> Enum.filter(&even?/1)
+    end
+  end
+
+  # Oneliner
+  def function_six(n) when n not in [1, 2], do: IO.puts("Oneliner #{inspect(n)}")
+
+  # Bitwise
+  def function_seven() do
+    one = 1 &&& 1
+    two = 1 <<< 2
+    _three = 9 ^^^ 3
+    four = 9 ||| 3
+    five ~~~2 &&& 3
+    [one, two, four, five]
+  end
+
+  # Binary pattern matching
+  def parse(<<_type, length::big-32, data::binary>>) do
+    case byte_size(data) == length do
+      true -> :ok
+      false -> :error
+    end
+  end
+
+  def sigil_multiline_string do
+    ~S"""
+    Converts double-quotes to single-quotes.
+
+    ## Examples
+
+        iex> convert("\"foo\"")
+        "'foo'"
+
+    """
+  end
+end
+
+</textarea>
+  </form>
+  <script>
+    var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
+        mode: "text/x-elixir",
+        matchBrackets: true,
+        indentUnit: 4
+    });
+  </script>
+
+  <p><strong>MIME types defined:</strong> <code>text/x-elixir</code>.</p>
+</article>

--- a/mode/index.html
+++ b/mode/index.html
@@ -56,7 +56,7 @@ option.</p>
       <li><a href="ebnf/index.html">EBNF</a></li>
       <li><a href="ecl/index.html">ECL</a></li>
       <li><a href="eiffel/index.html">Eiffel</a></li>
-      <li><a href="https://github.com/optick/codemirror-mode-elixir">Elixir</a></li>
+      <li><a href="elixir/index.html">Elixir</a></li>
       <li><a href="elm/index.html">Elm</a></li>
       <li><a href="erlang/index.html">Erlang</a></li>
       <li><a href="factor/index.html">Factor</a></li>


### PR DESCRIPTION
Hello.

First of all, thank you for making this great thing! I was using it for years and didn't even know about it :)

Bitbucket Server uses CodeMirror (version 49 in latest available release) to highlight syntax of source files. As an Elixir developer and Bitbucket Server user I wasn't really happy that Bitbucket can't do syntax highlighting for Elixir, after years of waiting I finally decided to do something about it :)

CodeMirror has built-in modes for almost every language but not for Elixir. There is mode from @ianwalter https://github.com/ianwalter/codemirror-mode-elixir but apparently it can't be used in Bitbucket since it's not a part of CodeMirror repo. It also has Vue as a dependency, which is unnecessary in my opinion. This mode also doesn't support few syntax features of Elixir language like sigils, maps, structs.

So I made new Elixir mode based on Elm and Haskell modes, it's probably not perfect but it works. I'd welcome any kind of feedback.