### PR TITLE
Append the tooltip to the wrapper element

### DIFF
--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -16,7 +16,10 @@
     var tt = document.createElement("div");
     tt.className = "CodeMirror-lint-tooltip cm-s-" + cm.options.theme;
     tt.appendChild(content.cloneNode(true));
-    cm.getWrapperElement().appendChild(tt);
+    if(cm.options.lint.selfContain)
+      cm.getWrapperElement().appendChild(tt);
+    else
+      document.body.appendChild(tt);
 
     function position(e) {
       if (!tt.parentNode) return CodeMirror.off(document, "mousemove", position);

--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -16,7 +16,7 @@
     var tt = document.createElement("div");
     tt.className = "CodeMirror-lint-tooltip cm-s-" + cm.options.theme;
     tt.appendChild(content.cloneNode(true));
-    document.body.appendChild(tt);
+    cm.getWrapperElement().appendChild(tt);
 
     function position(e) {
       if (!tt.parentNode) return CodeMirror.off(document, "mousemove", position);

--- a/demo/lint.html
+++ b/demo/lint.html
@@ -150,7 +150,9 @@ li.last {
     lineNumbers: true,
     mode: "javascript",
     gutters: ["CodeMirror-lint-markers"],
-    lint: true
+    lint: {
+      selfContain: true
+    }
   });
 
   var editor_json = CodeMirror.fromTextArea(document.getElementById("code-json"), {

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2911,6 +2911,7 @@ editor.setOption("extraKeys", {
       will only be executed when the promise resolves.
       By default, the linter will run (debounced) whenever the document is changed.
       You can pass a <code>lintOnChange: false</code> option to disable that.
+      You can pass a <code>selfContain: true</code> option to render the tooltip inside the editor instance.
       Depends on <code>addon/lint/lint.css</code>. A demo can be
       found <a href="../demo/lint.html">here</a>.</dd>
 


### PR DESCRIPTION
The tooltip in the existing way append to the body.
When applied the codemirror context inside a shadow root (custom element) this calls append the tooltip out of the root components where the behavior of the tooltip is broken.

Forcing, the user has to monkey patch the appendchild method to override the behavior or modify the code.

This change would append the tooltip to render in its own context.