### PR TITLE
Fix test driver

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -1,4 +1,4 @@
-var tests = [], filters = [], allNames = [];
+var tests = [], filters = [], nameCounts = {};
 
 function Failure(why) {this.message = why;}
 Failure.prototype.toString = function() { return this.message; };
@@ -12,13 +12,12 @@ function indexOf(collection, elt) {
 
 function test(name, run, expectedFail) {
   // Force unique names
-  var originalName = name;
-  var i = 2; // Second function would be NAME_2
-  while (indexOf(allNames, name) !== -1){
-    name = originalName + "_" + i;
-    i++;
+  if (nameCounts[name] == undefined){
+    nameCounts[name] = 2;
+  } else { 
+    // Append number if not first test with this name.
+    name = name + '_' + (nameCounts[name]++);
   }
-  allNames.push(name);
   // Add test
   tests.push({name: name, func: run, expectedFail: expectedFail});
   return name;

--- a/test/driver.js
+++ b/test/driver.js
@@ -11,8 +11,6 @@ function indexOf(collection, elt) {
 }
 
 function test(name, run, expectedFail) {
-  if (!/^vim/.test(name)) return
-  console.log(name)
   // Force unique names
   var originalName = name;
   var i = 2; // Second function would be NAME_2


### PR DESCRIPTION
Remove hard coded filter which only allowed vim tests to run.

Also improved the unique naming algorithm's time complexity from O(n^3) to O(n). With these 2000 tests this will reduce the iterations needed from 2 000 000 to 2000 iterations (or if all tests had the same name 4 * 10^9 iterations). 