### PR TITLE
[Soy] Improve map, list, record and list comprehension highlighting

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -156,7 +156,7 @@
       } else if (match = stream.match(/^\$([\w]+)/)) {
         return ref(state.variables, match[1], !state.lookupVariables);
       } else if (match = stream.match(/^\w+/)) {
-        return /^(?:as|and|or|not|in|for|if)$/.test(match[0]) ? "keyword" : null;
+        return /^(?:as|and|or|not|in|if)$/.test(match[0]) ? "keyword" : null;
       }
 
       stream.next();
@@ -375,6 +375,13 @@
               state.soyState.pop();
               state.lookupVariables = true;
               return null;
+            }
+            if (stream.match(/for/)) {
+              state.soyState.push("var-def")
+              return "keyword";
+            } else if (stream.match(/in/)) {
+              state.lookupVariables = true;
+              return "keyword";
             }
             return expression(stream, state);
 

--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -247,12 +247,43 @@
 
           case "param-type":
             var peekChar = stream.peek();
-            if (peekChar == "}" || peekChar == "=") {
+            if ("}]=>,".indexOf(peekChar) != -1) {
+              state.soyState.pop();
+              return null;
+            } else if (peekChar == "[") {
+              state.soyState.push('param-type-record');
+              return null;
+            } else if (stream.match(/^(map)|(list)/)) {
+              state.soyState.push('param-type-map-list');
+              return "type";
+            } else if (stream.eatWhile(/^([\w]+|[?])/)) {
+              return "type";
+            }
+            stream.next();
+            return null;
+
+          case "param-type-record":
+            var peekChar = stream.peek();
+            if (peekChar == "]") {
               state.soyState.pop();
               return null;
             }
-            if (stream.eatWhile(/^([\w]+|[?])/)) {
-              return "type";
+            if (stream.match(/^\w+/)) {
+              state.soyState.push('param-type');
+              return "property";
+            }
+            stream.next();
+            return null;
+
+          case "param-type-map-list":
+            var peekChar = stream.peek();
+            if (stream.match(/^[>]/)) {
+              state.soyState.pop();
+              return null;
+            }
+            if (stream.match(/^[<,]/)) {
+              state.soyState.push('param-type');
+              return null;
             }
             stream.next();
             return null;

--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -131,17 +131,17 @@
         state.soyState.push("list-literal");
         state.lookupVariables = false;
         return null;
-      } else if (stream.match(/map/)) {
+      } else if (stream.match(/map\b/)) {
         state.soyState.push("map-literal");
         return "keyword";
-      } else if (stream.match(/record/)) {
+      } else if (stream.match(/record\b/)) {
         state.soyState.push("record-literal");
         return "keyword";
       } else if (stream.match(/([\w]+)(?=\()/)) {
         return "variable callee";
       } else if (match = stream.match(/^["']/)) {
         state.soyState.push("string");
-        state.quoteKind = match;
+        state.quoteKind = match[0];
         return "string";
       } else if (stream.match(/^[(]/)) {
         state.soyState.push("open-parentheses");
@@ -300,10 +300,10 @@
             } else if (peekChar == "[") {
               state.soyState.push('param-type-record');
               return null;
-            } else if (stream.match(/^(map)|(list)/)) {
-              state.soyState.push('param-type-map-list');
-              return "type";
-            } else if (stream.eatWhile(/^([\w]+|[?])/)) {
+            } else if (match = stream.match(/^([\w]+|[?])/)) {
+              if (match[0] == "map" || match[0] == "list") {
+                state.soyState.push('param-type-map-list');
+              }
               return "type";
             }
             stream.next();
@@ -376,10 +376,10 @@
               state.lookupVariables = true;
               return null;
             }
-            if (stream.match(/for/)) {
+            if (stream.match(/for\b/)) {
               state.soyState.push("var-def")
               return "keyword";
-            } else if (stream.match(/in/)) {
+            } else if (stream.match(/in\b/)) {
               state.lookupVariables = true;
               return "keyword";
             }

--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -63,13 +63,27 @@
      '[keyword {] [atom 0x1F] [keyword }]',
      '[keyword {] [atom 0x1F00BBEA] [keyword }]');
 
-  MT('param-type-test',
+  MT('param-type-record',
+     '[keyword {@param] [def record]: [[[property foo]: [type bool], [property bar]: [type int] ]][keyword }]',
+  );
+
+  MT('param-type-map',
+     '[keyword {@param] [def unknown]: [type map]<[type string], [type bool]>[keyword }]',
+  );
+
+  MT('param-type-list',
+     '[keyword {@param] [def list]: [type list]<[type ?]>[keyword }]'
+  );
+
+  MT('param-type-any',
+     '[keyword {@param] [def unknown]: [type ?][keyword }]',
+  );
+
+  MT('param-type-nested',
      '[keyword {@param] [def a]: ' +
-         '[type list]<[[[type a]: [type int], ' +
-         '[type b]: [type map]<[type string], ' +
-         '[type bool]>]]>][keyword }]',
-      '[keyword {@param] [def unknown]: [type ?][keyword }]',
-      '[keyword {@param] [def list]: [type list]<[type ?]>[keyword }]');
+         '[type list]<[[[property a]: [type int], ' +
+         '[property b]: [type map]<[type string], ' +
+         '[type bool]>]]>][keyword }]',);
 
   MT('undefined-var',
      '[keyword {][variable-2&error $var]');

--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -247,4 +247,8 @@
      '[keyword {if] [atom true][keyword }]',
      '  Optional',
      '[keyword&error {/badend][keyword }]');
+
+  MT('list-comprehension',
+     '[keyword {let] [def $test]: [[[variable $a] [operator +] [atom 1] [keyword for] ' +
+         '[variable $a] [keyword in] [variable $myList] [keyword if] [variable $a] [operator >=] [atom 3] ] [keyword /}]');
 })();

--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -232,6 +232,17 @@
      '[keyword {lb}]',
      '[keyword {rb}]');
 
+  MT('let-list-literal',
+     '[keyword {let] [def $test]: [[[[[string \'a\'] ], [[[string \'b\'] ]] [keyword /}]');
+
+  MT('let-record-literal',
+     '[keyword {let] [def $test]: [keyword record]([property test]: [callee&variable bidiGlobalDir](), ' +
+         '[property foo]: [atom 5]) [keyword /}]');
+
+  MT('let-map-literal',
+     '[keyword {let] [def $test]: [keyword map]([string \'outer\']: [keyword map]([atom 5]: [atom false]), ' +
+         '[string \'foo\']: [string \'bar\']) [keyword /}]');
+
   MT('wrong-closing-tag',
      '[keyword {if] [atom true][keyword }]',
      '  Optional',

--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -233,7 +233,7 @@
      '[keyword {rb}]');
 
   MT('let-list-literal',
-     '[keyword {let] [def $test]: [[[[[string \'a\'] ], [[[string \'b\'] ]] [keyword /}]');
+     '[keyword {let] [def $test]: [[[[[string \'a\'] ], [[[string \'b\'] ] ] [keyword /}]');
 
   MT('let-record-literal',
      '[keyword {let] [def $test]: [keyword record]([property test]: [callee&variable bidiGlobalDir](), ' +
@@ -249,6 +249,7 @@
      '[keyword&error {/badend][keyword }]');
 
   MT('list-comprehension',
+     '[keyword {let] [def $myList]: [[[[[string \'a\'] ] ] [keyword /}] ' +
      '[keyword {let] [def $test]: [[[variable $a] [operator +] [atom 1] [keyword for] ' +
-         '[variable $a] [keyword in] [variable $myList] [keyword if] [variable $a] [operator >=] [atom 3] ] [keyword /}]');
+         '[def $a] [keyword in] [variable-2 $myList] [keyword if] [variable-2 $a] [operator >=] [atom 3] ] [keyword /}]');
 })();


### PR DESCRIPTION
Add support for map, list and records.

Example of code which is now supported:
  {@param name: [test: number]}
  {@param numbers: list<number>}
  {@param strToNumMap: map<string, number>}
  {let $list: [['a'], ['b']] /}
  {let $list2: [$a + 1 for $a in $name if $a >= 3] /}
  {let $record: record(test: 'a', foo: 'bar') /}
  {let $map: map('test': 'a', 4: 'bar') /}