### PR TITLE
Fixes blockquote continuing without `>` in continueList

### DIFF
--- a/addon/edit/continuelist.js
+++ b/addon/edit/continuelist.js
@@ -41,7 +41,9 @@
         return;
       }
       if (emptyListRE.test(line)) {
-        if (!/>\s*$/.test(line)) cm.replaceRange("", {
+        var endOfQuote = inQuote && />\s*$/.test(line)
+        var endOfList = !/>\s*$/.test(line)
+        if (endOfQuote || endOfList) cm.replaceRange("", {
           line: pos.line, ch: 0
         }, {
           line: pos.line, ch: pos.ch + 1


### PR DESCRIPTION
In CodeMirror, using markdown mode and the continueList addon, blockquotes are not getting reset when the last line contains `> `

Currently:
```
> I am a blockquote
> 
I am still marked as a blockquote and get markdown style
```

This fix:
```
> I am a blockquote
> 
^ this will get replaced like other lists, and I am no longer marked as a blockquote
```