### PR TITLE
sTeX: Ensured that tag does not clash with object prototype props

### DIFF
--- a/mode/stex/stex.js
+++ b/mode/stex/stex.js
@@ -103,7 +103,7 @@
       // Do we look like '\command' ?  If so, attempt to apply the plugin 'command'
       if (source.match(/^\\[a-zA-Z@]+/)) {
         var cmdName = source.current().slice(1);
-        plug = plugins[cmdName] || plugins["DEFAULT"];
+        plug = plugins.hasOwnProperty(cmdName) ? plugins[cmdName] : plugins["DEFAULT"];
         plug = new plug();
         pushCommand(state, plug);
         setState(state, beginParams);


### PR DESCRIPTION
TeX user is free to declare macros with any name and in case of names such as `constructor` or `hasOwnProperty` etc., mode was picking prototype properties instead of default plugin.