### PR TITLE
Brace folding for Protobuf mode

### DIFF
--- a/mode/protobuf/protobuf.js
+++ b/mode/protobuf/protobuf.js
@@ -62,7 +62,10 @@
   };
 
   CodeMirror.defineMode("protobuf", function() {
-    return {token: tokenBase};
+    return {
+      token: tokenBase,
+      fold: "brace"
+    };
   });
 
   CodeMirror.defineMIME("text/x-protobuf", "protobuf");


### PR DESCRIPTION
Add folding for Protobuf's TextFormat. The syntax uses `{}` mainly. But also has `[]` (rare) and `<>` (legacy?). I don't believe `brace-fold` supports `<>` but I've never seen it in the wild so it's probably not too useful to support.

See [text_format.cc](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/text_format.cc) for the closest thing to a grammer.