### PR TITLE
Markdown: Disallow single dash for a setext header, fixes #6129

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -87,7 +87,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   ,   listRE = /^(?:[*\-+]|^[0-9]+([.)]))\s+/
   ,   taskListRE = /^\[(x| )\](?=\s)/i // Must follow listRE
   ,   atxHeaderRE = modeCfg.allowAtxHeaderWithoutSpace ? /^(#+)/ : /^(#+)(?: |$)/
-  ,   setextHeaderRE = /^ *(?:\={1,}|-{1,})\s*$/
+  ,   setextHeaderRE = /^ {0,3}(?:\={1,}|-{2,})\s*$/
   ,   textRE = /^[^#!\[\]*_\\<>` "'(~:]+/
   ,   fencedCodeRE = /^(~~~+|```+)[ \t]*([\w+#-]*)[^\n`]*$/
   ,   linkDefRE = /^\s*\[[^\]]+?\]:.*$/ // naive link-definition

--- a/mode/markdown/test.js
+++ b/mode/markdown/test.js
@@ -286,10 +286,12 @@
      "[header&header-1 foo]",
      "[header&header-1 ===]");
 
-  // Check if single underlining - works
-  MT("setextH2",
-     "[header&header-2 foo]",
-     "[header&header-2 -]");
+  // Check if single underlining - should not be interpreted
+  // as it might lead to an empty list:
+  // https://spec.commonmark.org/0.28/#setext-heading-underline
+  MT("setextH2Single",
+     "foo",
+     "-");
 
   // Check if 3+ -'s work
   MT("setextH2",
@@ -380,10 +382,10 @@
      "[header&header-1 bar]",
      "[header&header-1 =]");
 
-  // ensure we don't regard space after dash as a list
+  // ensure we regard space after a single dash as a list
   MT("setext_emptyList",
-     "[header&header-2 foo]",
-     "[header&header-2 - ]",
+     "foo",
+     "[variable-2 - ]",
      "foo");
 
   // Single-line blockquote with trailing space


### PR DESCRIPTION
Reasons expressed by Michael in #6129 seem good enough, and a dash can be used for multiple purposes. I believe many people start writing lists right after an introductory sentence, and may be puzzled at why the previous line suddently becomes a header for a second.