### PR TITLE
Fix: setCursor doesn't work well with `inputStyle: "contenteditable",` 

### DIFF
--- a/demo/abc.html
+++ b/demo/abc.html
@@ -1,0 +1,49 @@
+<!doctype html>
+
+<title>CodeMirror: Native Spellchecker Demo</title>
+<meta charset="utf-8"/>
+<link rel=stylesheet href="../doc/docs.css">
+
+<link rel="stylesheet" href="../lib/codemirror.css">
+<link rel="stylesheet" href="../addon/hint/show-hint.css">
+<script src="../lib/codemirror.js"></script>
+<script src="../addon/hint/show-hint.js"></script>
+<script src="../addon/hint/anyword-hint.js"></script>
+<script src="../mode/javascript/javascript.js"></script>
+<div id=nav>
+  <a href="https://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../doc/logo.png"></a>
+
+  <ul>
+    <li><a href="../index.html">Home</a>
+    <li><a href="../doc/manual.html">Manual</a>
+    <li><a href="https://github.com/codemirror/codemirror">Code</a>
+  </ul>
+  <ul>
+    <li><a class=active href="#">Native Spellchecker Demo</a>
+  </ul>
+</div>
+
+<article>
+<h2>Native Spellchecker Demo</h2>
+<p>This editor uses <code>Codemirror.inputStyle: 'contenteditable'</code> and <code>spellcheck: true</code>.</p>
+<form><textarea id="code" name="code">
+Native abc tesst with contenteditableInput editor
+</textarea></form>
+
+<h2>Default Editor Mode</h2>
+<p>The native spellchecker (of the browser) does not run with <code>Codemirror.inputStyle: 'textarea'</code> (default value).</p>
+<form><textarea id="code2" name="code2">
+No spellchecker in a textareaInput editor
+</textarea></form>
+
+<script>
+var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
+  inputStyle: "contenteditable",
+  spellcheck: true
+})
+
+editor.focus()
+
+var editor2 = CodeMirror.fromTextArea(document.getElementById("code2"), {})
+</script>
+</article>

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -1419,6 +1419,8 @@ editor.setOption("extraKeys", {
         based on the relative position of the old selection—the editor
         will try to move further away from that, to prevent getting
         stuck.</dd>
+        <dt id="selection_bias"><code><strong>forceFocus</strong>: boolean</code></dt>
+        <dd>Give the editor focus after selection.</dd>
       </dl></dd>
 
       <dt id="setSelections"><code><strong>doc.setSelections</strong>(ranges: array&lt;{anchor, head}&gt;, ?primary: integer, ?options: object)</code></dt>

--- a/src/display/operations.js
+++ b/src/display/operations.js
@@ -32,6 +32,7 @@ export function startOperation(cm) {
     cursorActivityHandlers: null, // Set of handlers to fire cursorActivity on
     cursorActivityCalled: 0, // Tracks which cursorActivity handlers have been called already
     selectionChanged: false, // Whether the selection needs to be redrawn
+    forceFocus: false,       // Force focus after selection changed
     updateMaxLine: false,    // Set when the widest line needs to be determined anew
     scrollLeft: null, scrollTop: null, // Intermediate scroll position, not pushed to DOM yet
     scrollToPos: null,       // Used to scroll to a specific position
@@ -128,9 +129,9 @@ function endOperation_W2(op) {
   if (cm.state.focused && op.updateInput)
     cm.display.input.reset(op.typing)
 
-  if (!op.extActiveElt)
-    ensureFocus(op.cm)
-  else {
+  if (!op.extActiveElt || op.forceFocus) {
+    ensureFocus(cm)
+  } else {
     op.extActiveElt.focus()
   }
 }

--- a/src/display/operations.js
+++ b/src/display/operations.js
@@ -1,6 +1,7 @@
 import { clipPos } from "../line/pos.js"
 import { findMaxLine } from "../line/spans.js"
 import { displayWidth, measureChar, scrollGap } from "../measurement/position_measurement.js"
+import { activeElt } from "../util/dom.js"
 import { signal } from "../util/event.js"
 import { finishOperation, pushOperation } from "../util/operation_group.js"
 
@@ -76,6 +77,8 @@ function endOperation_R1(op) {
     display.maxLineChanged && cm.options.lineWrapping
   op.update = op.mustUpdate &&
     new DisplayUpdate(cm, op.mustUpdate && {top: op.scrollTop, ensure: op.scrollToPos}, op.forceUpdate)
+
+  op.extActiveElt = (!cm.state.focused) ? activeElt() : false
 }
 
 function endOperation_W1(op) {
@@ -125,8 +128,11 @@ function endOperation_W2(op) {
   if (cm.state.focused && op.updateInput)
     cm.display.input.reset(op.typing)
 
-  if (cm.state.focused)
+  if (!op.extActiveElt)
     ensureFocus(op.cm)
+  else {
+    op.extActiveElt.focus()
+  }
 }
 
 function endOperation_finish(op) {

--- a/src/display/operations.js
+++ b/src/display/operations.js
@@ -2,7 +2,6 @@ import { clipPos } from "../line/pos.js"
 import { findMaxLine } from "../line/spans.js"
 import { displayWidth, measureChar, scrollGap } from "../measurement/position_measurement.js"
 import { signal } from "../util/event.js"
-import { activeElt } from "../util/dom.js"
 import { finishOperation, pushOperation } from "../util/operation_group.js"
 
 import { ensureFocus } from "./focus.js"
@@ -35,7 +34,6 @@ export function startOperation(cm) {
     updateMaxLine: false,    // Set when the widest line needs to be determined anew
     scrollLeft: null, scrollTop: null, // Intermediate scroll position, not pushed to DOM yet
     scrollToPos: null,       // Used to scroll to a specific position
-    focus: false,
     id: ++nextOpId           // Unique ID
   }
   pushOperation(cm.curOp)
@@ -115,9 +113,8 @@ function endOperation_W2(op) {
     cm.display.maxLineChanged = false
   }
 
-  let takeFocus = op.focus && op.focus == activeElt()
   if (op.preparedSelection)
-    cm.display.input.showSelection(op.preparedSelection, takeFocus)
+    cm.display.input.showSelection(op.preparedSelection)
   if (op.updatedDisplay || op.startHeight != cm.doc.height)
     updateScrollbars(cm, op.barMeasure)
   if (op.updatedDisplay)
@@ -127,7 +124,9 @@ function endOperation_W2(op) {
 
   if (cm.state.focused && op.updateInput)
     cm.display.input.reset(op.typing)
-  if (takeFocus) ensureFocus(op.cm)
+
+  if (cm.state.focused)
+    ensureFocus(op.cm)
 }
 
 function endOperation_finish(op) {

--- a/src/input/ContentEditableInput.js
+++ b/src/input/ContentEditableInput.js
@@ -100,14 +100,14 @@ export default class ContentEditableInput {
   }
 
   prepareSelection() {
-    let result = prepareSelection(this.cm, false)
-    result.focus = this.cm.state.focused
-    return result
+    // Redraw the selection and/or cursor
+    return prepareSelection(this.cm, false)
   }
 
-  showSelection(info, takeFocus) {
+  showSelection(info) {
     if (!info || !this.cm.display.view.length) return
-    if (info.focus || takeFocus) this.showPrimarySelection()
+
+    if (info.focus) this.showPrimarySelection(info)
     this.showMultipleSelections(info)
   }
 

--- a/src/input/ContentEditableInput.js
+++ b/src/input/ContentEditableInput.js
@@ -107,7 +107,7 @@ export default class ContentEditableInput {
   showSelection(info) {
     if (!info || !this.cm.display.view.length) return
 
-    if (info.focus) this.showPrimarySelection(info)
+    this.showPrimarySelection(info)
     this.showMultipleSelections(info)
   }
 

--- a/src/model/selection_updates.js
+++ b/src/model/selection_updates.js
@@ -108,6 +108,9 @@ export function setSelectionNoUndo(doc, sel, options) {
 
   if (!(options && options.scroll === false) && doc.cm)
     ensureCursorVisible(doc.cm)
+
+  if ((options && options.forceFocus === true) && doc.cm)
+    doc.cm.curOp.forceFocus = true
 }
 
 function setSelectionInner(doc, sel) {


### PR DESCRIPTION
Fix: #6167

This PR fix `ContentEditableInput.showSelection(info)`, I removed takeFocus because [it always false](https://github.com/codemirror/CodeMirror/issues/6167#issuecomment-596173768). It is a [remanent code](https://github.com/codemirror/CodeMirror/commit/e4b1293d1246885025add6459c95e7188b66288b), it cannot work like that.

Also, I add a demo page to try the spellchecker (and also, because I discovered that we can active the spellchecker only with stackoverflow, not with the codemirror documentation....).

My last change is to add `options.forceFocus` because the behavior of selection in the `ContenteditableInput` editor with no focus is weird and different of the behavior that we get with `TextareaInput`.

# Q/A

## Q/A `setSelection`

To test my PR/fix you have to go on `demo/abc.html` and try to do : 
  - `editor.setSelection({line:0, ch:2}, {line:0, ch:5})`
  - `editor.setCursor({line:0, ch:2})`

Try each time with focus (--> click in the editor) and without no focus (--> click out of the editor, in the page)

## Q/A `options.forceFocus`

To test `options.forceFocus`:

1. Select a word on `demo/abc.html` page, like this:
![image](https://user-images.githubusercontent.com/18501150/76159080-19062380-611d-11ea-9fe8-e23be9ef280c.png)
2. Try `editor.setSelection({line:0, ch:2}, {line:0, ch:5})`, nothing should be change.
2. Try `editor.setSelection({line:0, ch:2}, {line:0, ch:5}, {forceFocus:true})`, selection should be visible, like this:
![image](https://user-images.githubusercontent.com/18501150/76159111-52d72a00-611d-11ea-88b8-f318b27a4d3e.png)


------------

We have a visual difference between contenteditable and textarea InputStyle: 
  - TextareaInput: Selection is show with focus or not focus ;
  - ContenteditableInput: Selection is only show if the editor has focus.

