### PR TITLE
Fixes #4804 dialog closes when tab loses focus

### DIFF
--- a/addon/dialog/dialog.js
+++ b/addon/dialog/dialog.js
@@ -82,7 +82,9 @@
         if (e.keyCode == 13) callback(inp.value, e);
       });
 
-      if (options.closeOnBlur !== false) CodeMirror.on(inp, "blur", close);
+      if (options.closeOnBlur !== false) CodeMirror.on(dialog, "focusout", function (evt) {
+        if (evt.relatedTarget !== null) close();
+      });
     } else if (button = dialog.getElementsByTagName("button")[0]) {
       CodeMirror.on(button, "click", function() {
         close();


### PR DESCRIPTION
The input field of a dialog loses focus when switching to another tab or dev tools. This fix checks to see if the new focus target is inside the window (i.e. not null) before closing the dialog.

I have also changed the target to be the dialog div, instead of the input field. This better suits sites that add other elements inside the dialog.

Tested and working in Firefox, Chrome, Safari and IE > 8.
IE 8 retains previous behaviour, since `relatedTarget` is undefined.