### PR TITLE
Fix issue with backslashes being highlighted as errors in Powershell code

### DIFF
--- a/mode/powershell/index.html
+++ b/mode/powershell/index.html
@@ -28,6 +28,10 @@
       <h2>PowerShell mode</h2>
 
       <div><textarea id="code" name="code">
+# Paths
+cd c:\
+c:\windows\calc.exe
+
 # Number Literals
 0 12345
 12kb 12mb 12gB 12Tb 12PB 12L 12D 12lkb 12dtb

--- a/mode/powershell/powershell.js
+++ b/mode/powershell/powershell.js
@@ -38,7 +38,7 @@ CodeMirror.defineMode('powershell', function() {
     /param|process|return|switch|throw|trap|try|until|where|while/
   ], { suffix: notCharacterOrDash });
 
-  var punctuation = /[\[\]{},;`\.]|@[({]/;
+  var punctuation = /[\[\]{},;`\\\.]|@[({]/;
   var wordOperators = buildRegexp([
     'f',
     /b?not/,

--- a/mode/powershell/test.js
+++ b/mode/powershell/test.js
@@ -63,7 +63,7 @@
   MT('operator_long', "[operator -match]");
 
   forEach([
-    '(', ')', '[[', ']]', '{', '}', ',', '`', ';', '.'
+    '(', ')', '[[', ']]', '{', '}', ',', '`', ';', '.', '\\'
   ], function(punctuation) {
     MT("punctuation_" + punctuation.replace(/^[\[\]]/,''), "[punctuation " + punctuation + "]");
   });


### PR DESCRIPTION
Today backslashes are highlighted with the `cm-error` class in Powershell code:

![image](https://user-images.githubusercontent.com/160104/77376758-d0a56180-6dbc-11ea-80a9-07e58d9e784e.png)

This PR treats a backslash as punctuation, removing the error highlight:

![image](https://user-images.githubusercontent.com/160104/77376872-3265cb80-6dbd-11ea-91fd-3f658d5cf4b0.png)
