### PR TITLE
[vim keymap] Fix EOL handling in visual mode.

### DIFF
--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -396,6 +396,7 @@ testMotion('_', ['6','_'], makeCursor(5, lines[5].textStart), makeCursor(0, 8));
 testMotion('$', '$', makeCursor(0, lines[0].length - 1), makeCursor(0, 1));
 testMotion('$_repeat', ['2', '$'], makeCursor(1, lines[1].length - 1),
     makeCursor(0, 3));
+testMotion('$', ['v', '$'], makeCursor(0, lines[0].length), makeCursor(0, 1));
 testMotion('f', ['f', 'p'], pChars[0], makeCursor(charLine.line, 0));
 testMotion('f_repeat', ['2', 'f', 'p'], pChars[2], pChars[0]);
 testMotion('f_num', ['f', '2'], numChars[2], makeCursor(charLine.line, 0));


### PR DESCRIPTION
Vim's visual mode allows the cursor to be positioned over EOL.
This change fixes a bug where that EOL behavior only worked when
in visual block mode.