### PR TITLE
Fix caret position updating with touch events in chrome

### DIFF
--- a/src/display/update_display.js
+++ b/src/display/update_display.js
@@ -2,7 +2,7 @@ import { sawCollapsedSpans } from "../line/saw_special_spans.js"
 import { heightAtLine, visualLineEndNo, visualLineNo } from "../line/spans.js"
 import { getLine, lineNumberFor } from "../line/utils_line.js"
 import { displayHeight, displayWidth, getDimensions, paddingVert, scrollGap } from "../measurement/position_measurement.js"
-import { mac, webkit } from "../util/browser.js"
+import { mac, webkit, chrome } from "../util/browser.js"
 import { activeElt, removeChildren, contains } from "../util/dom.js"
 import { hasHandler, signal } from "../util/event.js"
 import { indexOf } from "../util/misc.js"
@@ -92,6 +92,11 @@ export function updateDisplayIfNeeded(cm, update) {
 
   if (update.editorIsHidden) {
     resetView(cm)
+    return false
+  }
+
+  // Bail out if there is a touch event in progress on chrome. Fixes https://github.com/codemirror/CodeMirror/issues/5844
+  if (chrome && cm.activeTouch !== null && !update.force) {
     return false
   }
 


### PR DESCRIPTION
There has been an [issue in Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=418177) for quite a while (> 5 years) now, which breaks changing the caret position via touch events. 

I have provided more details about the bug in #5844.

While the fix is not the most elegant - I have to admit - it should not break anything else since it only interferes with Chrome environments where there is an `.activeTouch`. It did not break any tests for me.