### PR TITLE
Update runMode with changes from runmode.js

### DIFF
--- a/addon/runmode/runmode-standalone.js
+++ b/addon/runmode/runmode-standalone.js
@@ -104,14 +104,18 @@ CodeMirror.defineMIME("text/plain", "null");
 
 CodeMirror.runMode = function (string, modespec, callback, options) {
   var mode = CodeMirror.getMode({ indentUnit: 2 }, modespec);
+  var ie = /MSIE \d/.test(navigator.userAgent);
+  var ie_lt9 = ie && (document.documentMode == null || document.documentMode < 9);
 
-  if (callback.nodeType == 1) {
+  if (callback.appendChild) {
     var tabSize = (options && options.tabSize) || 4;
     var node = callback, col = 0;
     node.innerHTML = "";
     callback = function (text, style) {
       if (text == "\n") {
-        node.appendChild(document.createElement("br"));
+        // Emitting LF or CRLF on IE8 or earlier results in an incorrect display.
+        // Emitting a carriage return makes everything ok.
+        node.appendChild(document.createTextNode(ie_lt9 ? '\r' : text));
         col = 0;
         return;
       }


### PR DESCRIPTION
This PR updates the `runMode` function in runmode-standalone.js with 3 commits from [runmode.js](https://github.com/codemirror/CodeMirror/blob/master/addon/runmode/runmode.js):
- https://github.com/codemirror/CodeMirror/commit/7e35f03ad1639d92735c8dee1e1b5c86a727c873
- https://github.com/codemirror/CodeMirror/commit/53bc4b1f54670c827662d5210a37b35e63a07c39
- https://github.com/codemirror/CodeMirror/commit/64113ec97bb73c2a740d42d56021acb01ce05a92

The first commit from runmode.js allows the `callback` in runMode to be a function, as mentioned in https://codemirror.net/demo/runmode.html and https://discuss.codemirror.net/t/runmode-standalone-callback/2357. The last two commits fixes a copy-and-paste bug from IE.