### PR TITLE
Fix a accessibility issue to allow screenreader to read a label when …

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -421,7 +421,7 @@
       simply <code>true</code>), focusing of the editor is also
       disallowed.</dd>
 
-      <dt id="option_srLabel"><code><strong>srLabel</strong>: string</code></dt>
+      <dt id="option_screenReaderLabel"><code><strong>screenReaderLabel</strong>: string</code></dt>
       <dd>This label is read by the screenreaders when CodeMirror text area is focussed. This
       is helpful for accessibility.</dd>
 

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -422,7 +422,7 @@
       disallowed.</dd>
 
       <dt id="option_screenReaderLabel"><code><strong>screenReaderLabel</strong>: string</code></dt>
-      <dd>This label is read by the screenreaders when CodeMirror text area is focussed. This
+      <dd>This label is read by the screenreaders when CodeMirror text area is focused. This
       is helpful for accessibility.</dd>
 
       <dt id="option_showCursorWhenSelecting"><code><strong>showCursorWhenSelecting</strong>: boolean</code></dt>

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -421,6 +421,10 @@
       simply <code>true</code>), focusing of the editor is also
       disallowed.</dd>
 
+      <dt id="option_srLabel"><code><strong>srLabel</strong>: string</code></dt>
+      <dd>This label is read by the screenreaders when CodeMirror text area is focussed. This
+      is helpful for accessibility.</dd>
+
       <dt id="option_showCursorWhenSelecting"><code><strong>showCursorWhenSelecting</strong>: boolean</code></dt>
       <dd>Whether the cursor should be drawn when a selection is
       active. Defaults to false.</dd>

--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -132,6 +132,7 @@ export function defineOptions(CodeMirror) {
     }
     cm.display.input.readOnlyChanged(val)
   })
+  option("srLabel", 'CodeMirror text input')
   option("disableInput", false, (cm, val) => {if (!val) cm.display.input.reset()}, true)
   option("dragDrop", true, dragDropChanged)
   option("allowDropFileTypes", null)

--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -132,7 +132,7 @@ export function defineOptions(CodeMirror) {
     }
     cm.display.input.readOnlyChanged(val)
   })
-  option("srLabel", 'CodeMirror text input')
+  option("screenReaderLabel", 'CodeMirror text input')
   option("disableInput", false, (cm, val) => {if (!val) cm.display.input.reset()}, true)
   option("dragDrop", true, dragDropChanged)
   option("allowDropFileTypes", null)

--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -132,7 +132,12 @@ export function defineOptions(CodeMirror) {
     }
     cm.display.input.readOnlyChanged(val)
   })
-  option("screenReaderLabel", 'CodeMirror text input')
+
+  option("screenReaderLabel", null, (cm, val) => {
+    val = (val === '') ? null : val
+    cm.display.input.screenReaderLabelChanged(val)
+  })
+
   option("disableInput", false, (cm, val) => {if (!val) cm.display.input.reset()}, true)
   option("dragDrop", true, dragDropChanged)
   option("allowDropFileTypes", null)

--- a/src/input/ContentEditableInput.js
+++ b/src/input/ContentEditableInput.js
@@ -31,6 +31,9 @@ export default class ContentEditableInput {
     let div = input.div = display.lineDiv
     disableBrowserMagic(div, cm.options.spellcheck, cm.options.autocorrect, cm.options.autocapitalize)
 
+    /* Add the label for screenreaders, accessibility */
+    div.setAttribute('aria-label', this.cm.options.screenReaderLabel)
+
     on(div, "paste", e => {
       if (signalDOMEvent(cm, e) || handlePaste(e, cm)) return
       // IE doesn't fire input events, so we schedule a read for the pasted content in this way

--- a/src/input/ContentEditableInput.js
+++ b/src/input/ContentEditableInput.js
@@ -31,9 +31,6 @@ export default class ContentEditableInput {
     let div = input.div = display.lineDiv
     disableBrowserMagic(div, cm.options.spellcheck, cm.options.autocorrect, cm.options.autocapitalize)
 
-    /* Add the label for screenreaders, accessibility */
-    div.setAttribute('aria-label', this.cm.options.screenReaderLabel)
-
     on(div, "paste", e => {
       if (signalDOMEvent(cm, e) || handlePaste(e, cm)) return
       // IE doesn't fire input events, so we schedule a read for the pasted content in this way
@@ -100,6 +97,15 @@ export default class ContentEditableInput {
     }
     on(div, "copy", onCopyCut)
     on(div, "cut", onCopyCut)
+  }
+
+  screenReaderLabelChanged(label) {
+    // Label for screenreaders, accessibility
+    if(label) {
+      this.div.setAttribute('aria-label', label)
+    } else {
+      this.div.removeAttribute('aria-label')
+    }
   }
 
   prepareSelection() {

--- a/src/input/TextareaInput.js
+++ b/src/input/TextareaInput.js
@@ -118,6 +118,15 @@ export default class TextareaInput {
     this.textarea = this.wrapper.firstChild
   }
 
+  screenReaderLabelChanged(label) {
+    // Label for screenreaders, accessibility
+    if(label) {
+      this.textarea.setAttribute('aria-label', label)
+    } else {
+      this.textarea.removeAttribute('aria-label')
+    }
+  }
+
   prepareSelection() {
     // Redraw the selection and/or cursor
     let cm = this.cm, display = cm.display, doc = cm.doc

--- a/src/input/TextareaInput.js
+++ b/src/input/TextareaInput.js
@@ -112,7 +112,7 @@ export default class TextareaInput {
 
   createField(_display) {
     // Wraps and hides input textarea
-    this.wrapper = hiddenTextarea()
+    this.wrapper = hiddenTextarea(this.cm.options.srLabel)
     // The semihidden textarea that is focused when the editor is
     // focused, and receives input.
     this.textarea = this.wrapper.firstChild

--- a/src/input/TextareaInput.js
+++ b/src/input/TextareaInput.js
@@ -112,7 +112,7 @@ export default class TextareaInput {
 
   createField(_display) {
     // Wraps and hides input textarea
-    this.wrapper = hiddenTextarea(this.cm.options.srLabel)
+    this.wrapper = hiddenTextarea(this.cm.options.screenReaderLabel)
     // The semihidden textarea that is focused when the editor is
     // focused, and receives input.
     this.textarea = this.wrapper.firstChild

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -119,11 +119,8 @@ export function disableBrowserMagic(field, spellcheck, autocorrect, autocapitali
   field.setAttribute("spellcheck", !!spellcheck)
 }
 
-export function hiddenTextarea(label) {
+export function hiddenTextarea() {
   let te = elt("textarea", null, null, "position: absolute; bottom: -1em; padding: 0; width: 1px; height: 1em; outline: none")
-  /* Label for screenreaders, accessibility */
-  te.setAttribute('aria-label', label)
-
   let div = elt("div", [te], null, "overflow: hidden; position: relative; width: 3px; height: 0px;")
   // The textarea is kept positioned near the cursor to prevent the
   // fact that it'll be scrolled into view on input from scrolling

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -119,9 +119,15 @@ export function disableBrowserMagic(field, spellcheck, autocorrect, autocapitali
   field.setAttribute("spellcheck", !!spellcheck)
 }
 
-export function hiddenTextarea() {
+export function hiddenTextarea(label) {
   let te = elt("textarea", null, null, "position: absolute; bottom: -1em; padding: 0; width: 1px; height: 1em; outline: none")
-  let div = elt("div", [te], null, "overflow: hidden; position: relative; width: 3px; height: 0px;")
+  let te_id = 'cm-textarea-' + Math.floor(Math.random() * 9999)
+  te.setAttribute('id', te_id)
+  /* Label for screenreaders, accessibility */
+  let le = elt("label", label, null, 'position: absolute; width: 1px; height: 1px; padding: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;')
+  le.setAttribute('for', te_id)
+
+  let div = elt("div", [te, le], null, "overflow: hidden; position: relative; width: 3px; height: 0px;")
   // The textarea is kept positioned near the cursor to prevent the
   // fact that it'll be scrolled into view on input from scrolling
   // our fake cursor out of view. On webkit, when wrap=off, paste is

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -121,13 +121,10 @@ export function disableBrowserMagic(field, spellcheck, autocorrect, autocapitali
 
 export function hiddenTextarea(label) {
   let te = elt("textarea", null, null, "position: absolute; bottom: -1em; padding: 0; width: 1px; height: 1em; outline: none")
-  let te_id = 'cm-textarea-' + Math.floor(Math.random() * 9999)
-  te.setAttribute('id', te_id)
   /* Label for screenreaders, accessibility */
-  let le = elt("label", label, null, 'position: absolute; width: 1px; height: 1px; padding: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;')
-  le.setAttribute('for', te_id)
+  te.setAttribute('aria-label', label)
 
-  let div = elt("div", [te, le], null, "overflow: hidden; position: relative; width: 3px; height: 0px;")
+  let div = elt("div", [te], null, "overflow: hidden; position: relative; width: 3px; height: 0px;")
   // The textarea is kept positioned near the cursor to prevent the
   // fact that it'll be scrolled into view on input from scrolling
   // our fake cursor out of view. On webkit, when wrap=off, paste is


### PR DESCRIPTION
…CodeMirror focussed.
Added a CodeMirror option srLabel to allow user to set the label for screenreaders.