### PR TITLE
[hint] Nicer scrolling with non-standard padding

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -370,10 +370,11 @@
 
     scrollToActive: function() {
       var node = this.hints.childNodes[this.selectedHint]
+      var firstNode = this.hints.firstChild;
       if (node.offsetTop < this.hints.scrollTop)
-        this.hints.scrollTop = node.offsetTop - 3;
+        this.hints.scrollTop = node.offsetTop - firstNode.offsetTop;
       else if (node.offsetTop + node.offsetHeight > this.hints.scrollTop + this.hints.clientHeight)
-        this.hints.scrollTop = node.offsetTop + node.offsetHeight - this.hints.clientHeight + 3;
+        this.hints.scrollTop = node.offsetTop + node.offsetHeight - this.hints.clientHeight + firstNode.offsetTop;
     },
 
     screenAmount: function() {


### PR DESCRIPTION
The `scrollToActive` function used to have a `3px` offset hardcoded, which matches the default style (`padding: 2px; border-width: 1px;`). Custom values for these these style attributes would lead to a small visual bug:

For example, with custom `padding: 0px`
![image](https://user-images.githubusercontent.com/6933510/78451053-51990e80-7683-11ea-9834-a33a4d8f91cd.png)

Behaviour with default style is unaffected.