### PR TITLE
[show-hint addon] don't close hints on backspace prematurely

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -98,10 +98,15 @@
         cancelAnimationFrame(this.debounce);
         this.debounce = 0;
       }
+      
+      var identStart = this.startPos;
+      if(this.data) {
+        identStart = this.data.from;
+      }
 
       var pos = this.cm.getCursor(), line = this.cm.getLine(pos.line);
       if (pos.line != this.startPos.line || line.length - pos.ch != this.startLen - this.startPos.ch ||
-          pos.ch < this.startPos.ch || this.cm.somethingSelected() ||
+          pos.ch < identStart.ch || this.cm.somethingSelected() ||
           (!pos.ch || this.options.closeCharacters.test(line.charAt(pos.ch - 1)))) {
         this.close();
       } else {


### PR DESCRIPTION
Currently, when a completion is triggered with part of the identifier already typed and backspace is hit, hints are immediately closed (when cursor is moved before the original position that completion was triggered for).

After this change, they will be closed only when the entire identifier is erased (cursor is moved before the identifier start).

Before:
![codemirror-before](https://user-images.githubusercontent.com/1022675/78561574-42979500-7818-11ea-96c4-e6afae3e6077.gif)

After:
![codemirror-after](https://user-images.githubusercontent.com/1022675/78561604-50e5b100-7818-11ea-831f-0d4d35583c79.gif)
