### PR TITLE
[show-hint] Scroll cursor into view after picking.

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -89,8 +89,8 @@
       if (completion.hint) completion.hint(this.cm, data, completion);
       else this.cm.replaceRange(getText(completion), completion.from || data.from,
                                 completion.to || data.to, "complete");
-      this.cm.scrollIntoView();
       CodeMirror.signal(data, "pick", completion);
+      this.cm.scrollIntoView();
       this.close();
     },
 

--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -89,6 +89,7 @@
       if (completion.hint) completion.hint(this.cm, data, completion);
       else this.cm.replaceRange(getText(completion), completion.from || data.from,
                                 completion.to || data.to, "complete");
+      this.cm.scrollIntoView();
       CodeMirror.signal(data, "pick", completion);
       this.close();
     },

--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -86,11 +86,15 @@
 
     pick: function(data, i) {
       var completion = data.list[i];
-      if (completion.hint) completion.hint(this.cm, data, completion);
-      else this.cm.replaceRange(getText(completion), completion.from || data.from,
-                                completion.to || data.to, "complete");
-      CodeMirror.signal(data, "pick", completion);
-      this.cm.scrollIntoView();
+      this.cm.operation(function(){
+        if (completion.hint)
+          completion.hint(this.cm, data, completion);
+        else
+          this.cm.replaceRange(getText(completion), completion.from || data.from,
+                               completion.to || data.to, "complete");
+        CodeMirror.signal(data, "pick", completion);
+        this.cm.scrollIntoView();
+      })
       this.close();
     },
 


### PR DESCRIPTION
**Fixes a minor visual bug:**
The picked hint might push the cursor out of the screen - this scrolls the cursor back into view. (Would normally happen after the next keypress.)