### PR TITLE
[JavaScript-Hint] Added options.additionalContext if not hinting with…

### DIFF
--- a/addon/hint/javascript-hint.js
+++ b/addon/hint/javascript-hint.js
@@ -150,8 +150,9 @@
       for (var c = token.state.context; c; c = c.prev)
         for (var v = c.vars; v; v = v.next) maybeAdd(v.name)
       for (var v = token.state.globalVars; v; v = v.next) maybeAdd(v.name);
-      if (options && options.additionalContext !== undefined)
-        Object.keys(options.additionalContext).forEach(maybeAdd);
+      if (options && options.additionalContext != null)
+        for (var key in options.additionalContext)
+          maybeAdd(key);
       if (!options || options.useGlobalScope !== false)
         gatherCompletions(global);
       forEach(keywords, maybeAdd);

--- a/addon/hint/javascript-hint.js
+++ b/addon/hint/javascript-hint.js
@@ -144,12 +144,14 @@
         base = base[context.pop().string];
       if (base != null) gatherCompletions(base);
     } else {
-      // If not, just look in the global object and any local scope
+      // If not, just look in the global object, any local scope, and optional additional-context
       // (reading into JS mode internals to get at the local and global variables)
       for (var v = token.state.localVars; v; v = v.next) maybeAdd(v.name);
       for (var c = token.state.context; c; c = c.prev)
         for (var v = c.vars; v; v = v.next) maybeAdd(v.name)
       for (var v = token.state.globalVars; v; v = v.next) maybeAdd(v.name);
+      if (options && options.additionalContext !== undefined)
+        Object.keys(options.additionalContext).forEach(maybeAdd);
       if (!options || options.useGlobalScope !== false)
         gatherCompletions(global);
       forEach(keywords, maybeAdd);


### PR DESCRIPTION
In `./addon/hint/javascript-hint.js`: When using the `additionalContext` option, it was successfully giving me the correct additional-context once I had typed out the top-level context.  Example:

```javascript
options.additionalContext = {
  sensors: { sensorA: {something: 1}, sensorB: 2 },
  calculations: { calcA: "a+b", calcB: "c+d" },
  alerts: { alertA: "e+f", alertB: "g+h" },
  context: { contextA: "abc", contextB: 100 },
}
const jshint = CodeMirror.hint.javascript(cm, options)
```

... would successfully hint `['sensorA', 'sensorB']` if I had typed `sensors.`, but it would not hint `sensors` when typing outside of a context.

I just added the top-level keys of `options.additionalContext` to the hint list and it behaves as I would expect (in the example above it suggests `['sensors', 'calculations', ...]` when typing in "white space").

```javascript
if (context && context.length) {
...
} else {
  // If not, just look in the global object, any local scope, and optional additional-context
  // (reading into JS mode internals to get at the local and global variables)
...
  if (options && options.additionalContext !== undefined)
    Object.keys(options.additionalContext).forEach(maybeAdd);
...
}
```