### PR TITLE
Documentation update for simple mode: clarify that negative lookbehind assertion for regex is not supported

### DIFF
--- a/demo/simplemode.html
+++ b/demo/simplemode.html
@@ -67,7 +67,8 @@ highlighted by the mode shown in it).</p>
   will be taken into account when matching the token. This regex
   has to capture groups when the <code>token</code> property is
   an array. If it captures groups, it must capture <em>all</em> of the string
-  (since JS provides no way to find out where a group matched).</dd>
+  (since JS provides no way to find out where a group matched).
+  Currently negative lookbehind assertion for regex is not supported, regardless of browser support.</dd>
   <dt><code><strong>token</strong></code>: string | array&lt;string&gt; | null</dt>
   <dd>An optional token style. Multiple styles can be specified by
   separating them with dots or spaces. When this property holds an array of token styles,


### PR DESCRIPTION
Related issue: https://github.com/codemirror/CodeMirror/issues/6233

add "Currently negative lookbehind assertion for regex is not supported, regardless of browser support." in description of the "regex" property of the rule. This is documentation update and no actual code is modified.