### PR TITLE
Add support for globalThis in standalone mode

### DIFF
--- a/addon/runmode/runmode-standalone.js
+++ b/addon/runmode/runmode-standalone.js
@@ -1,7 +1,8 @@
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
 
-window.CodeMirror = {};
+var root = typeof globalThis !== 'undefined' ? globalThis : window;
+root.CodeMirror = {};
 
 (function() {
 "use strict";

--- a/test/lint.js
+++ b/test/lint.js
@@ -3,7 +3,7 @@ var blint = require("blint");
 ["mode", "lib", "addon", "keymap"].forEach(function(dir) {
   blint.checkDir(dir, {
     browser: true,
-    allowedGlobals: ["CodeMirror", "define", "test", "requirejs"],
+    allowedGlobals: ["CodeMirror", "define", "test", "requirejs", "globalThis"],
     ecmaVersion: 5,
     tabs: dir == "lib"
   });


### PR DESCRIPTION
We use the standalone mode in DevTools in a worker, where `window`
does not exist. Instead, we can use `globalThis` which should be
the corresponding global scope in all scenarios. For older browsers
that do not support `globalThis`, we fallback to `window`.

Relevant DevTools change:
https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/2174418/1/front_end/third_party/codemirror/package/addon/runmode/runmode-standalone.js