### PR TITLE
Add `late` and `required` keywords, and `Null` and `Never` types to Dart

### DIFF
--- a/mode/dart/dart.js
+++ b/mode/dart/dart.js
@@ -15,10 +15,10 @@
     "implements mixin get native set typedef with enum throw rethrow " +
     "assert break case continue default in return new deferred async await covariant " +
     "try catch finally do else for if switch while import library export " +
-    "part of show hide is as extension on yield").split(" ");
+    "part of show hide is as extension on yield late required").split(" ");
   var blockKeywords = "try catch finally do else for if switch while".split(" ");
   var atoms = "true false null".split(" ");
-  var builtins = "void bool num int double dynamic var String".split(" ");
+  var builtins = "void bool num int double dynamic var String Null Never".split(" ");
 
   function set(words) {
     var obj = {};


### PR DESCRIPTION
Addresses most of #6268 

Types with `?` suffixed remain unsupported. I wasn't sure the best way to add this. Just duplicate (approximately) the list and add `?`?