### PR TITLE
Fix bug with "map" in type name.

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -300,10 +300,10 @@
             } else if (peekChar == "[") {
               state.soyState.push('param-type-record');
               return null;
+            } else if (peekChar == "<") {
+              state.soyState.push('param-type-parameter');
+              return null;
             } else if (match = stream.match(/^([\w]+|[?])/)) {
-              if (match[0] == "map" || match[0] == "list") {
-                state.soyState.push('param-type-map-list');
-              }
               return "type";
             }
             stream.next();
@@ -322,8 +322,7 @@
             stream.next();
             return null;
 
-          case "param-type-map-list":
-            var peekChar = stream.peek();
+          case "param-type-parameter":
             if (stream.match(/^[>]/)) {
               state.soyState.pop();
               return null;


### PR DESCRIPTION
Instead of looking for explicit map or list change to look for the '<' to check for param type parameters.
Example:
`map<string, string>`
`list<string>`

Also removed unused `var peekChar = stream.peek();`