### PR TITLE
change fencedCodeBlockDefaultMode to 'text/plain' instead of ''

### DIFF
--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -49,7 +49,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
     modeCfg.fencedCodeBlockHighlighting = true;
 
   if (modeCfg.fencedCodeBlockDefaultMode === undefined)
-    modeCfg.fencedCodeBlockDefaultMode = '';
+    modeCfg.fencedCodeBlockDefaultMode = 'text/plain';
 
   if (modeCfg.xml === undefined)
     modeCfg.xml = true;


### PR DESCRIPTION
This PR changes the default value for the option `fencedCodeBlockDefaultMode` in [markdown mode](https://codemirror.net/mode/markdown/) from `''` to `'text/plain'`. 
- Alternatively, the string value `'null'` works as well since [in meta.js, 'null' is the mode for plain text](https://github.com/codemirror/CodeMirror/blob/840464b337695d3c4fd2807bdd69e462e2f7d118/mode/meta.js#L107).
- An issue with using `''` as the default value is with how [`CodeMirror.getMode` is currently defined in `runmode-standalone.js`](https://github.com/codemirror/CodeMirror/blob/840464b337695d3c4fd2807bdd69e462e2f7d118/addon/runmode/runmode-standalone.js#L94): since `''` is not a valid mime or mode, an error is thrown.
- `text/plain` is a valid mime and `'null'` is a valid mode, and are both defined in the [`runmode-standalone.js`](https://github.com/codemirror/CodeMirror/blob/840464b337695d3c4fd2807bdd69e462e2f7d118/addon/runmode/runmode-standalone.js#L104)and [`core`](https://github.com/codemirror/CodeMirror/blob/a5497d1c13f5742b6df963319e9abf30d510387a/src/edit/main.js#L48)
- With how [`CodeMirror.getMode` is defined in core](https://github.com/codemirror/CodeMirror/blob/840464b337695d3c4fd2807bdd69e462e2f7d118/src/modes.js#L40), `''` resolves to `text/plain` anyways since it's not a valid mime or mode.


