### PR TITLE
update runmode-standalone to match core and runmode.node.js

### DIFF
--- a/addon/runmode/runmode-standalone.js
+++ b/addon/runmode/runmode-standalone.js
@@ -105,6 +105,11 @@ CodeMirror.defineMode = function (name, mode) {
 };
 CodeMirror.defineMIME = function (mime, spec) { mimeModes[mime] = spec; };
 
+CodeMirror.defineMode("null", function() {
+  return {token: function(stream) {stream.skipToEnd();}};
+});
+CodeMirror.defineMIME("text/plain", "null");
+
 // Given a MIME type, a {name, ...options} config object, or a name
 // string, return a mode config object.
 CodeMirror.resolveMode = function(spec) {
@@ -155,11 +160,20 @@ CodeMirror.extendMode = function(mode, properties) {
   copyObj(properties, exts);
 };
 
+// Given a mode and a state (for that mode), find the inner mode and
+// state at the position that the state refers to.
+CodeMirror.innerMode = function(mode, state) {
+  let info
+  while (mode.innerMode) {
+    info = mode.innerMode(state)
+    if (!info || info.mode == mode) break
+    state = info.state
+    mode = info.mode
+  }
+  return info || {mode: mode, state: state}
+};
+
 CodeMirror.registerHelper = CodeMirror.registerGlobalHelper = Math.min;
-CodeMirror.defineMode("null", function() {
-  return {token: function(stream) {stream.skipToEnd();}};
-});
-CodeMirror.defineMIME("text/plain", "null");
 
 CodeMirror.runMode = function (string, modespec, callback, options) {
   var mode = CodeMirror.getMode({ indentUnit: 2 }, modespec);

--- a/addon/runmode/runmode-standalone.js
+++ b/addon/runmode/runmode-standalone.js
@@ -7,7 +7,7 @@ root.CodeMirror = {};
 (function() {
 "use strict";
 
-function splitLines(string){ return string.split(/\r?\n|\r/); };
+function splitLines(string){ return string.split(/\r\n?|\n/); };
 
 function StringStream(string, _tabSize, oracle) {
   this.pos = this.start = 0;

--- a/addon/runmode/runmode-standalone.js
+++ b/addon/runmode/runmode-standalone.js
@@ -146,6 +146,15 @@ CodeMirror.getMode = function (options, spec) {
 
   return modeObj
 };
+
+// This can be used to attach properties to mode objects from
+// outside the actual mode definition.
+var modeExtensions = CodeMirror.modeExtensions = {};
+CodeMirror.extendMode = function(mode, properties) {
+  var exts = modeExtensions.hasOwnProperty(mode) ? modeExtensions[mode] : (modeExtensions[mode] = {});
+  copyObj(properties, exts);
+};
+
 CodeMirror.registerHelper = CodeMirror.registerGlobalHelper = Math.min;
 CodeMirror.defineMode("null", function() {
   return {token: function(stream) {stream.skipToEnd();}};

--- a/addon/runmode/runmode-standalone.js
+++ b/addon/runmode/runmode-standalone.js
@@ -160,6 +160,18 @@ CodeMirror.extendMode = function(mode, properties) {
   copyObj(properties, exts);
 };
 
+CodeMirror.copyState = function(mode, state) {
+  if (state === true) return state
+  if (mode.copyState) return mode.copyState(state)
+  let nstate = {}
+  for (let n in state) {
+    let val = state[n]
+    if (val instanceof Array) val = val.concat([])
+    nstate[n] = val
+  }
+  return nstate
+}
+
 // Given a mode and a state (for that mode), find the inner mode and
 // state at the position that the state refers to.
 CodeMirror.innerMode = function(mode, state) {

--- a/addon/runmode/runmode-standalone.js
+++ b/addon/runmode/runmode-standalone.js
@@ -92,10 +92,24 @@ CodeMirror.resolveMode = function(spec) {
   else return spec || {name: "null"};
 };
 CodeMirror.getMode = function (options, spec) {
-  spec = CodeMirror.resolveMode(spec);
-  var mfactory = modes[spec.name];
-  if (!mfactory) throw new Error("Unknown mode: " + spec);
-  return mfactory(options, spec);
+  spec = CodeMirror.resolveMode(spec)
+  let mfactory = modes[spec.name]
+  if (!mfactory) return CodeMirror.getMode(options, "text/plain")
+  let modeObj = mfactory(options, spec)
+  if (modeExtensions.hasOwnProperty(spec.name)) {
+    let exts = modeExtensions[spec.name]
+    for (let prop in exts) {
+      if (!exts.hasOwnProperty(prop)) continue
+      if (modeObj.hasOwnProperty(prop)) modeObj["_" + prop] = modeObj[prop]
+      modeObj[prop] = exts[prop]
+    }
+  }
+  modeObj.name = spec.name
+  if (spec.helperType) modeObj.helperType = spec.helperType
+  if (spec.modeProps) for (let prop in spec.modeProps)
+    modeObj[prop] = spec.modeProps[prop]
+
+  return modeObj
 };
 CodeMirror.registerHelper = CodeMirror.registerGlobalHelper = Math.min;
 CodeMirror.defineMode("null", function() {


### PR DESCRIPTION
This PR does the following:
- updates `splitLines` to match `runmode.node.js`
This just follows changes made to `runmode.node.js` made in https://github.com/codemirror/CodeMirror/commit/0bc820bf5836ff9aac41409934203c87ceabf535
- updates `getMode` to match core and `runmode.node.js`
This just follows changes made to `runmode.node.js` made in https://github.com/codemirror/CodeMirror/commit/0bc820bf5836ff9aac41409934203c87ceabf535.
Function was mainly taken from [`modes.js`](https://github.com/codemirror/CodeMirror/blob/master/src/modes.js).
- updates `resolveMode` to match core
Function was mainly taken from [`modes.js`](https://github.com/codemirror/CodeMirror/blob/master/src/modes.js).

- includes `extendMode` to match core and `runmode.node.js`
This just follows the changes made to `runmode.node.js` made in https://github.com/codemirror/CodeMirror/commit/0bc820bf5836ff9aac41409934203c87ceabf535
Function was mainly taken from [`modes.js`](https://github.com/codemirror/CodeMirror/blob/master/src/modes.js).
- includes `innerMode` to match core
This just follows the changes made to `runmode.node.js` made in https://github.com/codemirror/CodeMirror/commit/deaa842dc6f1711874c1cacc6b984f7264932f83
Function was mainly taken from [`modes.js`](https://github.com/codemirror/CodeMirror/blob/master/src/modes.js). This is needed for [markdown to work](https://github.com/codemirror/CodeMirror/blob/840464b337695d3c4fd2807bdd69e462e2f7d118/mode/markdown/markdown.js#L781) in standalone.
- includes `copyState` to match core
Function was mainly taken from [`modes.js`](https://github.com/codemirror/CodeMirror/blob/master/src/modes.js). This is needed for [markdown to work](https://github.com/codemirror/CodeMirror/blob/840464b337695d3c4fd2807bdd69e462e2f7d118/mode/markdown/markdown.js#L781) in standalone. 

- updates `StringStream` to match core
This just follows the changes made to `runmode.node.js` made in https://github.com/codemirror/CodeMirror/commit/0bc820bf5836ff9aac41409934203c87ceabf535, later changes made to [`util/StringStream`](https://github.com/codemirror/CodeMirror/blob/master/src/util/StringStream.js), and the previous [commit to `runmode-standalone`](https://github.com/codemirror/CodeMirror/commit/91cb2943208f7fa34ba125ea2ef30582ea601f32).