### PR TITLE
update runmode-node to match core

### DIFF
--- a/addon/runmode/runmode.node.js
+++ b/addon/runmode/runmode.node.js
@@ -164,6 +164,18 @@ exports.getMode = function(options, spec) {
   return modeObj;
 };
 
+exports.copyState = function(mode, state) {
+  if (state === true) return state
+  if (mode.copyState) return mode.copyState(state)
+  let nstate = {}
+  for (let n in state) {
+    let val = state[n]
+    if (val instanceof Array) val = val.concat([])
+    nstate[n] = val
+  }
+  return nstate
+}
+
 exports.innerMode = function(mode, state) {
   var info;
   while (mode.innerMode) {

--- a/addon/runmode/runmode.node.js
+++ b/addon/runmode/runmode.node.js
@@ -219,11 +219,12 @@ exports.registerHelper = exports.registerGlobalHelper = Math.min;
 
 exports.runMode = function(string, modespec, callback, options) {
   var mode = exports.getMode({indentUnit: 2}, modespec);
+  var tabSize = (options && options.tabSize) || 4;
   var lines = splitLines(string), state = (options && options.state) || exports.startState(mode);
-  var context = {lines: lines, line: 0}
-  for (var i = 0, e = lines.length; i < e; ++i, ++context.line) {
+  var oracle = {lookAhead: function(n) { return lines[i + n] }, baseToken: function() {}}
+  for (var i = 0, e = lines.length; i < e; ++i) {
     if (i) callback("\n");
-    var stream = new exports.StringStream(lines[i], 4, context);
+    var stream = new exports.StringStream(lines[i], tabSize, oracle);
     if (!stream.string && mode.blankLine) mode.blankLine(state);
     while (!stream.eol()) {
       var style = mode.token(stream, state);

--- a/addon/runmode/runmode.node.js
+++ b/addon/runmode/runmode.node.js
@@ -44,13 +44,13 @@ var countColumn = exports.countColumn = function(string, end, tabSize, startInde
   }
 };
 
-function StringStream(string, tabSize, context) {
+function StringStream(string, tabSize, lineOracle) {
   this.pos = this.start = 0;
   this.string = string;
   this.tabSize = tabSize || 8;
   this.lastColumnPos = this.lastColumnValue = 0;
   this.lineStart = 0;
-  this.context = context
+  this.lineOracle = lineOracle
 };
 
 StringStream.prototype = {
@@ -62,20 +62,21 @@ StringStream.prototype = {
       return this.string.charAt(this.pos++);
   },
   eat: function(match) {
-    var ch = this.string.charAt(this.pos);
-    if (typeof match == "string") var ok = ch == match;
-    else var ok = ch && (match.test ? match.test(ch) : match(ch));
-    if (ok) {++this.pos; return ch;}
+    let ch = this.string.charAt(this.pos)
+    let ok
+    if (typeof match == "string") ok = ch == match
+    else ok = ch && (match.test ? match.test(ch) : match(ch))
+    if (ok) {++this.pos; return ch}
   },
   eatWhile: function(match) {
-    var start = this.pos;
+    let start = this.pos
     while (this.eat(match)){}
-    return this.pos > start;
+    return this.pos > start
   },
   eatSpace: function() {
-    var start = this.pos;
-    while (/[\s\u00a0]/.test(this.string.charAt(this.pos))) ++this.pos;
-    return this.pos > start;
+    let start = this.pos
+    while (/[\s\u00a0]/.test(this.string.charAt(this.pos))) ++this.pos
+    return this.pos > start
   },
   skipToEnd: function() {this.pos = this.string.length;},
   skipTo: function(ch) {
@@ -116,8 +117,12 @@ StringStream.prototype = {
     finally { this.lineStart -= n; }
   },
   lookAhead: function(n) {
-    var line = this.context.line + n
-    return line >= this.context.lines.length ? null : this.context.lines[line]
+    let oracle = this.lineOracle
+    return oracle && oracle.lookAhead(n)
+  },
+  baseToken: function() {
+    let oracle = this.lineOracle
+    return oracle && oracle.baseToken(this.pos)
   }
 };
 exports.StringStream = StringStream;


### PR DESCRIPTION
This PR does the following:
- updates StringStream to [`src/util/StringStream.js`](https://github.com/codemirror/CodeMirror/blob/master/src/util/StringStream.js)
- updates runMode to use the oracle interface in updated StringStream
- updates resolveMode to same method defined in [`src/modes.js`](https://github.com/codemirror/CodeMirror/blob/master/src/modes.js)
- includes `copyState` from `src/modes.js` to allow for some languages like Markdown or HTMLMixed to work with runmode.node.js 