### PR TITLE
Updated Puppeteer version to latest in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "blint": "^1.1.0",
     "node-static": "0.7.11",
-    "puppeteer": "^1.20.0",
+    "puppeteer": "^4.0.0",
     "rollup": "^1.26.3",
     "rollup-plugin-buble": "^0.19.8"
   },


### PR DESCRIPTION
Updated Puppeteer version to latest in package.json as the latest puppeteer version has support for aarch64 platform.