### PR TITLE
Add support for index in for loops and fix issue with variable scope issue

### DIFF
--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -138,6 +138,11 @@
      '[keyword {/foreach}]',
      '');
 
+   MT('foreach-index',
+      '[keyword {foreach] [def $foo],[def $index] [keyword in] [[]] [keyword }]',
+      '  [keyword {][variable-2 $foo][keyword }] [keyword {][variable-2 $index][keyword }]',
+      '[keyword {/foreach}]');
+
   MT('nested-kind-test',
      '[keyword {template] [def .foo] [attribute kind]=[string "html"][keyword }]',
      '  [tag&bracket <][tag div][tag&bracket >]',
@@ -259,6 +264,20 @@
      '[keyword {let] [def $myList]: [[[[[string \'a\'] ] ] [keyword /}] ' +
      '[keyword {let] [def $test]: [[[variable $a] [operator +] [atom 1] [keyword for] ' +
          '[def $a] [keyword in] [variable-2 $myList] [keyword if] [variable-2 $a] [operator >=] [atom 3] ] [keyword /}]');
+
+  MT('list-comprehension-index',
+     '[keyword {let] [def $test]: [[[variable $a] [operator +] [variable $index] [keyword for] ' +
+         '[def $a],[def $index] [keyword in] [[]] [keyword if] [variable-2 $a] [operator >=] [variable-2 $index] ] [keyword /}]');
+
+
+  MT('list-comprehension-variable-scope',
+     '[keyword {let] [def $name]: [string "world"][keyword /}]',
+     '[keyword {let] [def $test]: [[[variable $a] [operator +] [variable $index] [keyword for] ' +
+         '[def $a],[def $index] [keyword in] [[]] [keyword if] [variable-2 $a] [operator >=] [variable-2 $index] ] [keyword /}]',
+     '[keyword {][variable-2&error $a][keyword }]',
+     '[keyword {][variable-2&error $index][keyword }]',
+     '[keyword {][variable-2 $test][keyword }]',
+     '[keyword {][variable-2 $name][keyword }]');
 
   MT('import',
    '[keyword import] {[def Name], [variable Person] [keyword as] [def P]} [keyword from] [string \'examples/proto/example.proto\'];');


### PR DESCRIPTION
Add support for index in for loops.

```
{template .bar}
   {let $foo: [$a + $i for $a, $i in [1,2,3]] /}
   {for $a, $i in [1,2,3]}
     // ...
   {/for}
{/template}
```

Fixed variable scope issue with list comprehensions. Variables defined inside a list comprehension could be accessed outside the list.
