### PR TITLE
Support tag text objects in xml / htmlmixed mode.

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -156,6 +156,7 @@
     <script src="../addon/mode/multiplex_test.js"></script>
     <script src="../addon/fold/foldcode.js"></script>
     <script src="../addon/fold/brace-fold.js"></script>
+    <script src="../addon/fold/xml-fold.js"></script>
 
     <script src="emacs_test.js"></script>
     <script src="sql-hint-test.js"></script>

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1317,9 +1317,13 @@ testVim('=', function(cm, vim, helpers) {
   eq(expectedValue, cm.getValue());
 }, { value: '   word1\n  word2\n  word3', indentUnit: 2 });
 
-// Edit tests
-function testEdit(name, before, pos, edit, after) {
+// Edit tests - configureCm is an optional argument that gives caller
+// access to the cm object.
+function testEdit(name, before, pos, edit, after, configureCm) {
   return testVim(name, function(cm, vim, helpers) {
+             if (configureCm) {
+               configureCm(cm);
+             }
              var ch = before.search(pos)
              var line = before.substring(0, ch).split('\n').length - 1;
              if (line) {
@@ -1423,6 +1427,28 @@ testEdit('di<_middle_spc', 'a\t<\n\tbar\n>b', /r/, 'di<', 'a\t<>b');
 testEdit('di>_middle_spc', 'a\t<\n\tbar\n>b', /r/, 'di>', 'a\t<>b');
 testEdit('da<_middle_spc', 'a\t<\n\tbar\n>b', /r/, 'da<', 'a\tb');
 testEdit('da>_middle_spc', 'a\t<\n\tbar\n>b', /r/, 'da>', 'a\tb');
+
+// deleting tag objects
+testEdit('dat_noop', '<outer><inner>hello</inner></outer>', /n/, 'dat', '<outer><inner>hello</inner></outer>');
+testEdit('dat_open_tag', '<outer><inner>hello</inner></outer>', /n/, 'dat', '<outer></outer>', function(cm) {
+  cm.setOption('mode', 'xml');
+});
+testEdit('dat_inside_tag', '<outer><inner>hello</inner></outer>', /l/, 'dat', '<outer></outer>', function(cm) {
+  cm.setOption('mode', 'xml');
+});
+testEdit('dat_close_tag', '<outer><inner>hello</inner></outer>', /\//, 'dat', '<outer></outer>', function(cm) {
+  cm.setOption('mode', 'xml');
+});
+
+testEdit('dit_open_tag', '<outer><inner>hello</inner></outer>', /n/, 'dit', '<outer><inner></inner></outer>', function(cm) {
+  cm.setOption('mode', 'xml');
+});
+testEdit('dit_inside_tag', '<outer><inner>hello</inner></outer>', /l/, 'dit', '<outer><inner></inner></outer>', function(cm) {
+  cm.setOption('mode', 'xml');
+});
+testEdit('dit_close_tag', '<outer><inner>hello</inner></outer>', /\//, 'dit', '<outer><inner></inner></outer>', function(cm) {
+  cm.setOption('mode', 'xml');
+});
 
 function testSelection(name, before, pos, keys, sel) {
   return testVim(name, function(cm, vim, helpers) {


### PR DESCRIPTION
User can use `t` to operate on tag text objects. For example, given the
following html:

```
<div>
  <span>hello world!</span>
</div>
```

If the user's cursor (denoted by █) is inside "hello world!":

```
<div>
  <span>hello█world!</span>
</div>
```

And they enter `dit` (delete inner tag), then the text inside the
enclosing tag is deleted -- the following is the expected result:

```
<div>
  <span></span>
</div>
```

If they enter `dat` (delete around tag), then the surrounding tags are
deleted as well:

```
<div>
</div>
```

This logic depends on the following:

- mode/xml/xml.js
- addon/fold/xml-fold.js
- editor is in htmlmixedmode / xml mode

Caveats

This is _NOT_ a 100% accurate implementation of vim tag text objects.
For example, the following cases noop / are inconsistent with vim
behavior:

- Does not work inside comments:
  ```
  <!-- <div>broken</div> -->
  ```
- Does not work when tags have different cases:
  ```
  <div>broken</DIV>
  ```
- Does not work when inside a broken tag:
  ```
  <div><brok><en></div>
  ```

This addresses #3828.