### PR TITLE
[xml-hint addon] Allow attribute values function to return a Promise

### DIFF
--- a/addon/hint/xml-hint.js
+++ b/addon/hint/xml-hint.js
@@ -101,8 +101,14 @@
           }
           replaceToken = true;
         }
-        for (var i = 0; i < atValues.length; ++i) if (!prefix || matches(atValues[i], prefix, matchInMiddle))
-          result.push(quote + atValues[i] + quote);
+        function returnHintsFromAtValues(atValues) {
+          if (atValues)
+            for (var i = 0; i < atValues.length; ++i) if (!prefix || matches(atValues[i], prefix, matchInMiddle))
+              result.push(quote + atValues[i] + quote);
+          return returnHints();
+        }
+        if (atValues && atValues.then) return atValues.then(returnHintsFromAtValues);
+        return returnHintsFromAtValues(atValues);
       } else { // An attribute name
         if (token.type == "attribute") {
           prefix = token.string;
@@ -112,11 +118,14 @@
           result.push(attr);
       }
     }
-    return {
-      list: result,
-      from: replaceToken ? Pos(cur.line, tagStart == null ? token.start : tagStart) : cur,
-      to: replaceToken ? Pos(cur.line, token.end) : cur
-    };
+    function returnHints() {
+      return {
+        list: result,
+        from: replaceToken ? Pos(cur.line, tagStart == null ? token.start : tagStart) : cur,
+        to: replaceToken ? Pos(cur.line, token.end) : cur
+      };
+    }
+    return returnHints();
   }
 
   CodeMirror.registerHelper("hint", "xml", getHints);


### PR DESCRIPTION
The diff before commit looked even smaller when ignoring whitespace with `git diff --ignore-all-space`.

This change optionally extends a chain of promises from a developer's attribute values function through `xml-hint.js` to `show-hint.js` function `fetchHints`, where it already is supported since at least commit 87d10fa in 2016.

Keeps working with arrays returned (without promises) just as it used to.

If promise fulfilling function throws and consequentially promise value is undefined then returns empty list.

First use case was a need for an online lookup of values, depending on context, on another attribute value, that could not be done ahead of time and should be done asynchronously.