### PR TITLE
Annotate scrollbar when matches are folded

### DIFF
--- a/addon/scroll/annotatescrollbar.js
+++ b/addon/scroll/annotatescrollbar.js
@@ -72,10 +72,20 @@
     var wrapping = cm.getOption("lineWrapping");
     var singleLineH = wrapping && cm.defaultTextHeight() * 1.5;
     var curLine = null, curLineObj = null;
+
+    function getFoldLineHandle(pos) {
+      var marks = cm.findMarksAt(pos);
+      for (var i = 0; i < marks.length; ++i) {
+        if (marks[i].collapsed)
+          return marks[i].lines[0];
+      }
+    }
+
     function getY(pos, top) {
       if (curLine != pos.line) {
         curLine = pos.line;
-        curLineObj = cm.getLineHandle(curLine);
+        if(!(curLineObj = getFoldLineHandle(pos)))
+          curLineObj = cm.getLineHandle(curLine);
       }
       if ((curLineObj.widgets && curLineObj.widgets.length) ||
           (wrapping && curLineObj.height > singleLineH))

--- a/test/annotatescrollbar.js
+++ b/test/annotatescrollbar.js
@@ -1,0 +1,55 @@
+namespace = "annotatescrollbar_";
+
+(function () {
+  function test(name, run, content, query, expected) {
+    return testCM(name, function (cm) {
+      var annotation = cm.annotateScrollbar({
+        listenForChanges: false,
+        className: "CodeMirror-search-match"
+      });
+      var matches = [];
+      var cursor = cm.getSearchCursor(query, CodeMirror.Pos(0, 0));
+      while (cursor.findNext()) {
+        var match = {
+          from: cursor.from(),
+          to: cursor.to()
+        };
+        matches.push(match)
+      }
+
+      if (run) run(cm);
+
+      cm.display.barWidth = 5;
+      annotation.update(matches);
+
+      var annotations = cm.getWrapperElement().getElementsByClassName(annotation.options.className);
+      eq(annotations.length, expected, "Expected " + expected + " annotations on the scrollbar.")
+    }, {
+      value: content,
+      mode: "javascript",
+      foldOptions: {
+        rangeFinder: CodeMirror.fold.brace
+      }
+    });
+  }
+
+  function doFold(cm) {
+    cm.foldCode(cm.getCursor());
+  }
+  var simpleProg = "function foo() {\n\n  return \"foo\";\n\n}\n\nfoo();\n";
+  var consecutiveLineMatches = "function foo() {\n  return \"foo\";\n}\nfoo();\n";
+  var singleLineMatches = "function foo() { return \"foo\"; }foo();\n";
+
+  // Base case - expect 3 matches and 3 annotations
+  test("simple", null, simpleProg, "foo", 3);
+  // Consecutive line matches are combines into a single annotation - expect 3 matches and 2 annotations
+  test("combineConsecutiveLine", null, consecutiveLineMatches, "foo", 2);
+  // Matches on a single line get a single annotation - expect 3 matches and 1 annotation
+  test("combineSingleLine", null, singleLineMatches, "foo", 1);
+  // Matches within a fold are annotated on the folded line - expect 3 matches and 2 annotations
+  test("simpleFold", doFold, simpleProg, "foo", 2);
+  // Combination of combineConsecutiveLine and simpleFold cases - expect 3 matches and 1 annotation
+  test("foldedMatch", doFold, consecutiveLineMatches, "foo", 1);
+  // Hidden matches within a fold are annotated on the folded line - expect 1 match and 1 annotation
+  test("hiddenMatch", doFold, simpleProg, "return", 1);
+})();

--- a/test/index.html
+++ b/test/index.html
@@ -157,12 +157,14 @@
     <script src="../addon/fold/foldcode.js"></script>
     <script src="../addon/fold/brace-fold.js"></script>
     <script src="../addon/fold/xml-fold.js"></script>
+    <script src="../addon/scroll/annotatescrollbar.js"></script>
 
     <script src="emacs_test.js"></script>
     <script src="sql-hint-test.js"></script>
     <script src="sublime_test.js"></script>
     <script src="vim_test.js"></script>
     <script src="html-hint-test.js"></script>
+    <script src="annotatescrollbar.js"></script>
     <script>
       window.onload = runHarness;
       CodeMirror.on(window, 'hashchange', runHarness);


### PR DESCRIPTION
PR for issue #6385 

The changes to annotatescrollbar.js will check to see if the current match is collapsed ("folded"). And if so, then use the first line of the markText.lines as the current line for the annotation. This addresses the 2 issues:

- If there is a match on the folded line and there are also matches within the folded content then when the fold is collapsed, we expect at least the match on the folded line to be annotated on scrollbar. But it's not.
- Matches hidden within a collapsed fold are not annotated on the scrollbar.

**Disclaimer:**
I'm not familiar enough with the wide scope of this project so I cannot guarantee that this will not have unintended side effects. That being said, I did my best to ensure that all lint/test cases are passing.
