### PR TITLE
fix focus/blur issues during editing

### DIFF
--- a/src/display/focus.js
+++ b/src/display/focus.js
@@ -15,7 +15,22 @@ export function delayBlurEvent(cm) {
   } }, 100)
 }
 
+export function suppressFocusBlur(cm) {
+  if (!cm.state.focused) { return } // do not suppress first focus
+  cm.state.suppressFocusBlur = true
+}
+
+export function enableFocusBlur(cm) {
+  // IE fires some more events, so enable it delayed
+  if (cm.state.suppressFocusBlur) {
+    setTimeout(function() {
+      cm.state.suppressFocusBlur = false
+    },20)
+  }
+}
+
 export function onFocus(cm, e) {
+  if (cm.state.suppressFocusBlur) { return }
   if (cm.state.delayingBlurEvent) cm.state.delayingBlurEvent = false
 
   if (cm.options.readOnly == "nocursor") return
@@ -35,7 +50,7 @@ export function onFocus(cm, e) {
   restartBlink(cm)
 }
 export function onBlur(cm, e) {
-  if (cm.state.delayingBlurEvent) return
+  if (cm.state.delayingBlurEvent || cm.state.suppressFocusBlur) { return }
 
   if (cm.state.focused) {
     signal(cm, "blur", cm, e)

--- a/src/display/focus.js
+++ b/src/display/focus.js
@@ -5,6 +5,17 @@ import { signal } from "../util/event.js"
 
 export function ensureFocus(cm) {
   if (!cm.state.focused) { cm.display.input.focus(); onFocus(cm) }
+  else {
+    // if we are already focused, skip any blur/focus events and do
+    // a refocus after timeout. This is a fix for #6427, because
+    // IE fires blur/focus events if you reposition the cursor by
+    // a mouse click.
+    cm.state.delayingBlurEvent = true
+    setTimeout(function () { if (cm.state.delayingBlurEvent) {
+      cm.display.input.focus()
+      cm.state.delayingBlurEvent = false
+    } }, 100)
+  }
 }
 
 export function delayBlurEvent(cm) {

--- a/src/display/focus.js
+++ b/src/display/focus.js
@@ -15,22 +15,7 @@ export function delayBlurEvent(cm) {
   } }, 100)
 }
 
-export function suppressFocusBlur(cm) {
-  if (!cm.state.focused) { return } // do not suppress first focus
-  cm.state.suppressFocusBlur = true
-}
-
-export function enableFocusBlur(cm) {
-  // IE fires some more events, so enable it delayed
-  if (cm.state.suppressFocusBlur) {
-    setTimeout(function() {
-      cm.state.suppressFocusBlur = false
-    },20)
-  }
-}
-
 export function onFocus(cm, e) {
-  if (cm.state.suppressFocusBlur) { return }
   if (cm.state.delayingBlurEvent) cm.state.delayingBlurEvent = false
 
   if (cm.options.readOnly == "nocursor") return
@@ -50,7 +35,7 @@ export function onFocus(cm, e) {
   restartBlink(cm)
 }
 export function onBlur(cm, e) {
-  if (cm.state.delayingBlurEvent || cm.state.suppressFocusBlur) { return }
+  if (cm.state.delayingBlurEvent) return
 
   if (cm.state.focused) {
     signal(cm, "blur", cm, e)

--- a/src/edit/CodeMirror.js
+++ b/src/edit/CodeMirror.js
@@ -1,5 +1,5 @@
 import { Display } from "../display/Display.js"
-import { onFocus, onBlur, suppressFocusBlur, enableFocusBlur } from "../display/focus.js"
+import { onFocus, onBlur } from "../display/focus.js"
 import { maybeUpdateLineNumberWidth } from "../display/line_numbers.js"
 import { endOperation, operation, startOperation } from "../display/operations.js"
 import { initScrollbars } from "../display/scrollbars.js"
@@ -52,7 +52,6 @@ export function CodeMirror(place, options) {
     modeGen: 0,   // bumped when mode/overlay changes, used to invalidate highlighting info
     overwrite: false,
     delayingBlurEvent: false,
-    suppressFocusBlur: false, // used to supress signal focus/blur events on drag/drop operations.
     focused: false,
     suppressEdits: false, // used to disable editing during key handlers when in readOnly mode
     pasteIncoming: -1, cutIncoming: -1, // help recognize paste/cut edits in input.poll
@@ -107,13 +106,6 @@ export default CodeMirror
 function registerEventHandlers(cm) {
   let d = cm.display
   on(d.scroller, "mousedown", operation(cm, onMouseDown))
-  // disable event firing when user holds the mouse button or
-  // performs a dnd-operation.
-  on(d.scroller, "mousedown", function() { suppressFocusBlur(cm) })
-  on(d.scroller, "dragstart", function() { suppressFocusBlur(cm) })
-  on(d.scroller, "mouseup",   function() { enableFocusBlur(cm) })
-  on(d.scroller, "dragend",   function() { enableFocusBlur(cm) })
-
   // Older IE's will not fire a second mousedown for a double click
   if (ie && ie_version < 11)
     on(d.scroller, "dblclick", operation(cm, e => {

--- a/src/edit/mouse_events.js
+++ b/src/edit/mouse_events.js
@@ -12,7 +12,7 @@ import { getOrder, getBidiPartAt } from "../util/bidi.js"
 import { activeElt } from "../util/dom.js"
 import { e_button, e_defaultPrevented, e_preventDefault, e_target, hasHandler, off, on, signal, signalDOMEvent } from "../util/event.js"
 import { dragAndDrop } from "../util/feature_detection.js"
-import { bind, countColumn, findColumn, sel_mouse } from "../util/misc.js"
+import { countColumn, findColumn, sel_mouse } from "../util/misc.js"
 import { addModifierNames } from "../input/keymap.js"
 import { Pass } from "../util/misc.js"
 
@@ -127,7 +127,7 @@ function configureMouse(cm, repeat, event) {
 }
 
 function leftButtonDown(cm, pos, repeat, event) {
-  if (ie) setTimeout(bind(ensureFocus, cm), 0)
+  if (ie) ensureFocus(cm)
   else cm.curOp.focus = activeElt()
 
   let behavior = configureMouse(cm, repeat, event)


### PR DESCRIPTION
We use the CM field in our app and do a page update if the user leaves the CM field. (onBlur)
Unfortunately, blur events are fired during editing, follwed by an immediate "focus" event.
Especially IE (Version 11) fires a lot of "blur/(re)focus" events during editing.

We had a workaround in our code, that detects quick "blur/focus" events, but this workaround had other issues.
This PR fixes firing unneccessary (and unwanted) focus/blur events.

*Current Behaviour:*
When clicking around inside the CM field, unexpected blur events occur, followed by an immediate focus event

*Expected Behaviour:*
The first time you click in the CM field, a focus event should be fired
All subsequent clicks/text selections/d'n'd operations should not fire a "blur/focus" event.
If you click outside the CM field, a blur event should be fired

The idea behind this fix is, not to fire blur/focus as long as the user holds the mouse button down or is doing d'n'd operations

