### PR TITLE
Fixes #6331. Backticks are stripped from SQL query words before comparison

### DIFF
--- a/addon/hint/sql-hint.js
+++ b/addon/hint/sql-hint.js
@@ -187,7 +187,7 @@
   function eachWord(lineText, f) {
     var words = lineText.split(/\s+/)
     for (var i = 0; i < words.length; i++)
-      if (words[i]) f(words[i].replace(/[,;]/g, ''))
+      if (words[i]) f(words[i].replace(/[`,;]/g, ''))
   }
 
   function findTableByAlias(alias, editor) {


### PR DESCRIPTION
sqlhint.js: findTableByAlias() was receiving keywords with backticks still in place if used in the query - a helper function eachWord() only stripped commas and semicolons from the keywords, now stripping backticks as well. 