### PR TITLE
Improve parsing of IRI atoms (sparql mode)

### DIFF
--- a/mode/sparql/sparql.js
+++ b/mode/sparql/sparql.js
@@ -71,7 +71,7 @@ CodeMirror.defineMode("sparql", function(config) {
       return "operator";
     }
     else if (ch == ":") {
-      stream.eatWhile(/[\w\d\._\-]/);
+      eatPnLocal(stream);
       return "atom";
     }
     else if (ch == "@") {
@@ -81,7 +81,7 @@ CodeMirror.defineMode("sparql", function(config) {
     else {
       stream.eatWhile(/[_\w\d]/);
       if (stream.eat(":")) {
-        stream.eatWhile(/[\w\d_\-]/);
+        eatPnLocal(stream);
         return "atom";
       }
       var word = stream.current();
@@ -92,6 +92,10 @@ CodeMirror.defineMode("sparql", function(config) {
       else
         return "variable";
     }
+  }
+  
+  function eatPnLocal(stream) {
+    while (stream.match(/([:\w\d._-]|\\[-\\_~.!$&'()*+,;=/?#@%]|%[a-fA-F0-9][a-fA-F0-9])/));
   }
 
   function tokenLiteral(quote) {

--- a/mode/sparql/sparql.js
+++ b/mode/sparql/sparql.js
@@ -60,6 +60,12 @@ CodeMirror.defineMode("sparql", function(config) {
       stream.skipToEnd();
       return "comment";
     }
+    else if (ch === "^") {
+      ch = stream.next();
+      if (ch === "^") stream.eat("^");
+      else stream.eatWhile(operatorChars);
+      return "operator";
+    }
     else if (operatorChars.test(ch)) {
       stream.eatWhile(operatorChars);
       return "operator";

--- a/mode/sparql/sparql.js
+++ b/mode/sparql/sparql.js
@@ -93,7 +93,7 @@ CodeMirror.defineMode("sparql", function(config) {
         return "variable";
     }
   }
-  
+
   function eatPnLocal(stream) {
     while (stream.match(/([:\w\d._-]|\\[-\\_~.!$&'()*+,;=/?#@%]|%[a-fA-F0-9][a-fA-F0-9])/));
   }


### PR DESCRIPTION
Do not treat the opening "<" character of an unprefixed Datatype IRI as an operator along with the preceding "^^" characters. Respect the SPARQL 1.1 percent-encoding and backslash-escaping within the suffix of a prefixed IRI (and add colons to the set of allowable IRI characters).  

To address a single issue of everything after the last "#" within an IRI (a common character in IRIs) being highlighted as if it were a comment in some common prefixed and unprefixed cases. 