### PR TITLE
Add WebAssembly (wast) to meta.js

### DIFF
--- a/mode/meta.js
+++ b/mode/meta.js
@@ -169,7 +169,8 @@
     {name: "Z80", mime: "text/x-z80", mode: "z80", ext: ["z80"]},
     {name: "mscgen", mime: "text/x-mscgen", mode: "mscgen", ext: ["mscgen", "mscin", "msc"]},
     {name: "xu", mime: "text/x-xu", mode: "mscgen", ext: ["xu"]},
-    {name: "msgenny", mime: "text/x-msgenny", mode: "mscgen", ext: ["msgenny"]}
+    {name: "msgenny", mime: "text/x-msgenny", mode: "mscgen", ext: ["msgenny"]},
+    {name: "WebAssembly", mime: "text/webassembly", mode: "wast", ext: ["wat", "wast"]},
   ];
   // Ensure all modes have a mime property for backwards compatibility
   for (var i = 0; i < CodeMirror.modeInfo.length; i++) {


### PR DESCRIPTION
closes #6450 

### Summary

The WebAssembly `wast` mode already exists, but it is not currently available via `meta.js`. This will apply to the `.wat` and `.wast` extension for now, but it looks like `.wat` and `.wast` [have separate meanings going forward](https://developer.mozilla.org/en-US/docs/WebAssembly/Text_format_to_wasm).