### PR TITLE
[stylus mode] allow block comments

### DIFF
--- a/mode/stylus/stylus.js
+++ b/mode/stylus/stylus.js
@@ -722,6 +722,9 @@
         return indent;
       },
       electricChars: "}",
+      blockCommentStart: "/*",
+      blockCommentEnd: "*/",
+      blockCommentContinue: " * ",
       lineComment: "//",
       fold: "indent"
     };


### PR DESCRIPTION
Stylus language [supports block comments](https://stylus-lang.com/docs/comments.html) so this PR adds the missing props copied from the built-in css.js. Now we can use addons/comment.js and <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>/</kbd> hotkey to make block comments!