### PR TITLE
Add support for Soy Element Composition.

### DIFF
--- a/mode/htmlmixed/htmlmixed.js
+++ b/mode/htmlmixed/htmlmixed.js
@@ -74,7 +74,8 @@
       name: "xml",
       htmlMode: true,
       multilineTagIndentFactor: parserConfig.multilineTagIndentFactor,
-      multilineTagIndentPastTag: parserConfig.multilineTagIndentPastTag
+      multilineTagIndentPastTag: parserConfig.multilineTagIndentPastTag,
+      allowMissingTagName: parserConfig.allowMissingTagName,
     });
 
     var tags = {};

--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -16,6 +16,8 @@
     "alias": { noEndTag: true },
     "delpackage": { noEndTag: true },
     "namespace": { noEndTag: true, soyState: "namespace-def" },
+    "@attribute": paramData,
+    "@attribute?": paramData,
     "@param": paramData,
     "@param?": paramData,
     "@inject": paramData,
@@ -53,7 +55,7 @@
   CodeMirror.defineMode("soy", function(config) {
     var textMode = CodeMirror.getMode(config, "text/plain");
     var modes = {
-      html: CodeMirror.getMode(config, {name: "text/html", multilineTagIndentFactor: 2, multilineTagIndentPastTag: false}),
+      html: CodeMirror.getMode(config, {name: "text/html", multilineTagIndentFactor: 2, multilineTagIndentPastTag: false, allowMissingTagName: true}),
       attributes: textMode,
       text: textMode,
       uri: textMode,

--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -26,6 +26,10 @@
      '[keyword {] [callee&variable index]([variable-2&error $list])[keyword }]' +
         '[string "][tag&bracket />]');
 
+  MT('soy-element-composition-test',
+     '[tag&bracket <][keyword {][callee&variable foo]()[keyword }]',
+     '[tag&bracket ></>]');
+
   MT('namespace-test',
      '[keyword {namespace] [variable namespace][keyword }]')
 
@@ -173,6 +177,18 @@
   MT('param-type-and-default-value',
      '[keyword {template] [def .foo][keyword }]',
      '  [keyword {@param] [def bar]: [type bool] = [atom true][keyword }]',
+     '[keyword {/template}]',
+     '');
+
+  MT('attribute-type',
+     '[keyword {template] [def .foo][keyword }]',
+     '  [keyword {@attribute] [def bar]: [type string][keyword }]',
+     '[keyword {/template}]',
+     '');
+
+  MT('attribute-type-optional',
+     '[keyword {template] [def .foo][keyword }]',
+     '  [keyword {@attribute] [def bar]: [type string][keyword }]',
      '[keyword {/template}]',
      '');
 

--- a/mode/xml/xml.js
+++ b/mode/xml/xml.js
@@ -189,7 +189,7 @@ CodeMirror.defineMode("xml", function(editorConf, config_) {
 
   function Context(state, tagName, startOfLine) {
     this.prev = state.context;
-    this.tagName = tagName;
+    this.tagName = tagName || "";
     this.indent = state.indented;
     this.startOfLine = startOfLine;
     if (config.doNotIndent.hasOwnProperty(tagName) || (state.context && state.context.noIndent))
@@ -399,7 +399,7 @@ CodeMirror.defineMode("xml", function(editorConf, config_) {
     xmlCurrentContext: function(state) {
       var context = []
       for (var cx = state.context; cx; cx = cx.prev)
-        if (cx.tagName) context.push(cx.tagName)
+        context.push(cx.tagName)
       return context.reverse()
     }
   };


### PR DESCRIPTION
Add support for Soy Element Composition. It has the syntax in the form of

<{foo()}></>

This adds support to pass through allowEmptyTag and to support this mode in closetag.

<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
