### PR TITLE
Adding options customizing a behavior of `show-hint` addon

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -106,6 +106,11 @@
         this.debounce = 0;
       }
 
+      var identStart = this.startPos;
+      if(this.data) {
+        identStart = this.data.from;
+      }
+
       var pos = this.cm.getCursor(), line = this.cm.getLine(pos.line);
       if (this.options.closeOnCursorActivity &&
           (pos.line != this.startPos.line || line.length - pos.ch != this.startLen - this.startPos.ch ||
@@ -384,6 +389,17 @@
       node.className += " " + ACTIVE_HINT_ELEMENT_CLASS;
       this.scrollToActive()
       CodeMirror.signal(this.data, "select", this.data.list[this.selectedHint], node);
+    },
+
+    scrollToActive: function() {
+      var margin = this.completion.options.scrollMargin || 0;
+      var node1 = this.hints.childNodes[Math.max(0, this.selectedHint - margin)];
+      var node2 = this.hints.childNodes[Math.min(this.data.list.length - 1, this.selectedHint + margin)];
+      var firstNode = this.hints.firstChild;
+      if (node1.offsetTop < this.hints.scrollTop)
+        this.hints.scrollTop = node1.offsetTop - firstNode.offsetTop;
+      else if (node2.offsetTop + node2.offsetHeight > this.hints.scrollTop + this.hints.clientHeight)
+        this.hints.scrollTop = node2.offsetTop + node2.offsetHeight - this.hints.clientHeight + firstNode.offsetTop;
     },
 
     screenAmount: function() {

--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -112,12 +112,12 @@
       }
 
       var pos = this.cm.getCursor(), line = this.cm.getLine(pos.line);
-      if (this.options.closeOnCursorActivity &&
-          (pos.line != this.startPos.line || line.length - pos.ch != this.startLen - this.startPos.ch ||
-           pos.ch < identStart.ch || this.cm.somethingSelected() ||
-           (!pos.ch || this.options.closeCharacters.test(line.charAt(pos.ch - 1))))
-      ) {
-        this.close();
+      if (pos.line != this.startPos.line || line.length - pos.ch != this.startLen - this.startPos.ch ||
+        pos.ch < identStart.ch || this.cm.somethingSelected() ||
+        (!pos.ch || this.options.closeCharacters.test(line.charAt(pos.ch - 1)))) {
+        if (this.options.closeOnCursorActivity) {
+          this.close();
+        }
       } else {
         var self = this;
         this.debounce = requestAnimationFrame(function() {self.update();});

--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -1,6 +1,8 @@
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
 
+// declare global: DOMRect
+
 (function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
     mod(require("../../lib/codemirror"));

--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -113,8 +113,8 @@
 
       var pos = this.cm.getCursor(), line = this.cm.getLine(pos.line);
       if (pos.line != this.startPos.line || line.length - pos.ch != this.startLen - this.startPos.ch ||
-        pos.ch < identStart.ch || this.cm.somethingSelected() ||
-        (!pos.ch || this.options.closeCharacters.test(line.charAt(pos.ch - 1)))) {
+          pos.ch < identStart.ch || this.cm.somethingSelected() ||
+          (!pos.ch || this.options.closeCharacters.test(line.charAt(pos.ch - 1)))) {
         if (this.options.closeOnCursorActivity) {
           this.close();
         }


### PR DESCRIPTION
When working with the `show-hint` addon (very valuable in general, thanks!), I've come across situations when I had to customize its behavior.

I didn't want to highly customize the internal logic so I was able to simply add options modifying some of the taken actions.

However, I've made also two improvements not being behind the options:
- computing `startScroll` in `setTimeout` so it doesn't cause the forced reflow on init
- added a condition over the `this.scrollToActive()` call as it doesn't need to be scrolled to the first hint on init (especially that `selectedHint` is `0` by default) and it causes the reflow as well

I'd divide the options into two groups: functional and styling ones (having a performance impact).

Functional:
- `closeOnCursorActivity` - disable closing the suggestions list on the cursor activity. The suggestions `ul` element has been "blinking" on every cursor movement what wasn't desired
- `closeOnPick` - disable closing the suggestions list on picking the item. In my use case, a user picks the suggestion, and the new suggestions list loads immediately based on the previously chosen one so, again, list blinking wasn't desired

Styling:
- `paddingForScrollbar` - disable adding an additional padding for the scrollbar. Computing that has been causing a very noticeable (at least in our case) force reflows by using things like `clientHeight` or `getBoundingClientRect()`. I'd prefer to disable this in order to gain performance
- `moveOnOverlap` - disable moving the list on overlapping the screen (horizontal or vertical). It computes `hints.getBoundingClientRect()` what was also heavy performance-wise in our case. We don't need this functionality so I'd prefer to disable it

All of the options above are enabled by default so they don't affect existing users of the addon in any way.

In my particular scenario, I was able to decrease the time spent in the `show-hint` addon from (on average) `> 100ms` to max `11ms`.

If you'd find these changes valuable, I'd be happy to merge them.

_Question_: these options need to be described in https://codemirror.net/doc/manual.html#addon_show-hint or it's not strictly required?

Thank you.

