### PR TITLE
Fix white CodeMirror-scrollbar-filler on dark themes

### DIFF
--- a/lib/codemirror.css
+++ b/lib/codemirror.css
@@ -19,7 +19,7 @@
 }
 
 .CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
-  background-color: white; /* The little square between H and V scrollbars */
+  background-color: transparent; /* The little square between H and V scrollbars */
 }
 
 /* GUTTER */


### PR DESCRIPTION
background-color: white; remains white on dark themes which doesn't suit dark background pages. Changing it to transparent to match the theme.