### PR TITLE
Fix shell Heredoc for these cases:

### DIFF
--- a/mode/shell/shell.js
+++ b/mode/shell/shell.js
@@ -71,7 +71,7 @@ CodeMirror.defineMode('shell', function() {
       return 'attribute';
     }
     if (ch == "<") {
-      var heredoc = stream.match(/^<-?\s+(.*)/)
+      var heredoc = stream.match(/^<-?\s*['"]?([^'"]*)['"]?/)
       if (heredoc) {
         state.tokens.unshift(tokenHeredoc(heredoc[1]))
         return 'string-2'


### PR DESCRIPTION
(a space is not required and the DELIMITER may be quoted for special meaning)
```
cat <<EOF
EOF

cat <<'EOF'
EOF

cat <<"EOF"
EOF

cat << 'EOF'
EOF

cat << "EOF"
EOF
```
Initial Issue #6468