### PR TITLE
[hardwrap addon] Minor fix for lines starting with spaces in non-forceBreak mode

### DIFF
--- a/addon/wrap/hardwrap.js
+++ b/addon/wrap/hardwrap.js
@@ -35,7 +35,7 @@
     for (; at > 0; --at)
       if (wrapOn.test(text.slice(at - 1, at + 1))) break;
 
-    if (at == 0 && !forceBreak) {
+    if (text.slice(0, at) == " ".repeat(at) && !forceBreak) {
       // didn't find a break point before column, in non-forceBreak mode try to
       // find one after 'column'.
       for (at = column + 1; at < text.length - 1; ++at) {


### PR DESCRIPTION
Fixes wrapping behavior for lines like:
```
   This line withAVeryLongWordThatIsGreaterThanColumn and words after it.
```