### PR TITLE
Add missing languages link

### DIFF
--- a/mode/index.html
+++ b/mode/index.html
@@ -153,6 +153,7 @@ option.</p>
       <li><a href="vhdl/index.html">VHDL</a></li>
       <li><a href="vue/index.html">Vue.js app</a></li>
       <li><a href="webidl/index.html">Web IDL</a></li>
+      <li><a href="wast/index.html">WebAssembly Text Format</a></li>
       <li><a href="xml/index.html">XML/HTML</a></li>
       <li><a href="xquery/index.html">XQuery</a></li>
       <li><a href="yacas/index.html">Yacas</a></li>


### PR DESCRIPTION
Looks like there is only one missing.
bash$ `(cd mode; for f in */; do grep -Fq href=\"$f index.html || echo $f; done)`