### PR TITLE
Update Verilog mode support

### DIFF
--- a/mode/verilog/test.js
+++ b/mode/verilog/test.js
@@ -270,4 +270,99 @@
     ""
   );
 
+  MT("indent_uvm_macros",
+     /**
+      *  `uvm_object_utils_begin(foo)
+      *    `uvm_field_event(foo, UVM_ALL_ON)
+      *  `uvm_object_utils_end
+      */
+     "[def `uvm_object_utils_begin][bracket (][variable foo][bracket )]",
+     "    [def `uvm_field_event][bracket (][variable foo], [variable UVM_ALL_ON][bracket )]",
+     "[def `uvm_object_utils_end]",
+     "[variable foo][bracket ()];",
+     ""
+  );
+
+  MT("indent_uvm_macros2",
+     /**
+      * `uvm_do_with(mem_read,{
+      *    bar_nb == 0;
+      * })
+      */
+     "[def `uvm_do_with][bracket (][variable mem_read],[bracket {]",
+     "    [variable bar_nb] [meta ==] [number 0];",
+     "[bracket })]",
+     "[variable foo][bracket ()];",
+     ""
+  );
+
+  MT("indent_wait_disable_fork",
+     /**
+      * virtual task body();
+      *    repeat (20) begin
+      *       fork
+      *          `uvm_create_on(t,p_seq)
+      *       join_none
+      *    end
+      *    wait fork;
+      *    disable fork;
+      * endtask : body
+
+      */
+     "[keyword virtual] [keyword task] [variable body][bracket ()];",
+     "    [keyword repeat] [bracket (][number 20][bracket )] [keyword begin]",
+     "        [keyword fork]",
+     "            [def `uvm_create_on][bracket (][variable t],[variable p_seq][bracket )]",
+     "        [keyword join_none]",
+     "    [keyword end]",
+     "    [keyword wait] [keyword fork];",
+     "    [keyword disable] [keyword fork];",
+     "[keyword endtask] : [variable body]",
+     ""
+  );
+
+  MT("indent_typedef_class",
+     /**
+      * typedef class asdf;
+      * typedef p p_t[];
+      * typedef enum {
+      *    ASDF
+      * } t;
+      */
+     "[keyword typedef] [keyword class] [variable asdf];",
+     "[keyword typedef] [variable p] [variable p_t][bracket [[]]];",
+     "[keyword typedef] [keyword enum] [bracket {]",
+     "    [variable ASDF]",
+     "[bracket }] [variable t];",
+     ""
+  );
+
+  MT("indent_case_with_macro",
+     /**
+      * // It should be assumed that Macros can have ';' inside, or 'begin'/'end' blocks.
+      * // As such, 'case' statement should indent correctly with macros inside.
+      * case(foo)
+      *    ASDF : this.foo = seqNum;
+      *    ABCD : `update(f)
+      *    EFGH : `update(g)
+      * endcase
+      */
+     "[keyword case][bracket (][variable foo][bracket )]",
+     "    [variable ASDF] : [keyword this].[variable foo] [meta =] [variable seqNum];",
+     "    [variable ABCD] : [def `update][bracket (][variable f][bracket )]",
+     "    [variable EFGH] : [def `update][bracket (][variable g][bracket )]",
+     "[keyword endcase]",
+     ""
+  );
+
+  MT("indent_extern_function",
+     /**
+      * extern virtual function void do(ref packet trans);
+      * extern virtual function void do2(ref packet trans);
+      */
+     "[keyword extern] [keyword virtual] [keyword function] [keyword void] [variable do1][bracket (][keyword ref] [variable packet] [variable trans][bracket )];",
+     "[keyword extern] [keyword virtual] [keyword function] [keyword void] [variable do2][bracket (][keyword ref] [variable packet] [variable trans][bracket )];",
+     ""
+  );
+
 })();

--- a/mode/verilog/test.js
+++ b/mode/verilog/test.js
@@ -152,7 +152,7 @@
       *       8'b0 + 8'b1;
       * end
       */
-     "[keyword always] @[bracket (][keyword posedge] [variable clk][bracket )] [keyword begin]",
+     "[keyword always] [def @][bracket (][keyword posedge] [variable clk][bracket )] [keyword begin]",
      "    [keyword if] [bracket (][variable rst][bracket )]",
      "        [variable data_out] [meta <=] [number 8'b0] [meta +]",
      "                    [number 8'b1];",

--- a/mode/verilog/test.js
+++ b/mode/verilog/test.js
@@ -139,6 +139,32 @@
      ""
   );
 
+  MT("align_assignments",
+     /**
+      * always @(posedge clk) begin
+      *    if (rst)
+      *       data_out <= 8'b0 +
+      *                   8'b1;
+      *    else
+      *       data_out = 8'b0 +
+      *                  8'b1;
+      *    data_out =
+      *       8'b0 + 8'b1;
+      * end
+      */
+     "[keyword always] @[bracket (][keyword posedge] [variable clk][bracket )] [keyword begin]",
+     "    [keyword if] [bracket (][variable rst][bracket )]",
+     "        [variable data_out] [meta <=] [number 8'b0] [meta +]",
+     "                    [number 8'b1];",
+     "    [keyword else]",
+     "        [variable data_out] [meta =] [number 8'b0] [meta +]",
+     "                   [number 8'b1];",
+     "    [variable data_out] [meta =] [number 8'b0] [meta +]",
+     "               [number 8'b1];",
+     "[keyword end]",
+     ""
+  );
+
   // Indentation tests
   MT("indent_single_statement_if",
       "[keyword if] [bracket (][variable foo][bracket )]",
@@ -279,7 +305,6 @@
      "[def `uvm_object_utils_begin][bracket (][variable foo][bracket )]",
      "    [def `uvm_field_event][bracket (][variable foo], [variable UVM_ALL_ON][bracket )]",
      "[def `uvm_object_utils_end]",
-     "[variable foo][bracket ()];",
      ""
   );
 
@@ -292,7 +317,6 @@
      "[def `uvm_do_with][bracket (][variable mem_read],[bracket {]",
      "    [variable bar_nb] [meta ==] [number 0];",
      "[bracket })]",
-     "[variable foo][bracket ()];",
      ""
   );
 
@@ -307,7 +331,6 @@
       *    wait fork;
       *    disable fork;
       * endtask : body
-
       */
      "[keyword virtual] [keyword task] [variable body][bracket ()];",
      "    [keyword repeat] [bracket (][number 20][bracket )] [keyword begin]",
@@ -362,6 +385,58 @@
       */
      "[keyword extern] [keyword virtual] [keyword function] [keyword void] [variable do1][bracket (][keyword ref] [variable packet] [variable trans][bracket )];",
      "[keyword extern] [keyword virtual] [keyword function] [keyword void] [variable do2][bracket (][keyword ref] [variable packet] [variable trans][bracket )];",
+     ""
+  );
+
+  MT("indent_assignment",
+     /**
+      * for (int i=1;i < fun;i++) begin
+      *    foo = 2 << asdf || 11'h35 >> abcd
+      *          && 8'h6 | 1'b1;
+      * end
+      */
+     "[keyword for] [bracket (][keyword int] [variable i][meta =][number 1];[variable i] [meta <] [variable fun];[variable i][meta ++][bracket )] [keyword begin]",
+     "    [variable foo] [meta =] [number 2] [meta <<] [variable asdf] [meta ||] [number 11'h35] [meta >>] [variable abcd]",
+     "          [meta &&] [number 8'h6] [meta |] [number 1'b1];",
+     "[keyword end]",
+     ""
+  );
+
+  MT("indent_foreach_constraint",
+     /**
+      * `uvm_rand_send_with(wrTlp, {
+      *    length ==1;
+      *    foreach (Data[i]) {
+      *       payload[i] == Data[i];
+      *    }
+      * })
+      */
+     "[def `uvm_rand_send_with][bracket (][variable wrTlp], [bracket {]",
+     "    [variable length] [meta ==][number 1];",
+     "    [keyword foreach] [bracket (][variable Data][bracket [[][variable i][bracket ]])] [bracket {]",
+     "        [variable payload][bracket [[][variable i][bracket ]]] [meta ==] [variable Data][bracket [[][variable i][bracket ]]];",
+     "    [bracket }]",
+     "[bracket })]",
+     ""
+  );
+
+  MT("indent_compiler_directives",
+     /**
+      * `ifdef DUT
+      * `else
+      *     `ifndef FOO
+      *         `define FOO
+      *     `endif
+      * `endif
+      * `timescale 1ns/1ns
+      */
+     "[def `ifdef] [variable DUT]",
+     "[def `else]",
+     "    [def `ifndef] [variable FOO]",
+     "        [def `define] [variable FOO]",
+     "    [def `endif]",
+     "[def `endif]",
+     "[def `timescale] [number 1][variable ns][meta /][number 1][variable ns]",
      ""
   );
 

--- a/mode/verilog/verilog.js
+++ b/mode/verilog/verilog.js
@@ -175,6 +175,12 @@ CodeMirror.defineMode("verilog", function(config, parserConfig) {
       stream.eatWhile(/[\d_.]/);
       return "def";
     }
+    // Event
+    if (ch == '@') {
+      stream.next();
+      stream.eatWhile(/[@]/);
+      return "def";
+    }
     // Strings
     if (ch == '"') {
       stream.next();

--- a/mode/verilog/verilog.js
+++ b/mode/verilog/verilog.js
@@ -208,6 +208,15 @@ CodeMirror.defineMode("verilog", function(config, parserConfig) {
       if (keywords[cur]) {
         if (openClose[cur]) {
           curPunc = "newblock";
+          if (cur === "fork") {
+            // Fork can be a statement instead of block in cases of:
+            // "disable fork;" and "wait fork;" (trailing semicolon)
+            stream.eatSpace()
+            if (stream.peek() == ';') {
+              curPunc = "newstatement";
+            }
+            stream.backUp(stream.current().length - cur.length);    
+          }
         }
         if (statementKeywords[cur]) {
           curPunc = "newstatement";

--- a/mode/verilog/verilog.js
+++ b/mode/verilog/verilog.js
@@ -106,7 +106,7 @@ CodeMirror.defineMode("verilog", function(config, parserConfig) {
   }
 
   // Keywords which open statements that are ended with a semi-colon
-  var statementKeywords = words("always always_comb always_ff always_latch assert assign assume else export for foreach forever if import initial repeat while");
+  var statementKeywords = words("always always_comb always_ff always_latch assert assign assume else export for foreach forever if import initial repeat while extern typedef");
 
   function tokenBase(stream, state) {
     var ch = stream.peek(), style;
@@ -365,6 +365,8 @@ CodeMirror.defineMode("verilog", function(config, parserConfig) {
           // Do nothing in this case
         } else if (curKeyword == "task" && ctx && ctx.type == "statement") {
           // Same thing for task
+        } else if (curKeyword == "class" && ctx && ctx.type == "statement") {
+          // Same thing for class (e.g. typedef)
         } else {
           var close = openClose[curKeyword];
           pushContext(state, stream.column(), close);

--- a/mode/verilog/verilog.js
+++ b/mode/verilog/verilog.js
@@ -80,11 +80,11 @@ CodeMirror.defineMode("verilog", function(config, parserConfig) {
 
   var closingBracketOrWord = /^((`?\w+)|[)}\]])/;
   var closingBracket = /[)}\]]/;
-  const compilerDirectiveRegex      = new RegExp(
+  var compilerDirectiveRegex      = new RegExp(
     "^(`(?:ifdef|ifndef|elsif|else|endif|undef|undefineall|define|include|begin_keywords|celldefine|default|" +
     "nettype|end_keywords|endcelldefine|line|nounconnected_drive|pragma|resetall|timescale|unconnected_drive))\\b");
-  const compilerDirectiveBeginRegex = /^(`(?:ifdef|ifndef|elsif|else))\b/;
-  const compilerDirectiveEndRegex   = /^(`(?:elsif|else|endif))\b/;
+  var compilerDirectiveBeginRegex = /^(`(?:ifdef|ifndef|elsif|else))\b/;
+  var compilerDirectiveEndRegex   = /^(`(?:elsif|else|endif))\b/;
 
   var curPunc;
   var curKeyword;
@@ -141,7 +141,7 @@ CodeMirror.defineMode("verilog", function(config, parserConfig) {
         curKeyword = cur;
         // Macros that end in _begin, are start of block and end with _end
         if (cur.startsWith("`uvm_") && cur.endsWith("_begin")) {
-          const keywordClose = curKeyword.substr(0,curKeyword.length - 5) + "end";
+          var keywordClose = curKeyword.substr(0,curKeyword.length - 5) + "end";
           openClose[cur] = keywordClose;
           curPunc = "newblock";
         } else if (cur.startsWith("`uvm_") && cur.endsWith("_end")) {
@@ -225,7 +225,7 @@ CodeMirror.defineMode("verilog", function(config, parserConfig) {
             if (stream.peek() == ';') {
               curPunc = "newstatement";
             }
-            stream.backUp(stream.current().length - cur.length);    
+            stream.backUp(stream.current().length - cur.length);
           }
         }
         if (statementKeywords[cur]) {
@@ -275,12 +275,12 @@ CodeMirror.defineMode("verilog", function(config, parserConfig) {
     this.prev = prev;
   }
   function pushContext(state, col, type, scopekind) {
-    const indent = state.indented;
-    const c = new Context(indent, col, type, scopekind ? scopekind : "", null, state.context);
+    var indent = state.indented;
+    var c = new Context(indent, col, type, scopekind ? scopekind : "", null, state.context);
     return state.context = c;
   }
   function popContext(state) {
-    const t = state.context.type;
+    var t = state.context.type;
     if (t == ")" || t == "]" || t == "}") {
       state.indented = state.context.indented;
     }
@@ -377,7 +377,7 @@ CodeMirror.defineMode("verilog", function(config, parserConfig) {
       }
       if (ctx.align == null) ctx.align = true;
 
-      const isClosingAssignment = ctx.type == "assignment" &&
+      var isClosingAssignment = ctx.type == "assignment" &&
         closingBracket.test(curPunc) && ctx.prev && ctx.prev.type === curPunc;
       if (curPunc == ctx.type || isClosingAssignment) {
         if (isClosingAssignment) {
@@ -391,7 +391,7 @@ CodeMirror.defineMode("verilog", function(config, parserConfig) {
             while (ctx && (ctx.type == "statement" || ctx.type == "assignment")) ctx = popContext(state);
           }
         } else if (curPunc == "}") {
-          // Handle closing statements like constraint block: "foreach () {}" which 
+          // Handle closing statements like constraint block: "foreach () {}" which
           // do not have semicolon at end.
           if (ctx && (ctx.type === "statement")) {
             while (ctx && (ctx.type == "statement")) ctx = popContext(state);
@@ -451,7 +451,7 @@ CodeMirror.defineMode("verilog", function(config, parserConfig) {
       var ctx = state.context, firstChar = textAfter && textAfter.charAt(0);
       if (ctx.type == "statement" && firstChar == "}") ctx = ctx.prev;
       var closing = false;
-      const possibleClosing = textAfter.match(closingBracketOrWord);
+      var possibleClosing = textAfter.match(closingBracketOrWord);
       if (possibleClosing)
         closing = isClosing(possibleClosing[0], ctx.type);
       if (!compilerDirectivesUseRegularIndentation && textAfter.match(compilerDirectiveRegex)) {

--- a/mode/verilog/verilog.js
+++ b/mode/verilog/verilog.js
@@ -62,7 +62,7 @@ CodeMirror.defineMode("verilog", function(config, parserConfig) {
      binary_module_path_operator ::=
        == | != | && | || | & | | | ^ | ^~ | ~^
   */
-  var isOperatorChar = /[\+\-\*\/!~&|^%=?:]/;
+  var isOperatorChar = /[\+\-\*\/!~&|^%=?:<>]/;
   var isBracketChar = /[\[\]{}()]/;
 
   var unsignedNumber = /\d[0-9_]*/;


### PR DESCRIPTION
This resolves #6227 support request, adding in missing construct support.
Additional tests created for these new scenarios, and all previous tests pass unedited.

Sorry, this is my first pull request...let me know if I need to tweak how I'm doing this. Thanks!
<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
