### PR TITLE
Break an inifite loop in text wrapping.

### DIFF
--- a/addon/wrap/hardwrap.js
+++ b/addon/wrap/hardwrap.js
@@ -91,7 +91,8 @@
       }
       while (curLine.length > column) {
         var bp = findBreakPoint(curLine, column, wrapOn, killTrailing, forceBreak);
-        if (bp.from != bp.to || forceBreak) {
+        if (bp.from != bp.to ||
+            forceBreak && leadingSpace !== curLine.slice(0, bp.to)) {
           changes.push({text: ["", leadingSpace],
                         from: Pos(curNo, bp.from),
                         to: Pos(curNo, bp.to)});


### PR DESCRIPTION
This breaks an infinite loop triggered by wrapping a text containing a word longer than the targed width (e.g., a long URL).