### PR TITLE
Document singleCursorHeightPerLine option

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -513,13 +513,13 @@
       of the line, looks better</dd>
 
       <dt id="option_singleCursorHeightPerLine"><code><strong>singleCursorHeightPerLine</strong>: boolean</code></dt>
-      <dd>Determines if CodeMirror can expect all lines to be of the
-      same height (<code>true</code>, the default) and the cursor-size
-      can therefore be lazily evaluated. In case your editor contains
-      multiple line-sizes, for instance, if <a href="#addLineClass"><code>addLineClass</code></a>
-      sets classes which contain <code>line-height</code>-rules, you
-      should consider setting this to <code>false</code> to prevent
-      visual artefacts.
+      <dd>If set to <code>true</code> (the default), CodeMirror will
+      calculate the cursor height from the adjacent characters or
+      text markers. If set to <code>false</code>, the cursor height
+      will be calculated based off the height of all bounding boxes
+      on the current (wrapped) line, keeping the height consistent.
+      This is visible especially if you use text markers that are
+      bigger than the font-size of the characters on the line.
 
       <dt id="option_resetSelectionOnContextMenu"><code><strong>resetSelectionOnContextMenu</strong>: boolean</code></dt>
       <dd>Controls whether, when the context menu is opened with a

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -512,6 +512,15 @@
       which causes the cursor to not reach all the way to the bottom
       of the line, looks better</dd>
 
+      <dt id="option_singleCursorHeightPerLine"><code><strong>singleCursorHeightPerLine</strong>: boolean</code></dt>
+      <dd>Determines if CodeMirror can expect all lines to be of the
+      same height (<code>true</code>, the default) and the cursor-size
+      can therefore be lazily evaluated. In case your editor contains
+      multiple line-sizes, for instance, if <a href="#addLineClass"><code>addLineClass</code></a>
+      sets classes which contain <code>line-height</code>-rules, you
+      should consider setting this to <code>false</code> to prevent
+      visual artefacts.
+
       <dt id="option_resetSelectionOnContextMenu"><code><strong>resetSelectionOnContextMenu</strong>: boolean</code></dt>
       <dd>Controls whether, when the context menu is opened with a
       click outside of the current selection, the cursor is moved to


### PR DESCRIPTION
<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->

It's me again with an undocumented option! Tested on the most recent CodeMirror version, and works like a charm. (Source: https://github.com/codemirror/CodeMirror/issues/2941)

Thanks again for CodeMirror, and I'm looking forward to switching to CodeMirror.Next ❤️