### PR TITLE
Fix the search addon page link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Fix platform detection on recent iPadOS.
 
 ### New features
 
-[search addon](https://codemirror.net/demo/search/): Make it possible to configure the search addon to show the dialog at the bottom of the editor.
+[search addon](https://codemirror.net/demo/search.html): Make it possible to configure the search addon to show the dialog at the bottom of the editor.
 
 ## 5.58.3 (2020-11-19)
 


### PR DESCRIPTION
Simply add the .html extension to the link.

<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
