### PR TITLE
Extended the `closeOnCursorActivity` flag to be `updateOnCursorActivity`

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -61,8 +61,10 @@
     this.startPos = this.cm.getCursor("start");
     this.startLen = this.cm.getLine(this.startPos.line).length - this.cm.getSelection().length;
 
-    var self = this;
-    cm.on("cursorActivity", this.activityFunc = function() { self.cursorActivity(); });
+    if (this.options.updateOnCursorActivity) {
+      var self = this;
+      cm.on("cursorActivity", this.activityFunc = function() { self.cursorActivity(); });
+    }
   }
 
   var requestAnimationFrame = window.requestAnimationFrame || function(fn) {
@@ -75,7 +77,9 @@
       if (!this.active()) return;
       this.cm.state.completionActive = null;
       this.tick = null;
-      this.cm.off("cursorActivity", this.activityFunc);
+      if (this.options.updateOnCursorActivity) {
+        this.cm.off("cursorActivity", this.activityFunc);
+      }
 
       if (this.widget && this.data) CodeMirror.signal(this.data, "close");
       if (this.widget) this.widget.close();
@@ -117,9 +121,7 @@
       if (pos.line != this.startPos.line || line.length - pos.ch != this.startLen - this.startPos.ch ||
           pos.ch < identStart.ch || this.cm.somethingSelected() ||
           (!pos.ch || this.options.closeCharacters.test(line.charAt(pos.ch - 1)))) {
-        if (this.options.closeOnCursorActivity) {
-          this.close();
-        }
+        this.close();
       } else {
         var self = this;
         this.debounce = requestAnimationFrame(function() {self.update();});
@@ -492,9 +494,9 @@
     completeSingle: true,
     alignWithWord: true,
     closeCharacters: /[\s()\[\]{};:>,]/,
-    closeOnCursorActivity: true,
     closeOnPick: true,
     closeOnUnfocus: true,
+    updateOnCursorActivity: true,
     completeOnSingleClick: true,
     container: null,
     customKeys: null,


### PR DESCRIPTION
I had to slightly change the behavior of `closeOnCursorActivity` flag. In fact, it became `updateOnCursorActivity`.

The reason is that it has been sometimes possible (quite often on Safari) to be stuck with multiple dropdowns.
I'm controlling the opening/closing of the hints from outside but `Completion#cursorActivity` is async as it uses `setTimeout`. As a result, it has been possible to have `new Widget` called twice without closing between so two dropdowns have been displayed (without any way to dismiss the previous one).

Then, I'd prefer to opt-out from the whole "update on cursor activity" functionality (not only closing) as I'm controlling that on my own from outside of the addon.

Thanks for checking this PR out :)