### PR TITLE
Fix invalid comparison of string with number

### DIFF
--- a/src/edit/methods.js
+++ b/src/edit/methods.js
@@ -479,7 +479,7 @@ function findPosH(doc, pos, dir, unit, visually) {
   function moveOnce(boundToLine) {
     let next
     if (unit == "codepoint") {
-      let ch = lineObj.text.charCodeAt(pos.ch + (unit > 0 ? 0 : -1))
+      let ch = lineObj.text.charCodeAt(pos.ch - 1)
       if (isNaN(ch)) {
         next = null
       } else {


### PR DESCRIPTION
In this case, the `unit` is of type string. As such, `"codepoint" > 0`
always produces false, hence the code in question always became -1.
I found this while debugging https://crbug.com/1161083, which turns
out was already reported and fixed with
https://github.com/codemirror/CodeMirror/commit/37d7b2efceb192c94811a13b2b7b3eec4b786608