### PR TITLE
fix fold issue: when JSON array contains json object, it will fold ob…

### DIFF
--- a/addon/fold/brace-fold.js
+++ b/addon/fold/brace-fold.js
@@ -31,10 +31,10 @@ CodeMirror.registerHelper("fold", "brace", function(cm, start) {
     }
   }
 
-  var startToken = "{", endToken = "}", startCh = findOpening("{");
+  var startToken = "[", endToken = "]", startCh = findOpening(startToken);
   if (startCh == null) {
-    startToken = "[", endToken = "]";
-    startCh = findOpening("[");
+    startToken = "{", endToken = "}";
+    startCh = findOpening(startToken);
   }
 
   if (startCh == null) return;


### PR DESCRIPTION
When the JSON array contains a json object, such as bellow:
{
    "name": "hello",
    "test": [{
        "a": {
            "a": 123
        }
    }, {
        "b": {
            "b": 123
        }
    }]
}

When user click the fold icon, it will fold the first object in array:
{
    "name": "hello",
    "test": [{ --<-->--}, 
    {
        "b": {
            "b": 123
        }
    }]
}

But actually user wants to fold the array.
{
    "name": "hello",
    "test": [{ --<-->--}]
}



<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
