### PR TITLE
Add highlightNonMatching config to matchbracket addon

### DIFF
--- a/addon/edit/matchbrackets.js
+++ b/addon/edit/matchbrackets.js
@@ -80,11 +80,12 @@
 
   function matchBrackets(cm, autoclear, config) {
     // Disable brace matching in long lines, since it'll cause hugely slow updates
-    var maxHighlightLen = cm.state.matchBrackets.maxHighlightLineLength || 1000;
+    var maxHighlightLen = cm.state.matchBrackets.maxHighlightLineLength || 1000,
+      highlightNonMatching = config && config.highlightNonMatching;
     var marks = [], ranges = cm.listSelections();
     for (var i = 0; i < ranges.length; i++) {
       var match = ranges[i].empty() && findMatchingBracket(cm, ranges[i].head, config);
-      if (match && cm.getLine(match.from.line).length <= maxHighlightLen) {
+      if (match && (match.match || highlightNonMatching !== false) && cm.getLine(match.from.line).length <= maxHighlightLen) {
         var style = match.match ? "CodeMirror-matchingbracket" : "CodeMirror-nonmatchingbracket";
         marks.push(cm.markText(match.from, Pos(match.from.line, match.from.ch + 1), {className: style}));
         if (match.to && cm.getLine(match.to.line).length <= maxHighlightLen)

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2443,6 +2443,8 @@ editor.setOption("extraKeys", {
         <dl>
           <dt><strong><code>afterCursor</code></strong></dt>
           <dd>Only use the character after the start position, never the one before it.</dd>
+          <dt><strong><code>highlightNonMatching</code></strong></dt>
+          <dd>Also highlight pairs of non-matching as well as stray brackets. Enabled by default.</dd>
           <dt><strong><code>strict</code></strong></dt>
           <dd>Causes only matches where both brackets are at the same side of the start position to be considered.</dd>
           <dt><strong><code>maxScanLines</code></strong></dt>


### PR DESCRIPTION
It's not uncommon to have non-matching brackets in MediaWiki wikitext source code. This is not always an error. Another reason why we want to disable this feature is that it's rather distracting while typing. We [temporarily patched our copy of the addon](https://gerrit.wikimedia.org/r/656119), but think it's worth having a proper config flag.

[Bug: T269096](https://phabricator.wikimedia.org/T269096)