### PR TITLE
Replace regex with faster string matches

### DIFF
--- a/mode/dtd/dtd.js
+++ b/mode/dtd/dtd.js
@@ -112,7 +112,7 @@ CodeMirror.defineMode("dtd", function(config) {
     indent: function(state, textAfter) {
       var n = state.stack.length;
 
-      if( textAfter.match(/\]\s+|\]/) )n=n-1;
+      if( textAfter.charAt(0) === ']' )n--;
       else if(textAfter.substr(textAfter.length-1, textAfter.length) === ">"){
         if(textAfter.substr(0,1) === "<") {}
         else if( type == "doindent" && textAfter.length > 1 ) {}

--- a/mode/ebnf/ebnf.js
+++ b/mode/ebnf/ebnf.js
@@ -41,10 +41,10 @@
             state.stringType = stream.peek();
             stream.next(); // Skip quote
             state.stack.unshift(stateType._string);
-          } else if (stream.match(/^\/\*/)) { //comments starting with /*
+          } else if (stream.match('/*')) { //comments starting with /*
             state.stack.unshift(stateType.comment);
             state.commentType = commentType.slash;
-          } else if (stream.match(/^\(\*/)) { //comments starting with (*
+          } else if (stream.match('(*')) { //comments starting with (*
             state.stack.unshift(stateType.comment);
             state.commentType = commentType.parenthesis;
           }
@@ -69,10 +69,10 @@
 
         case stateType.comment:
           while (state.stack[0] === stateType.comment && !stream.eol()) {
-            if (state.commentType === commentType.slash && stream.match(/\*\//)) {
+            if (state.commentType === commentType.slash && stream.match('*/')) {
               state.stack.shift(); // Clear flag
               state.commentType = null;
-            } else if (state.commentType === commentType.parenthesis && stream.match(/\*\)/)) {
+            } else if (state.commentType === commentType.parenthesis && stream.match('*)')) {
               state.stack.shift(); // Clear flag
               state.commentType = null;
             } else {
@@ -83,7 +83,7 @@
 
         case stateType.characterClass:
           while (state.stack[0] === stateType.characterClass && !stream.eol()) {
-            if (!(stream.match(/^[^\]\\]+/) || stream.match(/^\\./))) {
+            if (!(stream.match(/^[^\]\\]+/) || stream.match('.'))) {
               state.stack.shift();
             }
           }
@@ -168,10 +168,10 @@
           }
         }
 
-        if (stream.match(/^\/\//)) {
+        if (stream.match('//')) {
           stream.skipToEnd();
           return "comment";
-        } else if (stream.match(/return/)) {
+        } else if (stream.match('return')) {
           return "operator";
         } else if (stream.match(/^[a-zA-Z_][a-zA-Z0-9_]*/)) {
           if (stream.match(/(?=[\(.])/)) {

--- a/mode/julia/julia.js
+++ b/mode/julia/julia.js
@@ -80,7 +80,7 @@ CodeMirror.defineMode("julia", function(config, parserConf) {
   // tokenizers
   function tokenBase(stream, state) {
     // Handle multiline comments
-    if (stream.match(/^#=/, false)) {
+    if (stream.match('#=', false)) {
       state.tokenize = tokenComment;
       return state.tokenize(stream, state);
     }
@@ -141,10 +141,10 @@ CodeMirror.defineMode("julia", function(config, parserConf) {
     }
 
     if (inArray(state)) {
-      if (state.lastToken == "end" && stream.match(/^:/)) {
+      if (state.lastToken == "end" && stream.match(':')) {
         return "operator";
       }
-      if (stream.match(/^end/)) {
+      if (stream.match('end')) {
         return "number";
       }
     }
@@ -201,7 +201,7 @@ CodeMirror.defineMode("julia", function(config, parserConf) {
     }
 
     // Handle Chars
-    if (stream.match(/^'/)) {
+    if (stream.match('\'')) {
       state.tokenize = tokenChar;
       return state.tokenize(stream, state);
     }
@@ -263,7 +263,7 @@ CodeMirror.defineMode("julia", function(config, parserConf) {
         state.scopes.push('(');
         charsAdvanced += match[1].length;
       }
-      if (currentScope(state) == '(' && stream.match(/^\)/)) {
+      if (currentScope(state) == '(' && stream.match(')')) {
         state.scopes.pop();
         charsAdvanced += 1;
         if (state.scopes.length <= state.firstParenPos) {
@@ -295,10 +295,10 @@ CodeMirror.defineMode("julia", function(config, parserConf) {
   }
 
   function tokenAnnotation(stream, state) {
-    stream.match(/.*?(?=,|;|{|}|\(|\)|=|$|\s)/);
-    if (stream.match(/^{/)) {
+    stream.match(/.*?(?=[,;{}()=\s]|$)/);
+    if (stream.match('{')) {
       state.nestedParameters++;
-    } else if (stream.match(/^}/) && state.nestedParameters > 0) {
+    } else if (stream.match('}') && state.nestedParameters > 0) {
       state.nestedParameters--;
     }
     if (state.nestedParameters > 0) {
@@ -310,13 +310,13 @@ CodeMirror.defineMode("julia", function(config, parserConf) {
   }
 
   function tokenComment(stream, state) {
-    if (stream.match(/^#=/)) {
+    if (stream.match('#=')) {
       state.nestedComments++;
     }
     if (!stream.match(/.*?(?=(#=|=#))/)) {
       stream.skipToEnd();
     }
-    if (stream.match(/^=#/)) {
+    if (stream.match('=#')) {
       state.nestedComments--;
       if (state.nestedComments == 0)
         state.tokenize = tokenBase;
@@ -347,7 +347,7 @@ CodeMirror.defineMode("julia", function(config, parserConf) {
       return "string";
     }
     if (!stream.match(/^[^']+(?=')/)) { stream.skipToEnd(); }
-    if (stream.match(/^'/)) { state.tokenize = tokenBase; }
+    if (stream.match('\'')) { state.tokenize = tokenBase; }
     return "error";
   }
 

--- a/mode/markdown/markdown.js
+++ b/mode/markdown/markdown.js
@@ -612,7 +612,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
           return getType(state);
         }
       } else if (ch === ' ') {
-        if (stream.match(/^~~/, true)) { // Probably surrounded by space
+        if (stream.match('~~', true)) { // Probably surrounded by space
           if (stream.peek() === ' ') { // Surrounded by spaces, ignore
             return getType(state);
           } else { // Not surrounded by spaces, back up pointer
@@ -711,7 +711,7 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
   }
 
   function footnoteLinkInside(stream, state) {
-    if (stream.match(/^\]:/, true)) {
+    if (stream.match(']:', true)) {
       state.f = state.inline = footnoteUrl;
       if (modeCfg.highlightFormatting) state.formatting = "link";
       var returnType = getType(state);

--- a/mode/mscgen/mscgen.js
+++ b/mode/mscgen/mscgen.js
@@ -153,7 +153,7 @@
         return "variable";
 
       /* attribute lists */
-      if (!pConfig.inAttributeList && !!pConfig.attributes && pStream.match(/\[/, true, true)) {
+      if (!pConfig.inAttributeList && !!pConfig.attributes && pStream.match('[', true, true)) {
         pConfig.inAttributeList = true;
         return "bracket";
       }
@@ -161,7 +161,7 @@
         if (pConfig.attributes !== null && pStream.match(wordRegexpBoundary(pConfig.attributes), true, true)) {
           return "attribute";
         }
-        if (pStream.match(/]/, true, true)) {
+        if (pStream.match(']', true, true)) {
           pConfig.inAttributeList = false;
           return "bracket";
         }

--- a/mode/oz/oz.js
+++ b/mode/oz/oz.js
@@ -45,7 +45,7 @@ CodeMirror.defineMode("oz", function (conf) {
     }
 
     // Special [] keyword
-    if (stream.match(/(\[])/)) {
+    if (stream.match('[]')) {
         return "keyword"
     }
 

--- a/mode/pegjs/pegjs.js
+++ b/mode/pegjs/pegjs.js
@@ -39,7 +39,7 @@ CodeMirror.defineMode("pegjs", function (config) {
         stream.next(); // Skip quote
         state.inString = true; // Update state
       }
-      if (!state.inString && !state.inComment && stream.match(/^\/\*/)) {
+      if (!state.inString && !state.inComment && stream.match('/*')) {
         state.inComment = true;
       }
 
@@ -59,7 +59,7 @@ CodeMirror.defineMode("pegjs", function (config) {
         return state.lhs ? "property string" : "string"; // Token style
       } else if (state.inComment) {
         while (state.inComment && !stream.eol()) {
-          if (stream.match(/\*\//)) {
+          if (stream.match('*/')) {
             state.inComment = false; // Clear flag
           } else {
             stream.match(/^.[^\*]*/);
@@ -76,7 +76,7 @@ CodeMirror.defineMode("pegjs", function (config) {
         stream.next();
         state.inCharacterClass = true;
         return 'bracket';
-      } else if (stream.match(/^\/\//)) {
+      } else if (stream.match('//')) {
         stream.skipToEnd();
         return "comment";
       } else if (state.braced || stream.peek() === '{') {

--- a/mode/pug/pug.js
+++ b/mode/pug/pug.js
@@ -261,7 +261,7 @@ CodeMirror.defineMode("pug", function (config) {
       }
       return 'variable';
     }
-    if (stream.match(/^\+#{/, false)) {
+    if (stream.match('+#{', false)) {
       stream.next();
       state.mixinCallAfter = true;
       return interpolation(stream, state);

--- a/mode/rpm/rpm.js
+++ b/mode/rpm/rpm.js
@@ -80,12 +80,12 @@ CodeMirror.defineMode("rpm-spec", function() {
 
       // Macros like '%make_install' or '%attr(0775,root,root)'
       if (stream.match(/^%[\w]+/)) {
-        if (stream.match(/^\(/)) { state.macroParameters = true; }
+        if (stream.match('(')) { state.macroParameters = true; }
         return "keyword";
       }
       if (state.macroParameters) {
         if (stream.match(/^\d+/)) { return "number";}
-        if (stream.match(/^\)/)) {
+        if (stream.match(')')) {
           state.macroParameters = false;
           return "keyword";
         }

--- a/mode/sass/sass.js
+++ b/mode/sass/sass.js
@@ -231,7 +231,7 @@ CodeMirror.defineMode("sass", function(config) {
       }
 
       if(ch === "@"){
-        if(stream.match(/@extend/)){
+        if(stream.match('@extend')){
           if(!stream.match(/\s*[\w]/))
             dedent(state);
         }

--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -411,7 +411,7 @@
             return null;
 
           case "list-literal":
-            if (stream.match(/\]/)) {
+            if (stream.match(']')) {
               state.soyState.pop();
               state.lookupVariables = true;
               popcontext(state);
@@ -517,14 +517,14 @@
             }
             return expression(stream, state);
           case "literal":
-            if (stream.match(/^(?=\{\/literal})/)) {
+            if (stream.match('{/literal}', false)) {
               state.soyState.pop();
               return this.token(stream, state);
             }
             return tokenUntil(stream, state, /\{\/literal}/);
         }
 
-        if (stream.match(/^\{literal}/)) {
+        if (stream.match('{literal}')) {
           state.indent += config.indentUnit;
           state.soyState.push("literal");
           state.context = new Context(state.context, "literal", state.variables);
@@ -581,12 +581,12 @@
           state.soyState.push("import");
           state.indent += 2 * config.indentUnit;
           return "keyword";
-        } else if (match = stream.match(/^<\{/)) {
+        } else if (match = stream.match('<{')) {
           state.soyState.push("template-call-expression");
           state.indent += 2 * config.indentUnit;
           state.soyState.push("tag");
           return "keyword";
-        } else if (match = stream.match(/^<\/>/)) {
+        } else if (match = stream.match('</>')) {
           state.indent -= 1 * config.indentUnit;
           return "keyword";
         }

--- a/mode/sql/sql.js
+++ b/mode/sql/sql.js
@@ -243,9 +243,9 @@ CodeMirror.defineMode("sql", function(config, parserConfig) {
     // varName can be quoted with ` or ' or "
     // ref: http://dev.mysql.com/doc/refman/5.5/en/user-variables.html
     if (stream.eat("@")) {
-      stream.match(/^session\./);
-      stream.match(/^local\./);
-      stream.match(/^global\./);
+      stream.match('session.');
+      stream.match('local.');
+      stream.match('global.');
     }
 
     if (stream.eat("'")) {

--- a/mode/stylus/stylus.js
+++ b/mode/stylus/stylus.js
@@ -138,7 +138,7 @@
         // Variable
         if (stream.match(/^(\.|\[)[\w-\'\"\]]+/i, false)) {
           if (!wordIsTag(stream.current())) {
-            stream.match(/\./);
+            stream.match('.');
             return ["variable-2", "variable-name"];
           }
         }

--- a/mode/tiddlywiki/tiddlywiki.js
+++ b/mode/tiddlywiki/tiddlywiki.js
@@ -114,7 +114,7 @@ CodeMirror.defineMode("tiddlywiki", function () {
         return 'header';
     }
 
-    if (ch == '{' && stream.match(/\{\{/))
+    if (ch == '{' && stream.match('{{'))
       return chain(stream, state, twTokenCode);
 
     // rudimentary html:// file:// link matching. TW knows much more ...

--- a/mode/yaml-frontmatter/yaml-frontmatter.js
+++ b/mode/yaml-frontmatter/yaml-frontmatter.js
@@ -36,7 +36,7 @@
       },
       token: function (stream, state) {
         if (state.state == START) {
-          if (stream.match(/---/, false)) {
+          if (stream.match('---', false)) {
             state.state = FRONTMATTER
             return yamlMode.token(stream, state.inner)
           } else {

--- a/mode/yaml/yaml.js
+++ b/mode/yaml/yaml.js
@@ -38,9 +38,9 @@ CodeMirror.defineMode("yaml", function() {
         state.pair = false;
         state.pairStart = false;
         /* document start */
-        if(stream.match(/---/)) { return "def"; }
+        if(stream.match('---')) { return "def"; }
         /* document end */
-        if (stream.match(/\.\.\./)) { return "def"; }
+        if (stream.match('...')) { return "def"; }
         /* array list item */
         if (stream.match(/\s*-\s+/)) { return 'meta'; }
       }


### PR DESCRIPTION
Warning: This works only when the match() call is a StringStream.match(), not if it is a native String.match(). Please carefully review this and make sure this doesn't break anything.