### PR TITLE
Add missing ^ anchors to StringStream.match() patterns

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -3483,7 +3483,7 @@
         },
         isComplete: function(state) {
           if (state.nextCh === '#') {
-            var token = state.lineText.match(/#(\w+)/)[1];
+            var token = state.lineText.match(/^#(\w+)/)[1];
             if (token === 'endif') {
               if (state.forward && state.depth === 0) {
                 return true;

--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -350,8 +350,8 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
   function cpp11StringHook(stream, state) {
     stream.backUp(1);
     // Raw strings.
-    if (stream.match(/(R|u8R|uR|UR|LR)/)) {
-      var match = stream.match(/"([^\s\\()]{0,16})\(/);
+    if (stream.match(/^(?:R|u8R|uR|UR|LR)/)) {
+      var match = stream.match(/^"([^\s\\()]{0,16})\(/);
       if (!match) {
         return false;
       }
@@ -360,8 +360,8 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
       return tokenRawString(stream, state);
     }
     // Unicode strings/chars.
-    if (stream.match(/(u8|u|U|L)/)) {
-      if (stream.match(/["']/, /* eat */ false)) {
+    if (stream.match(/^(?:u8|u|U|L)/)) {
+      if (stream.match(/^["']/, /* eat */ false)) {
         return "string";
       }
       return false;

--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -78,8 +78,8 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
       return ret("qualifier", "qualifier");
     } else if (/[:;{}\[\]\(\)]/.test(ch)) {
       return ret(null, ch);
-    } else if (stream.match(/[\w-.]+(?=\()/)) {
-      if (/^(url(-prefix)?|domain|regexp)$/.test(stream.current().toLowerCase())) {
+    } else if (stream.match(/^[\w-.]+(?=\()/)) {
+      if (/^(url(-prefix)?|domain|regexp)$/i.test(stream.current())) {
         state.tokenize = tokenParenthesized;
       }
       return ret("variable callee", "variable");
@@ -108,7 +108,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
 
   function tokenParenthesized(stream, state) {
     stream.next(); // Must be '('
-    if (!stream.match(/\s*[\"\')]/, false))
+    if (!stream.match(/^\s*[\"\')]/, false))
       state.tokenize = tokenString(")");
     else
       state.tokenize = null;
@@ -781,7 +781,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
         }
       },
       ":": function(stream) {
-        if (stream.match(/\s*\{/, false))
+        if (stream.match(/^\s*\{/, false))
           return [null, null]
         return false;
       },

--- a/mode/cypher/cypher.js
+++ b/mode/cypher/cypher.js
@@ -21,11 +21,11 @@
     var tokenBase = function(stream/*, state*/) {
       var ch = stream.next();
       if (ch ==='"') {
-        stream.match(/.*?"/);
+        stream.match(/^[^"]*"/);
         return "string";
       }
       if (ch === "'") {
-        stream.match(/.*?'/);
+        stream.match(/^[^']*'/);
         return "string";
       }
       if (/[{}\(\),\.;\[\]]/.test(ch)) {

--- a/mode/mscgen/mscgen.js
+++ b/mode/mscgen/mscgen.js
@@ -72,11 +72,11 @@
   CodeMirror.defineMIME("text/x-msgenny", {name: "mscgen", language: "msgenny"});
 
   function wordRegexpBoundary(pWords) {
-    return new RegExp("\\b(" + pWords.join("|") + ")\\b", "i");
+    return new RegExp("^\\b(?:" + pWords.join("|") + ")\\b", "i");
   }
 
   function wordRegexp(pWords) {
-    return new RegExp("(" + pWords.join("|") + ")", "i");
+    return new RegExp("^(?:" + pWords.join("|") + ")", "i");
   }
 
   function startStateFn() {

--- a/mode/php/php.js
+++ b/mode/php/php.js
@@ -53,7 +53,7 @@
           [["]", null]]
         ], closing, escapes);
       }
-      if (stream.match(/\-\>\w/, false)) {
+      if (stream.match(/^->\w/, false)) {
         // Match object operator
         state.tokenize = matchSequence([
           [["->", null]],
@@ -106,7 +106,7 @@
       },
       "<": function(stream, state) {
         var before;
-        if (before = stream.match(/<<\s*/)) {
+        if (before = stream.match(/^<<\s*/)) {
           var quoted = stream.eat(/['"]/);
           stream.eatWhile(/[\w\.]/);
           var delim = stream.current().slice(before[0].length + (quoted ? 2 : 1));

--- a/mode/puppet/puppet.js
+++ b/mode/puppet/puppet.js
@@ -176,7 +176,7 @@ CodeMirror.defineMode("puppet", function () {
     // Match characters that we are going to assume
     // are trying to be regex
     if (ch == '/') {
-      stream.match(/.*?\//);
+      stream.match(/^[^\/]*\//);
       return 'variable-3';
     }
     // Match all the numbers


### PR DESCRIPTION
The method fails anyway (i.e. it acts as if there was no match) when the match is not at the start of the string. Adding the anchor does not change any behavior, but increases performance.