### PR TITLE
Fix matchbrackets incompatibility with certain modes

### DIFF
--- a/addon/edit/matchbrackets.js
+++ b/addon/edit/matchbrackets.js
@@ -38,7 +38,7 @@
     if (config && config.strict && (dir > 0) != (pos == where.ch)) return null;
     var style = cm.getTokenTypeAt(Pos(where.line, pos + 1));
 
-    var found = scanForBracket(cm, Pos(where.line, pos + (dir > 0 ? 1 : 0)), dir, style || null, config);
+    var found = scanForBracket(cm, Pos(where.line, pos + (dir > 0 ? 1 : 0)), dir, style, config);
     if (found == null) return null;
     return {from: Pos(where.line, pos), to: found && found.pos,
             match: found && found.ch == match.charAt(0), forward: dir > 0};


### PR DESCRIPTION
When a mode does not apply a CSS class name to basic black text (i.e. the style is `""`), the matchbrackets addon will stop working for no good reason. See https://phabricator.wikimedia.org/T269096#6758178 for a longer explanation why I think this `|| null` is a mistake and should be removed.

This `|| null` was added in 2014 as part of commit 98326d16a1a9fc6e399c9e55bba2f544c1c70731. I can't find an explanation. I suspect it was a mistake, possibly done to make the code more fail-safe, but not considering the empty string.