### PR TITLE
[vim] fix html in dialogs/prompts

### DIFF
--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -197,13 +197,13 @@ function testVim(name, run, opts, expectedFail) {
       }
     }
     function fakeOpenDialog(result) {
-      return function(text, callback) {
+      return function(template, callback) {
         return callback(result);
       }
     }
     function fakeOpenNotification(matcher) {
-      return function(text) {
-        matcher(text);
+      return function(template) {
+        matcher(template.innerHTML);
       }
     }
     var helpers = {
@@ -3168,6 +3168,13 @@ testVim(':_register', function(cm,vim,helpers) {
   });
   helpers.doKeys(':');
 }, {value: ''});
+testVim('registers_html_encoding', function(cm,vim,helpers) {
+  helpers.doKeys('y', 'y');
+  cm.openNotification = helpers.fakeOpenNotification(function(text) {
+    is(/"\s+&lt;script&gt;throw "&amp;amp;"&lt;\/script&gt;/.test(text));
+  });
+  helpers.doEx('registers');
+}, {value: '<script>throw "&amp;"</script>'});
 testVim('search_register_escape', function(cm, vim, helpers) {
   // Check that the register is restored if the user escapes rather than confirms.
   cm.openDialog = helpers.fakeOpenDialog('waldo');


### PR DESCRIPTION
Fixes vim registers command when html tags present.
Fixes vim prompts in Firefox Developer Tools.

Sorry for the gnarly diff, but it had to be done.
I've also inlined the dialog function and searchPromptDesc constant var, which had exactly one reference each.

Background:
Firefox - the cmdline and search prompt has been broken in Firefox for a while, the `<input>` tag gets stripped out (when assigning to innerHTML in the dialog addon). Luckily constructing DOM nodes instead works.
`:registers` - This command prints out text you last copied/changed/deleted along with named/numbers registers. If you have html in your registers, the output is incorrect / interpreted.