### PR TITLE
Chars consume possibility

### DIFF
--- a/src/util/StringStream.js
+++ b/src/util/StringStream.js
@@ -45,7 +45,7 @@ class StringStream {
     if (found > -1) {this.pos = found; return true}
   }
   backUp(n) {this.pos -= n}
-  comsume(n) {this.pos += n}
+  consume(n) {this.pos += n}
   column() {
     if (this.lastColumnPos < this.start) {
       this.lastColumnValue = countColumn(this.string, this.start, this.tabSize, this.lastColumnPos, this.lastColumnValue)

--- a/src/util/StringStream.js
+++ b/src/util/StringStream.js
@@ -45,6 +45,7 @@ class StringStream {
     if (found > -1) {this.pos = found; return true}
   }
   backUp(n) {this.pos -= n}
+  comsume(n) {this.pos += n}
   column() {
     if (this.lastColumnPos < this.start) {
       this.lastColumnValue = countColumn(this.string, this.start, this.tabSize, this.lastColumnPos, this.lastColumnValue)


### PR DESCRIPTION
We can test stream with `match(..., false)`. That is, we gain knowledge about the next chars. I do so and i want to consume some next `n` chars. 

`stream.backup(-n)` looks bad.
`stream.pos += n` looks bad two...

May be it would more consistently if we add `consume` method...

<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
