### PR TITLE
[vim] ignore CapsLock key events

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -353,7 +353,7 @@
       return cmd;
     }
 
-    var modifiers = {'Shift': 'S', 'Ctrl': 'C', 'Alt': 'A', 'Cmd': 'D', 'Mod': 'A'};
+    var modifiers = {Shift:'S',Ctrl:'C',Alt:'A',Cmd:'D',Mod:'A',CapsLock:''};
     var specialKeys = {Enter:'CR',Backspace:'BS',Delete:'Del',Insert:'Ins'};
     function cmKeyToVimKey(key) {
       if (key.charAt(0) == '\'') {


### PR DESCRIPTION
A simple one :)
Fixes the issue reported on the forum https://discuss.codemirror.net/t/vim-incorrect-behavior-of-key-shift-key-in-ubuntu-20-04/2811

Adding CapsLock to `modifiers` means that `cmKeyToVimKey` won't treat it as a character (see `hasCharacter`). No other references to `modifiers`.