### PR TITLE
[vim] substitute pattern ending in dollar

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -5097,9 +5097,11 @@
               regexPart = new RegExp(regexPart).source; //normalize not escaped characters
           }
           replacePart = tokens[1];
-          if (regexPart && regexPart[regexPart.length - 1] === '$') {
-            regexPart = regexPart.slice(0, regexPart.length - 1) + '\\n';
-            replacePart = replacePart ? replacePart + '\n' : '\n';
+          // If the pattern ends with $ (line boundary assertion), change $ to \n.
+          // Caveat: this workaround cannot match on the last line of the document.
+          if (/(^|[^\\])(\\\\)*\$$/.test(regexPart)) {
+            regexPart = regexPart.slice(0, -1) + '\\n';
+            replacePart = (replacePart || '') + '\n';
           }
           if (replacePart !== undefined) {
             if (getOption('pcre')) {
@@ -5128,11 +5130,9 @@
           if (flagsPart) {
             if (flagsPart.indexOf('c') != -1) {
               confirm = true;
-              flagsPart.replace('c', '');
             }
             if (flagsPart.indexOf('g') != -1) {
               global = true;
-              flagsPart.replace('g', '');
             }
             if (getOption('pcre')) {
                regexPart = regexPart + '/' + flagsPart;

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -4311,10 +4311,14 @@ testSubstitute('ex_substitute_multibackslash_replacement', {
   value: 'one,two \n three,four',
   expectedValue: 'one\\\\\\\\two \n three\\\\\\\\four', // 2*8 backslashes.
   expr: '%s/,/\\\\\\\\\\\\\\\\/g'}); // 16 backslashes.
-testSubstitute('ex_substitute_dollar_match', {
+testSubstitute('ex_substitute_dollar_assertion', {
   value: 'one,two \n three,four',
-  expectedValue: 'one,two ,\n three,four',
+  expectedValue: 'one,two ,\n three,four', // TODO: should match at end of doc.
   expr: '%s/$/,/g'});
+testSubstitute('ex_substitute_dollar_literal', {
+  value: 'one$two\n$three\nfour$\n$',
+  expectedValue: 'one,two\n,three\nfour,\n,',
+  expr: '%s/\\$/,/g'});
 testSubstitute('ex_substitute_newline_match', {
   value: 'one,two \n three,four',
   expectedValue: 'one,two , three,four',


### PR DESCRIPTION
Fixes #6580

I seriously considered `if (regexPart === '$') {` since patterns like `/x$/` work better without the workaround (matches on last line).

I've opted to remove the useless calls to replace. Works fine as is and the flags ought to be saved, though they aren't currently.