### PR TITLE
Allow the omission of head in setSelections

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -1432,14 +1432,15 @@ editor.setOption("extraKeys", {
         stuck.</dd>
       </dl></dd>
 
-      <dt id="setSelections"><code><strong>doc.setSelections</strong>(ranges: array&lt;{anchor, head}&gt;, ?primary: integer, ?options: object)</code></dt>
+      <dt id="setSelections"><code><strong>doc.setSelections</strong>(ranges: array&lt;{anchor, ?head}&gt;, ?primary: integer, ?options: object)</code></dt>
       <dd>Sets a new set of selections. There must be at least one
       selection in the given array. When <code>primary</code> is a
       number, it determines which selection is the primary one. When
       it is not given, the primary index is taken from the previous
       selection, or set to the last range if the previous selection
       had less ranges than the new one. Supports the same options
-      as <a href="#setSelection"><code>setSelection</code></a>.</dd>
+      as <a href="#setSelection"><code>setSelection</code></a>.
+      <code>head</code> defaults to <code>anchor</code> when not given.</dd>
       <dt id="addSelection"><code><strong>doc.addSelection</strong>(anchor: {line, ch}, ?head: {line, ch})</code></dt>
       <dd>Adds a new selection to the existing set of selections, and
       makes it the primary selection.</dd>

--- a/src/model/Doc.js
+++ b/src/model/Doc.js
@@ -137,7 +137,7 @@ Doc.prototype = createObj(BranchChunk.prototype, {
     let out = []
     for (let i = 0; i < ranges.length; i++)
       out[i] = new Range(clipPos(this, ranges[i].anchor),
-                         clipPos(this, ranges[i].head))
+                         clipPos(this, ranges[i].head || ranges[i].anchor))
     if (primary == null) primary = Math.min(ranges.length - 1, this.sel.primIndex)
     setSelection(this, normalizeSelection(this.cm, out, primary), options)
   }),


### PR DESCRIPTION
This PR sets the default `head` to `anchor` in `setSelections()`, similar to `setSelection()`.
I think it should have been this way to ensure the API is consistent.

I'm more concerned about someone reading the latest docs but using an older version of CM that doesn't support this. Not sure how this is dealt with generally.