### PR TITLE
Allow empty cursor for VIM in contenteditable

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -302,11 +302,11 @@
           var lineLength = cm.getLine(range.anchor.line).length;
           if (range.anchor.ch < lineLength) {
             result.push(cm.markText(range.anchor, Pos(range.anchor.line, range.anchor.ch + 1),
-                                    {className: "cm-fat-cursor-mark"}));
+                                    {className: "cm-fat-cursor-mark", clearWhenEmpty: false}));
           } else {
             result.push(cm.markText(Pos(range.anchor.line, lineLength - 1),
                                     Pos(range.anchor.line, lineLength),
-                                    {className: "cm-fat-cursor-mark"}));
+                                    {className: "cm-fat-cursor-mark", clearWhenEmpty: false}));
           }
         }
       }
@@ -5579,7 +5579,7 @@
         var widget = dom('span', { 'class': className }, '\u00a0');
         vim.fakeCursorBookmark = cm.setBookmark(from, {widget: widget});
       } else {
-        vim.fakeCursor = cm.markText(from, to, {className: className});
+        vim.fakeCursor = cm.markText(from, to, {className: className, clearWhenEmpty: false});
       }
     }
     function clearFakeCursor(vim) {


### PR DESCRIPTION
Quick change to allow a vim cursor on empty lines in contenteditable mode, by enabling `clearWhenEmpty: false` for the call to markText.

Fixes: #6312 and #6393 
