### PR TITLE
[lua mode] use electricInput to automatically dedent

### DIFF
--- a/mode/lua/lua.js
+++ b/mode/lua/lua.js
@@ -148,6 +148,7 @@ CodeMirror.defineMode("lua", function(config, parserConfig) {
       return state.basecol + indentUnit * (state.indentDepth - (closing ? 1 : 0));
     },
 
+    electricInput: /^\s*(?:end|until|else|\)|\})$/,
     lineComment: "--",
     blockCommentStart: "--[[",
     blockCommentEnd: "]]"


### PR DESCRIPTION
It's inconvenient to have to manually dedent lines after typing `end` or `else`.  Note that `elseif` is also covered by this pattern, as `else` is a prefix of it.