### PR TITLE
Remove option-based emacsy key bindings

### DIFF
--- a/src/input/keymap.js
+++ b/src/input/keymap.js
@@ -29,10 +29,9 @@ keyMap.pcDefault = {
 // Very basic readline/emacs-style bindings, which are standard on Mac.
 keyMap.emacsy = {
   "Ctrl-F": "goCharRight", "Ctrl-B": "goCharLeft", "Ctrl-P": "goLineUp", "Ctrl-N": "goLineDown",
-  "Alt-F": "goWordRight", "Alt-B": "goWordLeft", "Ctrl-A": "goLineStart", "Ctrl-E": "goLineEnd",
-  "Ctrl-V": "goPageDown", "Shift-Ctrl-V": "goPageUp", "Ctrl-D": "delCharAfter", "Ctrl-H": "delCharBefore",
-  "Alt-D": "delWordAfter", "Alt-Backspace": "delWordBefore", "Ctrl-K": "killLine", "Ctrl-T": "transposeChars",
-  "Ctrl-O": "openLine"
+  "Ctrl-A": "goLineStart", "Ctrl-E": "goLineEnd", "Ctrl-V": "goPageDown", "Shift-Ctrl-V": "goPageUp",
+  "Ctrl-D": "delCharAfter", "Ctrl-H": "delCharBefore", "Alt-Backspace": "delWordBefore", "Ctrl-K": "killLine",
+  "Ctrl-T": "transposeChars", "Ctrl-O": "openLine"
 }
 keyMap.macDefault = {
   "Cmd-A": "selectAll", "Cmd-D": "deleteLine", "Cmd-Z": "undo", "Shift-Cmd-Z": "redo", "Cmd-Y": "redo",


### PR DESCRIPTION
Fixes https://github.com/codemirror/CodeMirror/issues/6630

Removes `Alt-D`, `Alt-F` and `Alt-B` from the default `emacsy` key bindings, which is enabled by default on macOS.

> A PR that moves those from `emacsy` to the proper emacs map in `keymap/emacs.js` would be very welcome.

It seems like these three are already implemented in `keymap/emacs.js`
https://github.com/codemirror/CodeMirror/blob/8bc57f76383e62e1a03c7d97c9eac74493fdbedc/keymap/emacs.js#L309
https://github.com/codemirror/CodeMirror/blob/8bc57f76383e62e1a03c7d97c9eac74493fdbedc/keymap/emacs.js#L311