### PR TITLE
[runmode] Pass the mode object to the callback

### DIFF
--- a/addon/runmode/runmode.js
+++ b/addon/runmode/runmode.js
@@ -67,7 +67,7 @@ CodeMirror.runMode = function(string, modespec, callback, options) {
     if (!stream.string && mode.blankLine) mode.blankLine(state);
     while (!stream.eol()) {
       var style = mode.token(stream, state);
-      callback(stream.current(), style, i, stream.start, state);
+      callback(stream.current(), style, i, stream.start, state, mode);
       stream.start = stream.pos;
     }
   }


### PR DESCRIPTION
Without the mode object, it's not possible to call the mode's `indent` method to compute how much a given line should be indented (which we now have a need to do in a standalone way).

<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
