### PR TITLE
Send new "updateGutter" signal on gutter resize

### DIFF
--- a/src/display/update_display.js
+++ b/src/display/update_display.js
@@ -5,6 +5,7 @@ import { displayHeight, displayWidth, getDimensions, paddingVert, scrollGap } fr
 import { mac, webkit } from "../util/browser.js"
 import { activeElt, removeChildren, contains } from "../util/dom.js"
 import { hasHandler, signal } from "../util/event.js"
+import { signalLater } from "../util/operation_group.js"
 import { indexOf } from "../util/misc.js"
 
 import { buildLineElement, updateLineForChanges } from "./update_line.js"
@@ -254,6 +255,8 @@ function patchDisplay(cm, updateNumbersFrom, dims) {
 export function updateGutterSpace(display) {
   let width = display.gutters.offsetWidth
   display.sizer.style.marginLeft = width + "px"
+  // Send an event to consumers responding to changes in gutter width.
+  signalLater(display, "gutterChanged", display)
 }
 
 export function setDocumentHeight(cm, measure) {


### PR DESCRIPTION
Some consumers need to know when the gutter width changes.  For
example, the MediaWiki Visual Editor maintains a transparent overlay
that must line up with the CodeMirror text area.  When line numbering
is enabled, the gutter will automatically resize as content grows
beyond 1,000 lines (and 10,000, etc.).  This shifts the text area,
and we need to recalculate position using
`display.gutters.offsetWidth`.