### PR TITLE
tweak to regex for dots in R

### DIFF
--- a/mode/r/r.js
+++ b/mode/r/r.js
@@ -54,7 +54,7 @@ CodeMirror.defineMode("r", function(config) {
     } else if (ch == "`") {
       stream.match(/[^`]+`/);
       return "variable-3";
-    } else if (ch == "." && stream.match(/.[.\d]+/)) {
+    } else if (ch == "." && stream.match(/.(?:[.]|\d+)/)) {
       return "keyword";
     } else if (/[\w\.]/.test(ch) && ch != "_") {
       stream.eatWhile(/[\w\.]/);


### PR DESCRIPTION
See https://stat.ethz.ch/R-manual/R-devel/library/base/html/dots.html and https://stat.ethz.ch/R-manual/R-devel/library/base/html/Reserved.html

Currently CodeMirror treats things like `..1.` and `...1` identically to `...`, `..1`, `..2`, etc.

The former two parse, but they parse as regular R objects per the naming rules seen e.g. here https://stat.ethz.ch/R-manual/R-devel/library/base/html/make.names.html

> A syntactically valid name consists of letters, numbers and the dot or underline characters and starts with a letter or the dot not followed by a number. Names such as ".2way" are not valid, and neither are the reserved words.

Please LMK if this should be tested, with the caveat that this is my first ever contribution to JS code so some hand-holding would be nice