### PR TITLE
remove extra test by restricting \w to exclude _ and 0-9

### DIFF
--- a/mode/r/r.js
+++ b/mode/r/r.js
@@ -56,7 +56,7 @@ CodeMirror.defineMode("r", function(config) {
       return "variable-3";
     } else if (ch == "." && stream.match(/.[.\d]+/)) {
       return "keyword";
-    } else if (/[\w\.]/.test(ch) && ch != "_") {
+    } else if (/[a-zA-Z\.]/.test(ch)) {
       stream.eatWhile(/[\w\.]/);
       var word = stream.current();
       if (atoms.propertyIsEnumerable(word)) return "atom";


### PR DESCRIPTION
The rule for starting a variable name is:

> A syntactically valid name consists of letters, numbers and the dot or underline characters and **starts with a letter or the dot not followed by a number**.

Per https://stat.ethz.ch/R-manual/R-devel/library/base/html/make.names.html

"dot not followed by a number" is handled by parsing numerics earlier