### PR TITLE
Fix shadow root contenteditable cursor edit bug

### DIFF
--- a/src/input/ContentEditableInput.js
+++ b/src/input/ContentEditableInput.js
@@ -10,7 +10,7 @@ import { simpleSelection } from "../model/selection.js"
 import { setSelection } from "../model/selection_updates.js"
 import { getBidiPartAt, getOrder } from "../util/bidi.js"
 import { android, chrome, gecko, ie_version } from "../util/browser.js"
-import { contains, range, removeChildrenAndAdd, selectInput } from "../util/dom.js"
+import { activeElt, contains, range, removeChildrenAndAdd, selectInput } from "../util/dom.js"
 import { on, signalDOMEvent } from "../util/event.js"
 import { Delayed, lst, sel_dontScroll } from "../util/misc.js"
 
@@ -96,7 +96,7 @@ export default class ContentEditableInput {
       let kludge = hiddenTextarea(), te = kludge.firstChild
       cm.display.lineSpace.insertBefore(kludge, cm.display.lineSpace.firstChild)
       te.value = lastCopied.text.join("\n")
-      let hadFocus = document.activeElement
+      let hadFocus = activeElt()
       selectInput(te)
       setTimeout(() => {
         cm.display.lineSpace.removeChild(kludge)
@@ -119,7 +119,7 @@ export default class ContentEditableInput {
 
   prepareSelection() {
     let result = prepareSelection(this.cm, false)
-    result.focus = document.activeElement == this.div
+    result.focus = activeElt() == this.div
     return result
   }
 
@@ -213,7 +213,7 @@ export default class ContentEditableInput {
 
   focus() {
     if (this.cm.options.readOnly != "nocursor") {
-      if (!this.selectionInEditor() || document.activeElement != this.div)
+      if (!this.selectionInEditor() || activeElt() != this.div)
         this.showSelection(this.prepareSelection(), true)
       this.div.focus()
     }


### PR DESCRIPTION
Fixes bug where the cursor always jumps back to the first character of the line after each key input. This happens when using `contenteditable` mode within a shadow root.

#### Repro link

https://jsbin.com/jujuxux/edit?html,output

#### Explanation

CM5's `contenteditable` mode uses `document.activeElement` to access the current focus state of the editor and put the cursor in the correct place after an edit. However, when the input element is located within a [shadow root](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot), then `document.activeElement` is not the focused editor element itself, instead it is the host element in the document scope that *contains* the focused editor element. This causes some confusion that ends up placing the cursor back on the start of the line after each edit.

This PR replaces use of `document.activeElement` with the existing `activeElt` utility function, which traverses through shadow roots to address this issue, and is already used in all other modules that look for the active element.

#### Repro source

```html
<script type="module">
import 'https://unpkg.com/codemirror@5.60.0/lib/codemirror.js';

const shadowHost = document.createElement('div');
const shadowRoot = shadowHost.attachShadow({mode: "open"});
document.body.appendChild(shadowHost);

const scopedStyle = document.createElement('link');
scopedStyle.rel = 'stylesheet';
scopedStyle.href = 'https://unpkg.com/codemirror@5.60.0/lib/codemirror.css';
shadowRoot.appendChild(scopedStyle);

CodeMirror(shadowRoot, {
  inputStyle: 'contenteditable',
  value: `edit me`,
});
</script>
```