### PR TITLE
Prevent line numbers from being voiced by screen readers

### DIFF
--- a/src/display/update_line.js
+++ b/src/display/update_line.js
@@ -104,6 +104,7 @@ function updateLineGutter(cm, lineView, lineN, dims) {
   if (cm.options.lineNumbers || markers) {
     let wrap = ensureLineWrapped(lineView)
     let gutterWrap = lineView.gutter = elt("div", null, "CodeMirror-gutter-wrapper", `left: ${cm.options.fixedGutter ? dims.fixedPos : -dims.gutterTotalWidth}px`)
+    gutterWrap.setAttribute("aria-hidden", "true")
     cm.display.input.setUneditable(gutterWrap)
     wrap.insertBefore(gutterWrap, lineView.text)
     if (lineView.line.gutterClass)


### PR DESCRIPTION
Prevent line numbers from being voiced by screen readers.

Sets `aria-hidden=true` on `.CodeMirror-gutter-wrapper` elements.

Tested with Voice Over on Chrome.

Fixes #6578
