### PR TITLE
[runmode] Export countColumn on the minimal CodeMirror

### DIFF
--- a/src/addon/runmode/codemirror-standalone.js
+++ b/src/addon/runmode/codemirror-standalone.js
@@ -1,4 +1,5 @@
 import StringStream from "../../util/StringStream.js"
+import { countColumn } from "../../util/misc.js"
 import * as modeMethods from "../../modes.js"
 
 // declare global: globalThis, CodeMirror
@@ -17,6 +18,7 @@ CodeMirror.defineMIME("text/plain", "null")
 
 CodeMirror.registerHelper = CodeMirror.registerGlobalHelper = Math.min
 CodeMirror.splitLines = function(string) { return string.split(/\r?\n|\r/) }
+CodeMirror.countColumn = countColumn
 
 CodeMirror.defaults = { indentUnit: 2 }
 export default CodeMirror


### PR DESCRIPTION
This is needed e.g. for the google-modes to produce correct indentation.

<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
