### PR TITLE
Allow an exclamation point at start of variable

### DIFF
--- a/mode/velocity/velocity.js
+++ b/mode/velocity/velocity.js
@@ -82,6 +82,7 @@ CodeMirror.defineMode("velocity", function() {
         }
         // variable?
         else if (ch == "$") {
+            stream.eat("!");
             stream.eatWhile(/[\w\d\$_\.{}-]/);
             // is it one of the specials?
             if (specials && specials.propertyIsEnumerable(stream.current())) {


### PR DESCRIPTION
The exclamation point at the start of a variable makes it 'silent' (it's wont be printed in case it is null)
See: http://velocity.apache.org/engine/devel/vtl-reference.html#variables
