### PR TITLE
[abbott.vim theme] Fix -moz-selection syntax error

### DIFF
--- a/theme/abbott.css
+++ b/theme/abbott.css
@@ -112,7 +112,7 @@
 }
 .cm-s-abbott .CodeMirror-line::-moz-selection,
 .cm-s-abbott .CodeMirror-line > span::-moz-selection,
-.cm-s-abbott .CodeMirror-line > span > span::-moz-selection*/ {
+.cm-s-abbott .CodeMirror-line > span > span::-moz-selection {
   background: #273900 /* dark_olive */;
 }
 


### PR DESCRIPTION
I'm sorry, it seems there's a syntax error in the theme that was merged in PR #6677. Just sending a quick fix for that. (I didn't catch this previously because I only tested the theme in browsers that also support the standard `::selection` pseudoelement, so the broken `::-moz-selection` rule didn't cause any visible issues.)

I ran abbott.css through the CSS validator to check for any more errors, and it validates successfully after this change.