### PR TITLE
Fix `%` highlight in Crystal

### DIFF
--- a/mode/crystal/crystal.js
+++ b/mode/crystal/crystal.js
@@ -164,10 +164,10 @@
         } else {
           if(delim = stream.match(/^%([^\w\s=])/)) {
             delim = delim[1];
-          } else if (stream.match(/^%[a-zA-Z0-9_\u009F-\uFFFF]*/)) {
+          } else if (stream.match(/^%[a-zA-Z_\u009F-\uFFFF][\w\u009F-\uFFFF]*/)) {
             // Macro variables
             return "meta";
-          } else {
+          } else if (stream.eat('%')) {
             // '%' operator
             return "operator";
           }


### PR DESCRIPTION
Fixed #6675

![スクリーンショット 2021-05-09 12 49 16](https://user-images.githubusercontent.com/6679325/117560095-c8de7480-b0c5-11eb-8561-d16acfbb1bb8.png)

Note that the last one `5%a` is not fixed, because it is hard. Please see https://github.com/codemirror/CodeMirror/issues/6675#issuecomment-835658444.

Thank you.