### PR TITLE
Fixes the syntax highlighting of TypeScript that broke after the exclamation mark

### DIFF
--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -799,6 +799,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (value == "@") return cont(expression, classBody)
   }
   function classfield(type, value) {
+    if (value == "!") return cont(classfield)
     if (value == "?") return cont(classfield)
     if (type == ":") return cont(typeexpr, maybeAssign)
     if (value == "=") return cont(expressionNoComma)


### PR DESCRIPTION
Syntax highlighting of TypeScript broke after encountering the first exclamation mark (Non-Null Assertion Operator).

Before:
![Screen Shot 2021-05-12 at 4 40 21 PM](https://user-images.githubusercontent.com/23285565/117988262-ea4c9400-b343-11eb-8e3f-334e452f3e0a.png)

After:
![Screen Shot 2021-05-12 at 5 03 37 PM](https://user-images.githubusercontent.com/23285565/117988365-02bcae80-b344-11eb-9b9c-8f7454636e4a.png)
