### PR TITLE
[core] fix n^2 code path in marking text

### DIFF
--- a/src/line/spans.js
+++ b/src/line/spans.js
@@ -28,7 +28,11 @@ export function removeMarkedSpan(spans, span) {
 }
 // Add a span to a line.
 export function addMarkedSpan(line, span) {
-  line.markedSpans = line.markedSpans ? line.markedSpans.concat([span]) : [span]
+  if (line.markedSpans) {
+    line.markedSpans.push(span)
+  } else {
+    line.markedSpans = [span]
+  }
   span.marker.attachLine(line)
 }
 


### PR DESCRIPTION
This caused some unnecessary slowdowns and GCs when adding many (thousands) of text markers. I looked around and couldn't find anything relying on new versions of the markedSpans array needing to be referentially different, but I could have missed something.

<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
