### PR TITLE
fix link from the documentation pointing to old mustache doc url

### DIFF
--- a/demo/mustache.html
+++ b/demo/mustache.html
@@ -61,7 +61,7 @@ var editor = CodeMirror.fromTextArea(document.getElementById("code"), {mode: "mu
 </script>
 
     <p>Demonstration of a mode that parses HTML, highlighting
-    the <a href="http://mustache.github.com/">Mustache</a> templating
+    the <a href="http://mustache.github.io/">Mustache</a> templating
     directives inside of it by using the code
     in <a href="../addon/mode/overlay.js"><code>overlay.js</code></a>. View
     source to see the 15 lines of code needed to accomplish this.</p>


### PR DESCRIPTION
fix a documentation link to point to new mustache documentation URL replacing `mustache.github.io` instead of `mustache.github.com` (which return a 404 as of today).