### PR TITLE
fix: [lint] exits early if required state is not present

### DIFF
--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -140,7 +140,9 @@
   }
 
   function startLinting(cm) {
-    var state = cm.state.lint, options = state.options;
+    var state = cm.state.lint;
+    if (!state) return;
+    var options = state.options;
     /*
      * Passing rules in `options` property prevents JSHint (and other linters) from complaining
      * about unrecognized rules like `onUpdateLinting`, `delay`, `lintOnChange`, etc.
@@ -161,8 +163,10 @@
   }
 
   function updateLinting(cm, annotationsNotSorted) {
+    var state = cm.state.lint;
+    if (!state) return;
+    var options = state.options;
     clearMarks(cm);
-    var state = cm.state.lint, options = state.options;
 
     var annotations = groupByLine(annotationsNotSorted);
 
@@ -254,6 +258,6 @@
   });
 
   CodeMirror.defineExtension("performLint", function() {
-    if (this.state.lint) startLinting(this);
+    startLinting(this);
   });
 });


### PR DESCRIPTION
Over on https://github.com/Kong/insomnia/, we've been getting this error on codemirror.  It appears to be (ultimately) due to a missing check for `state.lint` being present.  Sometimes it's there, sometimes it isn't.

![Screenshot_20210519_150136](https://user-images.githubusercontent.com/15232461/118875917-a1a05800-b8ba-11eb-90de-9d5827969562.png)

This PR fixes this bug.