### PR TITLE
feat: Highlight a row when lint caused error

### DIFF
--- a/addon/lint/lint.css
+++ b/addon/lint/lint.css
@@ -69,3 +69,7 @@
   background-position: right bottom;
   width: 100%; height: 100%;
 }
+
+.CodeMirror-lint-row-error {
+  background-color: rgba(183, 76, 81, 0.08);
+}

--- a/addon/lint/lint.css
+++ b/addon/lint/lint.css
@@ -70,6 +70,6 @@
   width: 100%; height: 100%;
 }
 
-.CodeMirror-lint-row-error {
+.CodeMirror-lint-line-error {
   background-color: rgba(183, 76, 81, 0.08);
 }

--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -11,6 +11,7 @@
 })(function(CodeMirror) {
   "use strict";
   var GUTTER_ID = "CodeMirror-lint-markers";
+  var LINT_ROW_ID = "CodeMirror-lint-row-error";
 
   function showTooltip(cm, e, content) {
     var tt = document.createElement("div");
@@ -75,7 +76,12 @@
 
   function clearMarks(cm) {
     var state = cm.state.lint;
-    if (state.hasGutter) cm.clearGutter(GUTTER_ID);
+    if (state.hasGutter) {
+      cm.clearGutter(GUTTER_ID);
+      for(var k = 0; k < cm.doc.size; k++) {
+        cm.removeLineClass(k, 'wrap', LINT_ROW_ID);
+      }
+    }
     for (var i = 0; i < state.marked.length; ++i)
       state.marked[i].clear();
     state.marked.length = 0;
@@ -196,9 +202,11 @@
         }));
       }
       // use original annotations[line] to show multiple messages
-      if (state.hasGutter)
+      if (state.hasGutter) {
         cm.setGutterMarker(line, GUTTER_ID, makeMarker(cm, tipLabel, maxSeverity, annotations[line].length > 1,
                                                        state.options.tooltips));
+        cm.addLineClass(line, 'wrap', LINT_ROW_ID);
+      }
     }
     if (options.onUpdateLinting) options.onUpdateLinting(annotationsNotSorted, annotations, cm);
   }

--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -11,7 +11,7 @@
 })(function(CodeMirror) {
   "use strict";
   var GUTTER_ID = "CodeMirror-lint-markers";
-  var LINT_ROW_ID = "CodeMirror-lint-row-error";
+  var LINT_ROW_ID = "CodeMirror-lint-line-error";
 
   function showTooltip(cm, e, content) {
     var tt = document.createElement("div");
@@ -78,13 +78,31 @@
     var state = cm.state.lint;
     if (state.hasGutter) {
       cm.clearGutter(GUTTER_ID);
-      for(var k = 0; k < cm.doc.size; k++) {
-        cm.removeLineClass(k, 'wrap', LINT_ROW_ID);
-      }
+    }
+    if (isHighlightErrorLinesEnabled(state)) {
+      clearErrorLines(cm);
     }
     for (var i = 0; i < state.marked.length; ++i)
       state.marked[i].clear();
     state.marked.length = 0;
+  }
+
+  function clearErrorLines(cm) {
+    for (var k = 0; k < cm.doc.size; k++) {
+      removeErrorLine(k, cm);
+    }
+  }
+
+  function isHighlightErrorLinesEnabled(state) {
+    return state.marked.length > 0 && state.options.highlightErrorLines;
+  }
+
+  function removeErrorLine(index, cm) {
+    cm.removeLineClass(index, 'wrap', LINT_ROW_ID);
+  }
+
+  function addErrorLine(index, cm) {
+    cm.addLineClass(index, 'wrap', LINT_ROW_ID);
   }
 
   function makeMarker(cm, labels, severity, multiple, tooltips) {
@@ -205,7 +223,10 @@
       if (state.hasGutter) {
         cm.setGutterMarker(line, GUTTER_ID, makeMarker(cm, tipLabel, maxSeverity, annotations[line].length > 1,
                                                        state.options.tooltips));
-        cm.addLineClass(line, 'wrap', LINT_ROW_ID);
+      }
+
+      if (isHighlightErrorLinesEnabled(state)) {
+        addErrorLine(line, cm);
       }
     }
     if (options.onUpdateLinting) options.onUpdateLinting(annotationsNotSorted, annotations, cm);

--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -88,13 +88,13 @@
   }
 
   function clearErrorLines(cm) {
-    for (var k = 0; k < cm.doc.size; k++) {
-      removeErrorLine(k, cm);
+    for (var i = cm.firstLine(), j = cm.lastLine(); i < j; i++) {
+      removeErrorLine(i, cm);
     }
   }
 
   function isHighlightErrorLinesEnabled(state) {
-    return state.marked.length > 0 && state.options.highlightErrorLines;
+    return state.options.highlightErrorLines;
   }
 
   function removeErrorLine(index, cm) {


### PR DESCRIPTION
When linter shows errors, there is no way to highlight the whole row
I'm able to set icon only
![image](https://user-images.githubusercontent.com/1669881/121187025-aed8b300-c878-11eb-9c27-8f23f93abb3e.png)


I would like to have a possibility to highlight the whole row, like:
![image](https://user-images.githubusercontent.com/1669881/121186706-6d480800-c878-11eb-99cd-d74e63545918.png)
