### PR TITLE
bugfix: highlight line by severity code

### DIFF
--- a/addon/lint/lint.css
+++ b/addon/lint/lint.css
@@ -70,6 +70,10 @@
   width: 100%; height: 100%;
 }
 
-.CodeMirror-lint-line {
+.CodeMirror-lint-line-error {
   background-color: rgba(183, 76, 81, 0.08);
+}
+
+.CodeMirror-lint-line-warning {
+  background-color: rgba(255, 211, 0, 0.1);
 }

--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -11,7 +11,7 @@
 })(function(CodeMirror) {
   "use strict";
   var GUTTER_ID = "CodeMirror-lint-markers";
-  var LINT_ROW_ID = "CodeMirror-lint-line";
+  var LINT_LINE_ID = "CodeMirror-lint-line-";
 
   function showTooltip(cm, e, content) {
     var tt = document.createElement("div");
@@ -84,12 +84,38 @@
   }
 
   function clearErrorLines(cm) {
-    for (var i = cm.firstLine(), j = cm.lastLine(); i <= j; i++)
-      cm.removeLineClass(i, "wrap", LINT_ROW_ID);
+    for (var i = cm.firstLine(), j = cm.lastLine(); i < j; i++) {
+      var wrapClass = cm.lineInfo(i).wrapClass;
+
+      if (wrapClass) {
+        removeErrorLine(i, cm, wrapClass);
+      }
+    }
   }
 
   function isHighlightErrorLinesEnabled(state) {
     return state.options.highlightLines;
+  }
+
+  function findLintLineCssClass(wrapClass) {
+    var lintLineClass = '';
+    wrapClass.split(' ').forEach(function (cssClass) {
+      if (cssClass.indexOf(LINT_LINE_ID) > -1) {
+        lintLineClass = cssClass;
+      }
+    });
+
+    return lintLineClass;
+  }
+
+  function removeErrorLine(index, cm, wrapClass) {
+    var lintLineClass = findLintLineCssClass(wrapClass);
+
+    if (!lintLineClass) {
+      return;
+    }
+
+    cm.removeLineClass(index, 'wrap', lintLineClass);
   }
 
   function makeMarker(cm, labels, severity, multiple, tooltips) {
@@ -212,7 +238,7 @@
                                                        state.options.tooltips));
 
       if (isHighlightErrorLinesEnabled(state))
-        cm.addLineClass(line, "wrap", LINT_ROW_ID);
+        cm.addLineClass(line, "wrap", LINT_LINE_ID + maxSeverity);
     }
     if (options.onUpdateLinting) options.onUpdateLinting(annotationsNotSorted, annotations, cm);
   }

--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -99,11 +99,13 @@
 
   function findLintLineCssClass(wrapClass) {
     var lintLineClass = '';
-    wrapClass.split(' ').forEach(function (cssClass) {
+    var classes = wrapClass.split(' ');
+    for (var i = 0, clsLength = classes.length; i < clsLength; i++) {
+      var cssClass = classes[i];
       if (cssClass.indexOf(LINT_LINE_ID) > -1) {
         lintLineClass = cssClass;
       }
-    });
+    }
 
     return lintLineClass;
   }


### PR DESCRIPTION
There is alway "red" lines for linter even "warning" message:
![image](https://user-images.githubusercontent.com/1669881/121802090-e1552800-cc4b-11eb-8c5c-16ac093835d3.png)

Expected result:
![image](https://user-images.githubusercontent.com/1669881/121802116-0ba6e580-cc4c-11eb-8455-5c6b3f6d5e49.png)
