### PR TITLE
Changed Cursor color in some themes 

### DIFF
--- a/theme/ayu-dark.css
+++ b/theme/ayu-dark.css
@@ -40,3 +40,10 @@
   text-decoration: underline;
   color: white !important;
 }
+
+/* changing cursor color in vim mode */
+.CodeMirror-cursor { background-color: #a2a8a175 !important; }
+
+.CodeMirror-cursors { background-color: #a2a8a175 !important; }
+
+.cm-animate-fat-cursor { background-color: #a2a8a175 !important; }

--- a/theme/ayu-dark.css
+++ b/theme/ayu-dark.css
@@ -42,8 +42,5 @@
 }
 
 /* changing cursor color in vim mode */
-.CodeMirror-cursor { background-color: #a2a8a175 !important; }
-
-.CodeMirror-cursors { background-color: #a2a8a175 !important; }
-
-.cm-animate-fat-cursor { background-color: #a2a8a175 !important; }
+.cm-s-ayu-dark .CodeMirror-cursor { background-color: #a2a8a175 !important; }
+.cm-s-ayu-dark .cm-animate-fat-cursor { background-color: #a2a8a175 !important; }

--- a/theme/ayu-dark.css
+++ b/theme/ayu-dark.css
@@ -1,123 +1,42 @@
 /* Based on https://github.com/dempfi/ayu */
 
-.cm-s-ayu-dark.CodeMirror {
-  background: #0a0e14;
-  color: #b3b1ad;
-}
-.cm-s-ayu-dark div.CodeMirror-selected {
-  background: #273747;
-}
-.cm-s-ayu-dark .CodeMirror-line::selection,
-.cm-s-ayu-dark .CodeMirror-line > span::selection,
-.cm-s-ayu-dark .CodeMirror-line > span > span::selection {
-  background: rgba(39, 55, 71, 99);
-}
-.cm-s-ayu-dark .CodeMirror-line::-moz-selection,
-.cm-s-ayu-dark .CodeMirror-line > span::-moz-selection,
-.cm-s-ayu-dark .CodeMirror-line > span > span::-moz-selection {
-  background: rgba(39, 55, 71, 99);
-}
-.cm-s-ayu-dark .CodeMirror-gutters {
-  background: #0a0e14;
-  border-right: 0px;
-}
-.cm-s-ayu-dark .CodeMirror-guttermarker {
-  color: white;
-}
-.cm-s-ayu-dark .CodeMirror-guttermarker-subtle {
-  color: #3d424d;
-}
-.cm-s-ayu-dark .CodeMirror-linenumber {
-  color: #3d424d;
-}
-.cm-s-ayu-dark .CodeMirror-cursor {
-  border-left: 1px solid #e6b450;
-}
+.cm-s-ayu-dark.CodeMirror { background: #0a0e14; color: #b3b1ad; }
+.cm-s-ayu-dark div.CodeMirror-selected { background: #273747; }
+.cm-s-ayu-dark .CodeMirror-line::selection, .cm-s-ayu-dark .CodeMirror-line > span::selection, .cm-s-ayu-dark .CodeMirror-line > span > span::selection { background: rgba(39, 55, 71, 99); }
+.cm-s-ayu-dark .CodeMirror-line::-moz-selection, .cm-s-ayu-dark .CodeMirror-line > span::-moz-selection, .cm-s-ayu-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(39, 55, 71, 99); }
+.cm-s-ayu-dark .CodeMirror-gutters { background: #0a0e14; border-right: 0px; }
+.cm-s-ayu-dark .CodeMirror-guttermarker { color: white; }
+.cm-s-ayu-dark .CodeMirror-guttermarker-subtle { color: #3d424d; }
+.cm-s-ayu-dark .CodeMirror-linenumber { color: #3d424d; }
+.cm-s-ayu-dark .CodeMirror-cursor { border-left: 1px solid #e6b450; }
 
-.cm-s-ayu-dark span.cm-comment {
-  color: #626a73;
-}
-.cm-s-ayu-dark span.cm-atom {
-  color: #ae81ff;
-}
-.cm-s-ayu-dark span.cm-number {
-  color: #e6b450;
-}
+.cm-s-ayu-dark span.cm-comment { color: #626a73; }
+.cm-s-ayu-dark span.cm-atom { color: #ae81ff; }
+.cm-s-ayu-dark span.cm-number { color: #e6b450; }
 
-.cm-s-ayu-dark span.cm-comment.cm-attribute {
-  color: #ffb454;
-}
-.cm-s-ayu-dark span.cm-comment.cm-def {
-  color: rgba(57, 186, 230, 80);
-}
-.cm-s-ayu-dark span.cm-comment.cm-tag {
-  color: #39bae6;
-}
-.cm-s-ayu-dark span.cm-comment.cm-type {
-  color: #5998a6;
-}
+.cm-s-ayu-dark span.cm-comment.cm-attribute { color: #ffb454; }
+.cm-s-ayu-dark span.cm-comment.cm-def { color: rgba(57, 186, 230, 80); }
+.cm-s-ayu-dark span.cm-comment.cm-tag { color: #39bae6; }
+.cm-s-ayu-dark span.cm-comment.cm-type { color: #5998a6; }
 
-.cm-s-ayu-dark span.cm-property,
-.cm-s-ayu-dark span.cm-attribute {
-  color: #ffb454;
-}
-.cm-s-ayu-dark span.cm-keyword {
-  color: #ff8f40;
-}
-.cm-s-ayu-dark span.cm-builtin {
-  color: #e6b450;
-}
-.cm-s-ayu-dark span.cm-string {
-  color: #c2d94c;
-}
+.cm-s-ayu-dark span.cm-property, .cm-s-ayu-dark span.cm-attribute { color: #ffb454; }  
+.cm-s-ayu-dark span.cm-keyword { color: #ff8f40; } 
+.cm-s-ayu-dark span.cm-builtin { color: #e6b450; }
+.cm-s-ayu-dark span.cm-string { color: #c2d94c; }
 
-.cm-s-ayu-dark span.cm-variable {
-  color: #b3b1ad;
-}
-.cm-s-ayu-dark span.cm-variable-2 {
-  color: #f07178;
-}
-.cm-s-ayu-dark span.cm-variable-3 {
-  color: #39bae6;
-}
-.cm-s-ayu-dark span.cm-type {
-  color: #ff8f40;
-}
-.cm-s-ayu-dark span.cm-def {
-  color: #ffee99;
-}
-.cm-s-ayu-dark span.cm-bracket {
-  color: #f8f8f2;
-}
-.cm-s-ayu-dark span.cm-tag {
-  color: rgba(57, 186, 230, 80);
-}
-.cm-s-ayu-dark span.cm-header {
-  color: #c2d94c;
-}
-.cm-s-ayu-dark span.cm-link {
-  color: #39bae6;
-}
-.cm-s-ayu-dark span.cm-error {
-  color: #ff3333;
-}
+.cm-s-ayu-dark span.cm-variable { color: #b3b1ad; }
+.cm-s-ayu-dark span.cm-variable-2 { color: #f07178; }
+.cm-s-ayu-dark span.cm-variable-3 { color: #39bae6; }
+.cm-s-ayu-dark span.cm-type { color: #ff8f40; }
+.cm-s-ayu-dark span.cm-def { color: #ffee99; }
+.cm-s-ayu-dark span.cm-bracket { color: #f8f8f2; }
+.cm-s-ayu-dark span.cm-tag { color: rgba(57, 186, 230, 80); }
+.cm-s-ayu-dark span.cm-header { color: #c2d94c; }
+.cm-s-ayu-dark span.cm-link { color: #39bae6; }
+.cm-s-ayu-dark span.cm-error { color: #ff3333; } 
 
-.cm-s-ayu-dark .CodeMirror-activeline-background {
-  background: #01060e;
-}
+.cm-s-ayu-dark .CodeMirror-activeline-background { background: #01060e; }
 .cm-s-ayu-dark .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;
-}
-
-.CodeMirror-cursor {
-  background-color: #a2a8a175 !important;
-}
-
-.CodeMirror-cursors {
-  background-color: #a2a8a175 !important;
-}
-
-.cm-animate-fat-cursor {
-  background-color: #a2a8a175 !important;
 }

--- a/theme/ayu-dark.css
+++ b/theme/ayu-dark.css
@@ -1,42 +1,123 @@
 /* Based on https://github.com/dempfi/ayu */
 
-.cm-s-ayu-dark.CodeMirror { background: #0a0e14; color: #b3b1ad; }
-.cm-s-ayu-dark div.CodeMirror-selected { background: #273747; }
-.cm-s-ayu-dark .CodeMirror-line::selection, .cm-s-ayu-dark .CodeMirror-line > span::selection, .cm-s-ayu-dark .CodeMirror-line > span > span::selection { background: rgba(39, 55, 71, 99); }
-.cm-s-ayu-dark .CodeMirror-line::-moz-selection, .cm-s-ayu-dark .CodeMirror-line > span::-moz-selection, .cm-s-ayu-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(39, 55, 71, 99); }
-.cm-s-ayu-dark .CodeMirror-gutters { background: #0a0e14; border-right: 0px; }
-.cm-s-ayu-dark .CodeMirror-guttermarker { color: white; }
-.cm-s-ayu-dark .CodeMirror-guttermarker-subtle { color: #3d424d; }
-.cm-s-ayu-dark .CodeMirror-linenumber { color: #3d424d; }
-.cm-s-ayu-dark .CodeMirror-cursor { border-left: 1px solid #e6b450; }
+.cm-s-ayu-dark.CodeMirror {
+  background: #0a0e14;
+  color: #b3b1ad;
+}
+.cm-s-ayu-dark div.CodeMirror-selected {
+  background: #273747;
+}
+.cm-s-ayu-dark .CodeMirror-line::selection,
+.cm-s-ayu-dark .CodeMirror-line > span::selection,
+.cm-s-ayu-dark .CodeMirror-line > span > span::selection {
+  background: rgba(39, 55, 71, 99);
+}
+.cm-s-ayu-dark .CodeMirror-line::-moz-selection,
+.cm-s-ayu-dark .CodeMirror-line > span::-moz-selection,
+.cm-s-ayu-dark .CodeMirror-line > span > span::-moz-selection {
+  background: rgba(39, 55, 71, 99);
+}
+.cm-s-ayu-dark .CodeMirror-gutters {
+  background: #0a0e14;
+  border-right: 0px;
+}
+.cm-s-ayu-dark .CodeMirror-guttermarker {
+  color: white;
+}
+.cm-s-ayu-dark .CodeMirror-guttermarker-subtle {
+  color: #3d424d;
+}
+.cm-s-ayu-dark .CodeMirror-linenumber {
+  color: #3d424d;
+}
+.cm-s-ayu-dark .CodeMirror-cursor {
+  border-left: 1px solid #e6b450;
+}
 
-.cm-s-ayu-dark span.cm-comment { color: #626a73; }
-.cm-s-ayu-dark span.cm-atom { color: #ae81ff; }
-.cm-s-ayu-dark span.cm-number { color: #e6b450; }
+.cm-s-ayu-dark span.cm-comment {
+  color: #626a73;
+}
+.cm-s-ayu-dark span.cm-atom {
+  color: #ae81ff;
+}
+.cm-s-ayu-dark span.cm-number {
+  color: #e6b450;
+}
 
-.cm-s-ayu-dark span.cm-comment.cm-attribute { color: #ffb454; }
-.cm-s-ayu-dark span.cm-comment.cm-def { color: rgba(57, 186, 230, 80); }
-.cm-s-ayu-dark span.cm-comment.cm-tag { color: #39bae6; }
-.cm-s-ayu-dark span.cm-comment.cm-type { color: #5998a6; }
+.cm-s-ayu-dark span.cm-comment.cm-attribute {
+  color: #ffb454;
+}
+.cm-s-ayu-dark span.cm-comment.cm-def {
+  color: rgba(57, 186, 230, 80);
+}
+.cm-s-ayu-dark span.cm-comment.cm-tag {
+  color: #39bae6;
+}
+.cm-s-ayu-dark span.cm-comment.cm-type {
+  color: #5998a6;
+}
 
-.cm-s-ayu-dark span.cm-property, .cm-s-ayu-dark span.cm-attribute { color: #ffb454; }  
-.cm-s-ayu-dark span.cm-keyword { color: #ff8f40; } 
-.cm-s-ayu-dark span.cm-builtin { color: #e6b450; }
-.cm-s-ayu-dark span.cm-string { color: #c2d94c; }
+.cm-s-ayu-dark span.cm-property,
+.cm-s-ayu-dark span.cm-attribute {
+  color: #ffb454;
+}
+.cm-s-ayu-dark span.cm-keyword {
+  color: #ff8f40;
+}
+.cm-s-ayu-dark span.cm-builtin {
+  color: #e6b450;
+}
+.cm-s-ayu-dark span.cm-string {
+  color: #c2d94c;
+}
 
-.cm-s-ayu-dark span.cm-variable { color: #b3b1ad; }
-.cm-s-ayu-dark span.cm-variable-2 { color: #f07178; }
-.cm-s-ayu-dark span.cm-variable-3 { color: #39bae6; }
-.cm-s-ayu-dark span.cm-type { color: #ff8f40; }
-.cm-s-ayu-dark span.cm-def { color: #ffee99; }
-.cm-s-ayu-dark span.cm-bracket { color: #f8f8f2; }
-.cm-s-ayu-dark span.cm-tag { color: rgba(57, 186, 230, 80); }
-.cm-s-ayu-dark span.cm-header { color: #c2d94c; }
-.cm-s-ayu-dark span.cm-link { color: #39bae6; }
-.cm-s-ayu-dark span.cm-error { color: #ff3333; } 
+.cm-s-ayu-dark span.cm-variable {
+  color: #b3b1ad;
+}
+.cm-s-ayu-dark span.cm-variable-2 {
+  color: #f07178;
+}
+.cm-s-ayu-dark span.cm-variable-3 {
+  color: #39bae6;
+}
+.cm-s-ayu-dark span.cm-type {
+  color: #ff8f40;
+}
+.cm-s-ayu-dark span.cm-def {
+  color: #ffee99;
+}
+.cm-s-ayu-dark span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-ayu-dark span.cm-tag {
+  color: rgba(57, 186, 230, 80);
+}
+.cm-s-ayu-dark span.cm-header {
+  color: #c2d94c;
+}
+.cm-s-ayu-dark span.cm-link {
+  color: #39bae6;
+}
+.cm-s-ayu-dark span.cm-error {
+  color: #ff3333;
+}
 
-.cm-s-ayu-dark .CodeMirror-activeline-background { background: #01060e; }
+.cm-s-ayu-dark .CodeMirror-activeline-background {
+  background: #01060e;
+}
 .cm-s-ayu-dark .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;
+}
+
+.CodeMirror-cursor {
+  background-color: #a2a8a175 !important;
+}
+
+.CodeMirror-cursors {
+  background-color: #a2a8a175 !important;
+}
+
+.cm-animate-fat-cursor {
+  background-color: #a2a8a175 !important;
 }

--- a/theme/ayu-mirage.css
+++ b/theme/ayu-mirage.css
@@ -1,126 +1,43 @@
 /* Based on https://github.com/dempfi/ayu */
 
-.cm-s-ayu-mirage.CodeMirror {
-  background: #1f2430;
-  color: #cbccc6;
-}
-.cm-s-ayu-mirage div.CodeMirror-selected {
-  background: #34455a;
-}
-.cm-s-ayu-mirage .CodeMirror-line::selection,
-.cm-s-ayu-mirage .CodeMirror-line > span::selection,
-.cm-s-ayu-mirage .CodeMirror-line > span > span::selection {
-  background: #34455a;
-}
-.cm-s-ayu-mirage .CodeMirror-line::-moz-selection,
-.cm-s-ayu-mirage .CodeMirror-line > span::-moz-selection,
-.cm-s-ayu-mirage .CodeMirror-line > span > span::-moz-selection {
-  background: rgba(25, 30, 42, 99);
-}
-.cm-s-ayu-mirage .CodeMirror-gutters {
-  background: #1f2430;
-  border-right: 0px;
-}
-.cm-s-ayu-mirage .CodeMirror-guttermarker {
-  color: white;
-}
-.cm-s-ayu-mirage .CodeMirror-guttermarker-subtle {
-  color: rgba(112, 122, 140, 66);
-}
-.cm-s-ayu-mirage .CodeMirror-linenumber {
-  color: rgba(61, 66, 77, 99);
-}
-.cm-s-ayu-mirage .CodeMirror-cursor {
-  border-left: 1px solid #ffcc66;
-}
+.cm-s-ayu-mirage.CodeMirror { background: #1f2430; color: #cbccc6; }
+.cm-s-ayu-mirage div.CodeMirror-selected { background: #34455a; }
+.cm-s-ayu-mirage .CodeMirror-line::selection, .cm-s-ayu-mirage .CodeMirror-line > span::selection, .cm-s-ayu-mirage .CodeMirror-line > span > span::selection { background: #34455a; }
+.cm-s-ayu-mirage .CodeMirror-line::-moz-selection, .cm-s-ayu-mirage .CodeMirror-line > span::-moz-selection, .cm-s-ayu-mirage .CodeMirror-line > span > span::-moz-selection { background: rgba(25, 30, 42, 99); }
+.cm-s-ayu-mirage .CodeMirror-gutters { background: #1f2430; border-right: 0px; }
+.cm-s-ayu-mirage .CodeMirror-guttermarker { color: white; }
+.cm-s-ayu-mirage .CodeMirror-guttermarker-subtle { color:  rgba(112, 122, 140, 66); }
+.cm-s-ayu-mirage .CodeMirror-linenumber { color: rgba(61, 66, 77, 99); }
+.cm-s-ayu-mirage .CodeMirror-cursor { border-left: 1px solid #ffcc66; }
 
-.cm-s-ayu-mirage span.cm-comment {
-  color: #5c6773;
-  font-style: italic;
-}
-.cm-s-ayu-mirage span.cm-atom {
-  color: #ae81ff;
-}
-.cm-s-ayu-mirage span.cm-number {
-  color: #ffcc66;
-}
+.cm-s-ayu-mirage span.cm-comment { color: #5c6773; font-style:italic; }
+.cm-s-ayu-mirage span.cm-atom { color: #ae81ff; }
+.cm-s-ayu-mirage span.cm-number { color: #ffcc66; }
 
-.cm-s-ayu-mirage span.cm-comment.cm-attribute {
-  color: #ffd580;
-}
-.cm-s-ayu-mirage span.cm-comment.cm-def {
-  color: #d4bfff;
-}
-.cm-s-ayu-mirage span.cm-comment.cm-tag {
-  color: #5ccfe6;
-}
-.cm-s-ayu-mirage span.cm-comment.cm-type {
-  color: #5998a6;
-}
+.cm-s-ayu-mirage span.cm-comment.cm-attribute { color: #ffd580; }
+.cm-s-ayu-mirage span.cm-comment.cm-def { color: #d4bfff; }
+.cm-s-ayu-mirage span.cm-comment.cm-tag { color: #5ccfe6; }
+.cm-s-ayu-mirage span.cm-comment.cm-type { color: #5998a6; }
 
-.cm-s-ayu-mirage span.cm-property {
-  color: #f29e74;
-}
-.cm-s-ayu-mirage span.cm-attribute {
-  color: #ffd580;
-}
-.cm-s-ayu-mirage span.cm-keyword {
-  color: #ffa759;
-}
-.cm-s-ayu-mirage span.cm-builtin {
-  color: #ffcc66;
-}
-.cm-s-ayu-mirage span.cm-string {
-  color: #bae67e;
-}
+.cm-s-ayu-mirage span.cm-property { color: #f29e74; }
+.cm-s-ayu-mirage span.cm-attribute { color: #ffd580; }  
+.cm-s-ayu-mirage span.cm-keyword { color: #ffa759; } 
+.cm-s-ayu-mirage span.cm-builtin { color: #ffcc66; }
+.cm-s-ayu-mirage span.cm-string { color: #bae67e; }
 
-.cm-s-ayu-mirage span.cm-variable {
-  color: #cbccc6;
-}
-.cm-s-ayu-mirage span.cm-variable-2 {
-  color: #f28779;
-}
-.cm-s-ayu-mirage span.cm-variable-3 {
-  color: #5ccfe6;
-}
-.cm-s-ayu-mirage span.cm-type {
-  color: #ffa759;
-}
-.cm-s-ayu-mirage span.cm-def {
-  color: #ffd580;
-}
-.cm-s-ayu-mirage span.cm-bracket {
-  color: rgba(92, 207, 230, 80);
-}
-.cm-s-ayu-mirage span.cm-tag {
-  color: #5ccfe6;
-}
-.cm-s-ayu-mirage span.cm-header {
-  color: #bae67e;
-}
-.cm-s-ayu-mirage span.cm-link {
-  color: #5ccfe6;
-}
-.cm-s-ayu-mirage span.cm-error {
-  color: #ff3333;
-}
+.cm-s-ayu-mirage span.cm-variable { color: #cbccc6; }
+.cm-s-ayu-mirage span.cm-variable-2 { color: #f28779; }
+.cm-s-ayu-mirage span.cm-variable-3 { color: #5ccfe6; }
+.cm-s-ayu-mirage span.cm-type { color: #ffa759; }
+.cm-s-ayu-mirage span.cm-def { color: #ffd580; }
+.cm-s-ayu-mirage span.cm-bracket { color: rgba(92, 207, 230, 80); }
+.cm-s-ayu-mirage span.cm-tag { color: #5ccfe6; }
+.cm-s-ayu-mirage span.cm-header { color: #bae67e; }
+.cm-s-ayu-mirage span.cm-link { color: #5ccfe6; }
+.cm-s-ayu-mirage span.cm-error { color: #ff3333; } 
 
-.cm-s-ayu-mirage .CodeMirror-activeline-background {
-  background: #191e2a;
-}
+.cm-s-ayu-mirage .CodeMirror-activeline-background { background: #191e2a; }
 .cm-s-ayu-mirage .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;
-}
-
-.CodeMirror-cursor {
-  background-color: #a2a8a175 !important;
-}
-
-.CodeMirror-cursors {
-  background-color: #a2a8a175 !important;
-}
-
-.cm-animate-fat-cursor {
-  background-color: #a2a8a175 !important;
 }

--- a/theme/ayu-mirage.css
+++ b/theme/ayu-mirage.css
@@ -8,7 +8,7 @@
 .cm-s-ayu-mirage .CodeMirror-guttermarker { color: white; }
 .cm-s-ayu-mirage .CodeMirror-guttermarker-subtle { color:  rgba(112, 122, 140, 66); }
 .cm-s-ayu-mirage .CodeMirror-linenumber { color: rgba(61, 66, 77, 99); }
-.cm-s-ayu-mirage .CodeMirror-cursor { border-left: 1px solid #ffcc66; }
+.cm-s-ayu-mirage .CodeMirror-cursor { border-left: 1px solid #ffcc66;  }
 
 .cm-s-ayu-mirage span.cm-comment { color: #5c6773; font-style:italic; }
 .cm-s-ayu-mirage span.cm-atom { color: #ae81ff; }
@@ -43,9 +43,5 @@
 }
 
  /* changing cursor color in vim mode */
-.CodeMirror-cursor { background-color: #a2a8a175 !important; }
-
-.CodeMirror-cursors { background-color: #a2a8a175 !important; }
-
+.cm-s-ayu-mirage .CodeMirror-cursor {background-color: #a2a8a175 !important;}
 .cm-animate-fat-cursor { background-color: #a2a8a175 !important; }
-

--- a/theme/ayu-mirage.css
+++ b/theme/ayu-mirage.css
@@ -1,43 +1,126 @@
 /* Based on https://github.com/dempfi/ayu */
 
-.cm-s-ayu-mirage.CodeMirror { background: #1f2430; color: #cbccc6; }
-.cm-s-ayu-mirage div.CodeMirror-selected { background: #34455a; }
-.cm-s-ayu-mirage .CodeMirror-line::selection, .cm-s-ayu-mirage .CodeMirror-line > span::selection, .cm-s-ayu-mirage .CodeMirror-line > span > span::selection { background: #34455a; }
-.cm-s-ayu-mirage .CodeMirror-line::-moz-selection, .cm-s-ayu-mirage .CodeMirror-line > span::-moz-selection, .cm-s-ayu-mirage .CodeMirror-line > span > span::-moz-selection { background: rgba(25, 30, 42, 99); }
-.cm-s-ayu-mirage .CodeMirror-gutters { background: #1f2430; border-right: 0px; }
-.cm-s-ayu-mirage .CodeMirror-guttermarker { color: white; }
-.cm-s-ayu-mirage .CodeMirror-guttermarker-subtle { color:  rgba(112, 122, 140, 66); }
-.cm-s-ayu-mirage .CodeMirror-linenumber { color: rgba(61, 66, 77, 99); }
-.cm-s-ayu-mirage .CodeMirror-cursor { border-left: 1px solid #ffcc66; }
+.cm-s-ayu-mirage.CodeMirror {
+  background: #1f2430;
+  color: #cbccc6;
+}
+.cm-s-ayu-mirage div.CodeMirror-selected {
+  background: #34455a;
+}
+.cm-s-ayu-mirage .CodeMirror-line::selection,
+.cm-s-ayu-mirage .CodeMirror-line > span::selection,
+.cm-s-ayu-mirage .CodeMirror-line > span > span::selection {
+  background: #34455a;
+}
+.cm-s-ayu-mirage .CodeMirror-line::-moz-selection,
+.cm-s-ayu-mirage .CodeMirror-line > span::-moz-selection,
+.cm-s-ayu-mirage .CodeMirror-line > span > span::-moz-selection {
+  background: rgba(25, 30, 42, 99);
+}
+.cm-s-ayu-mirage .CodeMirror-gutters {
+  background: #1f2430;
+  border-right: 0px;
+}
+.cm-s-ayu-mirage .CodeMirror-guttermarker {
+  color: white;
+}
+.cm-s-ayu-mirage .CodeMirror-guttermarker-subtle {
+  color: rgba(112, 122, 140, 66);
+}
+.cm-s-ayu-mirage .CodeMirror-linenumber {
+  color: rgba(61, 66, 77, 99);
+}
+.cm-s-ayu-mirage .CodeMirror-cursor {
+  border-left: 1px solid #ffcc66;
+}
 
-.cm-s-ayu-mirage span.cm-comment { color: #5c6773; font-style:italic; }
-.cm-s-ayu-mirage span.cm-atom { color: #ae81ff; }
-.cm-s-ayu-mirage span.cm-number { color: #ffcc66; }
+.cm-s-ayu-mirage span.cm-comment {
+  color: #5c6773;
+  font-style: italic;
+}
+.cm-s-ayu-mirage span.cm-atom {
+  color: #ae81ff;
+}
+.cm-s-ayu-mirage span.cm-number {
+  color: #ffcc66;
+}
 
-.cm-s-ayu-mirage span.cm-comment.cm-attribute { color: #ffd580; }
-.cm-s-ayu-mirage span.cm-comment.cm-def { color: #d4bfff; }
-.cm-s-ayu-mirage span.cm-comment.cm-tag { color: #5ccfe6; }
-.cm-s-ayu-mirage span.cm-comment.cm-type { color: #5998a6; }
+.cm-s-ayu-mirage span.cm-comment.cm-attribute {
+  color: #ffd580;
+}
+.cm-s-ayu-mirage span.cm-comment.cm-def {
+  color: #d4bfff;
+}
+.cm-s-ayu-mirage span.cm-comment.cm-tag {
+  color: #5ccfe6;
+}
+.cm-s-ayu-mirage span.cm-comment.cm-type {
+  color: #5998a6;
+}
 
-.cm-s-ayu-mirage span.cm-property { color: #f29e74; }
-.cm-s-ayu-mirage span.cm-attribute { color: #ffd580; }  
-.cm-s-ayu-mirage span.cm-keyword { color: #ffa759; } 
-.cm-s-ayu-mirage span.cm-builtin { color: #ffcc66; }
-.cm-s-ayu-mirage span.cm-string { color: #bae67e; }
+.cm-s-ayu-mirage span.cm-property {
+  color: #f29e74;
+}
+.cm-s-ayu-mirage span.cm-attribute {
+  color: #ffd580;
+}
+.cm-s-ayu-mirage span.cm-keyword {
+  color: #ffa759;
+}
+.cm-s-ayu-mirage span.cm-builtin {
+  color: #ffcc66;
+}
+.cm-s-ayu-mirage span.cm-string {
+  color: #bae67e;
+}
 
-.cm-s-ayu-mirage span.cm-variable { color: #cbccc6; }
-.cm-s-ayu-mirage span.cm-variable-2 { color: #f28779; }
-.cm-s-ayu-mirage span.cm-variable-3 { color: #5ccfe6; }
-.cm-s-ayu-mirage span.cm-type { color: #ffa759; }
-.cm-s-ayu-mirage span.cm-def { color: #ffd580; }
-.cm-s-ayu-mirage span.cm-bracket { color: rgba(92, 207, 230, 80); }
-.cm-s-ayu-mirage span.cm-tag { color: #5ccfe6; }
-.cm-s-ayu-mirage span.cm-header { color: #bae67e; }
-.cm-s-ayu-mirage span.cm-link { color: #5ccfe6; }
-.cm-s-ayu-mirage span.cm-error { color: #ff3333; } 
+.cm-s-ayu-mirage span.cm-variable {
+  color: #cbccc6;
+}
+.cm-s-ayu-mirage span.cm-variable-2 {
+  color: #f28779;
+}
+.cm-s-ayu-mirage span.cm-variable-3 {
+  color: #5ccfe6;
+}
+.cm-s-ayu-mirage span.cm-type {
+  color: #ffa759;
+}
+.cm-s-ayu-mirage span.cm-def {
+  color: #ffd580;
+}
+.cm-s-ayu-mirage span.cm-bracket {
+  color: rgba(92, 207, 230, 80);
+}
+.cm-s-ayu-mirage span.cm-tag {
+  color: #5ccfe6;
+}
+.cm-s-ayu-mirage span.cm-header {
+  color: #bae67e;
+}
+.cm-s-ayu-mirage span.cm-link {
+  color: #5ccfe6;
+}
+.cm-s-ayu-mirage span.cm-error {
+  color: #ff3333;
+}
 
-.cm-s-ayu-mirage .CodeMirror-activeline-background { background: #191e2a; }
+.cm-s-ayu-mirage .CodeMirror-activeline-background {
+  background: #191e2a;
+}
 .cm-s-ayu-mirage .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;
+}
+
+.CodeMirror-cursor {
+  background-color: #a2a8a175 !important;
+}
+
+.CodeMirror-cursors {
+  background-color: #a2a8a175 !important;
+}
+
+.cm-animate-fat-cursor {
+  background-color: #a2a8a175 !important;
 }

--- a/theme/ayu-mirage.css
+++ b/theme/ayu-mirage.css
@@ -41,3 +41,11 @@
   text-decoration: underline;
   color: white !important;
 }
+
+ /* changing cursor color in vim mode */
+.CodeMirror-cursor { background-color: #a2a8a175 !important; }
+
+.CodeMirror-cursors { background-color: #a2a8a175 !important; }
+
+.cm-animate-fat-cursor { background-color: #a2a8a175 !important; }
+

--- a/theme/base16-dark.css
+++ b/theme/base16-dark.css
@@ -8,100 +8,31 @@
 
 */
 
-.cm-s-base16-dark.CodeMirror {
-  background: #151515;
-  color: #e0e0e0;
-}
-.cm-s-base16-dark div.CodeMirror-selected {
-  background: #303030;
-}
-.cm-s-base16-dark .CodeMirror-line::selection,
-.cm-s-base16-dark .CodeMirror-line > span::selection,
-.cm-s-base16-dark .CodeMirror-line > span > span::selection {
-  background: rgba(48, 48, 48, 0.99);
-}
-.cm-s-base16-dark .CodeMirror-line::-moz-selection,
-.cm-s-base16-dark .CodeMirror-line > span::-moz-selection,
-.cm-s-base16-dark .CodeMirror-line > span > span::-moz-selection {
-  background: rgba(48, 48, 48, 0.99);
-}
-.cm-s-base16-dark .CodeMirror-gutters {
-  background: #151515;
-  border-right: 0px;
-}
-.cm-s-base16-dark .CodeMirror-guttermarker {
-  color: #ac4142;
-}
-.cm-s-base16-dark .CodeMirror-guttermarker-subtle {
-  color: #505050;
-}
-.cm-s-base16-dark .CodeMirror-linenumber {
-  color: #505050;
-}
-.cm-s-base16-dark .CodeMirror-cursor {
-  border-left: 1px solid #b0b0b0;
-}
+.cm-s-base16-dark.CodeMirror { background: #151515; color: #e0e0e0; }
+.cm-s-base16-dark div.CodeMirror-selected { background: #303030; }
+.cm-s-base16-dark .CodeMirror-line::selection, .cm-s-base16-dark .CodeMirror-line > span::selection, .cm-s-base16-dark .CodeMirror-line > span > span::selection { background: rgba(48, 48, 48, .99); }
+.cm-s-base16-dark .CodeMirror-line::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(48, 48, 48, .99); }
+.cm-s-base16-dark .CodeMirror-gutters { background: #151515; border-right: 0px; }
+.cm-s-base16-dark .CodeMirror-guttermarker { color: #ac4142; }
+.cm-s-base16-dark .CodeMirror-guttermarker-subtle { color: #505050; }
+.cm-s-base16-dark .CodeMirror-linenumber { color: #505050; }
+.cm-s-base16-dark .CodeMirror-cursor { border-left: 1px solid #b0b0b0; }
 
-.cm-s-base16-dark span.cm-comment {
-  color: #8f5536;
-}
-.cm-s-base16-dark span.cm-atom {
-  color: #aa759f;
-}
-.cm-s-base16-dark span.cm-number {
-  color: #aa759f;
-}
+.cm-s-base16-dark span.cm-comment { color: #8f5536; }
+.cm-s-base16-dark span.cm-atom { color: #aa759f; }
+.cm-s-base16-dark span.cm-number { color: #aa759f; }
 
-.cm-s-base16-dark span.cm-property,
-.cm-s-base16-dark span.cm-attribute {
-  color: #90a959;
-}
-.cm-s-base16-dark span.cm-keyword {
-  color: #ac4142;
-}
-.cm-s-base16-dark span.cm-string {
-  color: #f4bf75;
-}
+.cm-s-base16-dark span.cm-property, .cm-s-base16-dark span.cm-attribute { color: #90a959; }
+.cm-s-base16-dark span.cm-keyword { color: #ac4142; }
+.cm-s-base16-dark span.cm-string { color: #f4bf75; }
 
-.cm-s-base16-dark span.cm-variable {
-  color: #90a959;
-}
-.cm-s-base16-dark span.cm-variable-2 {
-  color: #6a9fb5;
-}
-.cm-s-base16-dark span.cm-def {
-  color: #d28445;
-}
-.cm-s-base16-dark span.cm-bracket {
-  color: #e0e0e0;
-}
-.cm-s-base16-dark span.cm-tag {
-  color: #ac4142;
-}
-.cm-s-base16-dark span.cm-link {
-  color: #aa759f;
-}
-.cm-s-base16-dark span.cm-error {
-  background: #ac4142;
-  color: #b0b0b0;
-}
+.cm-s-base16-dark span.cm-variable { color: #90a959; }
+.cm-s-base16-dark span.cm-variable-2 { color: #6a9fb5; }
+.cm-s-base16-dark span.cm-def { color: #d28445; }
+.cm-s-base16-dark span.cm-bracket { color: #e0e0e0; }
+.cm-s-base16-dark span.cm-tag { color: #ac4142; }
+.cm-s-base16-dark span.cm-link { color: #aa759f; }
+.cm-s-base16-dark span.cm-error { background: #ac4142; color: #b0b0b0; }
 
-.cm-s-base16-dark .CodeMirror-activeline-background {
-  background: #202020;
-}
-.cm-s-base16-dark .CodeMirror-matchingbracket {
-  text-decoration: underline;
-  color: white !important;
-}
-
-.CodeMirror-cursor {
-  background-color: #8e8d8875 !important;
-}
-
-.CodeMirror-cursors {
-  background-color: #8e8d8875 !important;
-}
-
-.cm-animate-fat-cursor {
-  background-color: #8e8d8875 !important;
-}
+.cm-s-base16-dark .CodeMirror-activeline-background { background: #202020; }
+.cm-s-base16-dark .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }

--- a/theme/base16-dark.css
+++ b/theme/base16-dark.css
@@ -8,31 +8,100 @@
 
 */
 
-.cm-s-base16-dark.CodeMirror { background: #151515; color: #e0e0e0; }
-.cm-s-base16-dark div.CodeMirror-selected { background: #303030; }
-.cm-s-base16-dark .CodeMirror-line::selection, .cm-s-base16-dark .CodeMirror-line > span::selection, .cm-s-base16-dark .CodeMirror-line > span > span::selection { background: rgba(48, 48, 48, .99); }
-.cm-s-base16-dark .CodeMirror-line::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span::-moz-selection, .cm-s-base16-dark .CodeMirror-line > span > span::-moz-selection { background: rgba(48, 48, 48, .99); }
-.cm-s-base16-dark .CodeMirror-gutters { background: #151515; border-right: 0px; }
-.cm-s-base16-dark .CodeMirror-guttermarker { color: #ac4142; }
-.cm-s-base16-dark .CodeMirror-guttermarker-subtle { color: #505050; }
-.cm-s-base16-dark .CodeMirror-linenumber { color: #505050; }
-.cm-s-base16-dark .CodeMirror-cursor { border-left: 1px solid #b0b0b0; }
+.cm-s-base16-dark.CodeMirror {
+  background: #151515;
+  color: #e0e0e0;
+}
+.cm-s-base16-dark div.CodeMirror-selected {
+  background: #303030;
+}
+.cm-s-base16-dark .CodeMirror-line::selection,
+.cm-s-base16-dark .CodeMirror-line > span::selection,
+.cm-s-base16-dark .CodeMirror-line > span > span::selection {
+  background: rgba(48, 48, 48, 0.99);
+}
+.cm-s-base16-dark .CodeMirror-line::-moz-selection,
+.cm-s-base16-dark .CodeMirror-line > span::-moz-selection,
+.cm-s-base16-dark .CodeMirror-line > span > span::-moz-selection {
+  background: rgba(48, 48, 48, 0.99);
+}
+.cm-s-base16-dark .CodeMirror-gutters {
+  background: #151515;
+  border-right: 0px;
+}
+.cm-s-base16-dark .CodeMirror-guttermarker {
+  color: #ac4142;
+}
+.cm-s-base16-dark .CodeMirror-guttermarker-subtle {
+  color: #505050;
+}
+.cm-s-base16-dark .CodeMirror-linenumber {
+  color: #505050;
+}
+.cm-s-base16-dark .CodeMirror-cursor {
+  border-left: 1px solid #b0b0b0;
+}
 
-.cm-s-base16-dark span.cm-comment { color: #8f5536; }
-.cm-s-base16-dark span.cm-atom { color: #aa759f; }
-.cm-s-base16-dark span.cm-number { color: #aa759f; }
+.cm-s-base16-dark span.cm-comment {
+  color: #8f5536;
+}
+.cm-s-base16-dark span.cm-atom {
+  color: #aa759f;
+}
+.cm-s-base16-dark span.cm-number {
+  color: #aa759f;
+}
 
-.cm-s-base16-dark span.cm-property, .cm-s-base16-dark span.cm-attribute { color: #90a959; }
-.cm-s-base16-dark span.cm-keyword { color: #ac4142; }
-.cm-s-base16-dark span.cm-string { color: #f4bf75; }
+.cm-s-base16-dark span.cm-property,
+.cm-s-base16-dark span.cm-attribute {
+  color: #90a959;
+}
+.cm-s-base16-dark span.cm-keyword {
+  color: #ac4142;
+}
+.cm-s-base16-dark span.cm-string {
+  color: #f4bf75;
+}
 
-.cm-s-base16-dark span.cm-variable { color: #90a959; }
-.cm-s-base16-dark span.cm-variable-2 { color: #6a9fb5; }
-.cm-s-base16-dark span.cm-def { color: #d28445; }
-.cm-s-base16-dark span.cm-bracket { color: #e0e0e0; }
-.cm-s-base16-dark span.cm-tag { color: #ac4142; }
-.cm-s-base16-dark span.cm-link { color: #aa759f; }
-.cm-s-base16-dark span.cm-error { background: #ac4142; color: #b0b0b0; }
+.cm-s-base16-dark span.cm-variable {
+  color: #90a959;
+}
+.cm-s-base16-dark span.cm-variable-2 {
+  color: #6a9fb5;
+}
+.cm-s-base16-dark span.cm-def {
+  color: #d28445;
+}
+.cm-s-base16-dark span.cm-bracket {
+  color: #e0e0e0;
+}
+.cm-s-base16-dark span.cm-tag {
+  color: #ac4142;
+}
+.cm-s-base16-dark span.cm-link {
+  color: #aa759f;
+}
+.cm-s-base16-dark span.cm-error {
+  background: #ac4142;
+  color: #b0b0b0;
+}
 
-.cm-s-base16-dark .CodeMirror-activeline-background { background: #202020; }
-.cm-s-base16-dark .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
+.cm-s-base16-dark .CodeMirror-activeline-background {
+  background: #202020;
+}
+.cm-s-base16-dark .CodeMirror-matchingbracket {
+  text-decoration: underline;
+  color: white !important;
+}
+
+.CodeMirror-cursor {
+  background-color: #8e8d8875 !important;
+}
+
+.CodeMirror-cursors {
+  background-color: #8e8d8875 !important;
+}
+
+.cm-animate-fat-cursor {
+  background-color: #8e8d8875 !important;
+}

--- a/theme/base16-dark.css
+++ b/theme/base16-dark.css
@@ -36,3 +36,11 @@
 
 .cm-s-base16-dark .CodeMirror-activeline-background { background: #202020; }
 .cm-s-base16-dark .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
+
+/* changing cursor color in vim */
+.CodeMirror-cursor { background-color: #8e8d8875 !important; }
+
+.CodeMirror-cursors { background-color: #8e8d8875 !important; }
+
+.cm-animate-fat-cursor { background-color: #8e8d8875 !important; }
+

--- a/theme/base16-dark.css
+++ b/theme/base16-dark.css
@@ -38,9 +38,6 @@
 .cm-s-base16-dark .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
 
 /* changing cursor color in vim */
-.CodeMirror-cursor { background-color: #8e8d8875 !important; }
-
-.CodeMirror-cursors { background-color: #8e8d8875 !important; }
-
-.cm-animate-fat-cursor { background-color: #8e8d8875 !important; }
+.cm-s-base16-dark .CodeMirror-cursor { background-color: #8e8d8875 !important; }
+.cm-s-base16-dark .cm-animate-fat-cursor { background-color: #8e8d8875 !important; }
 

--- a/theme/gruvbox-dark.css
+++ b/theme/gruvbox-dark.css
@@ -7,97 +7,31 @@
 
 */
 
-.cm-s-gruvbox-dark.CodeMirror,
-.cm-s-gruvbox-dark .CodeMirror-gutters {
-  background-color: #282828;
-  color: #bdae93;
-}
-.cm-s-gruvbox-dark .CodeMirror-gutters {
-  background: #282828;
-  border-right: 0px;
-}
-.cm-s-gruvbox-dark .CodeMirror-linenumber {
-  color: #7c6f64;
-}
-.cm-s-gruvbox-dark .CodeMirror-cursor {
-  border-left: 1px solid #ebdbb2;
-}
-.cm-s-gruvbox-dark div.CodeMirror-selected {
-  background: #928374;
-}
-.cm-s-gruvbox-dark span.cm-meta {
-  color: #83a598;
-}
+.cm-s-gruvbox-dark.CodeMirror, .cm-s-gruvbox-dark .CodeMirror-gutters { background-color: #282828; color: #bdae93; }
+.cm-s-gruvbox-dark .CodeMirror-gutters {background: #282828; border-right: 0px;}
+.cm-s-gruvbox-dark .CodeMirror-linenumber {color: #7c6f64;}
+.cm-s-gruvbox-dark .CodeMirror-cursor { border-left: 1px solid #ebdbb2; }
+.cm-s-gruvbox-dark div.CodeMirror-selected { background: #928374; }
+.cm-s-gruvbox-dark span.cm-meta { color: #83a598; }
 
-.cm-s-gruvbox-dark span.cm-comment {
-  color: #928374;
-}
-.cm-s-gruvbox-dark span.cm-number,
-span.cm-atom {
-  color: #d3869b;
-}
-.cm-s-gruvbox-dark span.cm-keyword {
-  color: #f84934;
-}
+.cm-s-gruvbox-dark span.cm-comment { color: #928374; }
+.cm-s-gruvbox-dark span.cm-number, span.cm-atom { color: #d3869b; }
+.cm-s-gruvbox-dark span.cm-keyword { color: #f84934; }
 
-.cm-s-gruvbox-dark span.cm-variable {
-  color: #ebdbb2;
-}
-.cm-s-gruvbox-dark span.cm-variable-2 {
-  color: #ebdbb2;
-}
-.cm-s-gruvbox-dark span.cm-variable-3,
-.cm-s-gruvbox-dark span.cm-type {
-  color: #fabd2f;
-}
-.cm-s-gruvbox-dark span.cm-operator {
-  color: #ebdbb2;
-}
-.cm-s-gruvbox-dark span.cm-callee {
-  color: #ebdbb2;
-}
-.cm-s-gruvbox-dark span.cm-def {
-  color: #ebdbb2;
-}
-.cm-s-gruvbox-dark span.cm-property {
-  color: #ebdbb2;
-}
-.cm-s-gruvbox-dark span.cm-string {
-  color: #b8bb26;
-}
-.cm-s-gruvbox-dark span.cm-string-2 {
-  color: #8ec07c;
-}
-.cm-s-gruvbox-dark span.cm-qualifier {
-  color: #8ec07c;
-}
-.cm-s-gruvbox-dark span.cm-attribute {
-  color: #8ec07c;
-}
+.cm-s-gruvbox-dark span.cm-variable { color: #ebdbb2; }
+.cm-s-gruvbox-dark span.cm-variable-2 { color: #ebdbb2; }
+.cm-s-gruvbox-dark span.cm-variable-3, .cm-s-gruvbox-dark span.cm-type { color: #fabd2f; }
+.cm-s-gruvbox-dark span.cm-operator { color: #ebdbb2; }
+.cm-s-gruvbox-dark span.cm-callee { color: #ebdbb2; }
+.cm-s-gruvbox-dark span.cm-def { color: #ebdbb2; }
+.cm-s-gruvbox-dark span.cm-property { color: #ebdbb2; }
+.cm-s-gruvbox-dark span.cm-string { color: #b8bb26; }
+.cm-s-gruvbox-dark span.cm-string-2 { color: #8ec07c; }
+.cm-s-gruvbox-dark span.cm-qualifier { color: #8ec07c; }
+.cm-s-gruvbox-dark span.cm-attribute { color: #8ec07c; }
 
-.cm-s-gruvbox-dark .CodeMirror-activeline-background {
-  background: #3c3836;
-}
-.cm-s-gruvbox-dark .CodeMirror-matchingbracket {
-  background: #928374;
-  color: #282828 !important;
-}
+.cm-s-gruvbox-dark .CodeMirror-activeline-background { background: #3c3836; }
+.cm-s-gruvbox-dark .CodeMirror-matchingbracket { background: #928374; color:#282828 !important; }
 
-.cm-s-gruvbox-dark span.cm-builtin {
-  color: #fe8019;
-}
-.cm-s-gruvbox-dark span.cm-tag {
-  color: #fe8019;
-}
-
-.CodeMirror-cursor {
-  background-color: #8e8d8875 !important;
-}
-
-.CodeMirror-cursors {
-  background-color: #8e8d8875 !important;
-}
-
-.cm-animate-fat-cursor {
-  background-color: #8e8d8875 !important;
-}
+.cm-s-gruvbox-dark span.cm-builtin { color: #fe8019; }
+.cm-s-gruvbox-dark span.cm-tag { color: #fe8019; }

--- a/theme/gruvbox-dark.css
+++ b/theme/gruvbox-dark.css
@@ -7,31 +7,97 @@
 
 */
 
-.cm-s-gruvbox-dark.CodeMirror, .cm-s-gruvbox-dark .CodeMirror-gutters { background-color: #282828; color: #bdae93; }
-.cm-s-gruvbox-dark .CodeMirror-gutters {background: #282828; border-right: 0px;}
-.cm-s-gruvbox-dark .CodeMirror-linenumber {color: #7c6f64;}
-.cm-s-gruvbox-dark .CodeMirror-cursor { border-left: 1px solid #ebdbb2; }
-.cm-s-gruvbox-dark div.CodeMirror-selected { background: #928374; }
-.cm-s-gruvbox-dark span.cm-meta { color: #83a598; }
+.cm-s-gruvbox-dark.CodeMirror,
+.cm-s-gruvbox-dark .CodeMirror-gutters {
+  background-color: #282828;
+  color: #bdae93;
+}
+.cm-s-gruvbox-dark .CodeMirror-gutters {
+  background: #282828;
+  border-right: 0px;
+}
+.cm-s-gruvbox-dark .CodeMirror-linenumber {
+  color: #7c6f64;
+}
+.cm-s-gruvbox-dark .CodeMirror-cursor {
+  border-left: 1px solid #ebdbb2;
+}
+.cm-s-gruvbox-dark div.CodeMirror-selected {
+  background: #928374;
+}
+.cm-s-gruvbox-dark span.cm-meta {
+  color: #83a598;
+}
 
-.cm-s-gruvbox-dark span.cm-comment { color: #928374; }
-.cm-s-gruvbox-dark span.cm-number, span.cm-atom { color: #d3869b; }
-.cm-s-gruvbox-dark span.cm-keyword { color: #f84934; }
+.cm-s-gruvbox-dark span.cm-comment {
+  color: #928374;
+}
+.cm-s-gruvbox-dark span.cm-number,
+span.cm-atom {
+  color: #d3869b;
+}
+.cm-s-gruvbox-dark span.cm-keyword {
+  color: #f84934;
+}
 
-.cm-s-gruvbox-dark span.cm-variable { color: #ebdbb2; }
-.cm-s-gruvbox-dark span.cm-variable-2 { color: #ebdbb2; }
-.cm-s-gruvbox-dark span.cm-variable-3, .cm-s-gruvbox-dark span.cm-type { color: #fabd2f; }
-.cm-s-gruvbox-dark span.cm-operator { color: #ebdbb2; }
-.cm-s-gruvbox-dark span.cm-callee { color: #ebdbb2; }
-.cm-s-gruvbox-dark span.cm-def { color: #ebdbb2; }
-.cm-s-gruvbox-dark span.cm-property { color: #ebdbb2; }
-.cm-s-gruvbox-dark span.cm-string { color: #b8bb26; }
-.cm-s-gruvbox-dark span.cm-string-2 { color: #8ec07c; }
-.cm-s-gruvbox-dark span.cm-qualifier { color: #8ec07c; }
-.cm-s-gruvbox-dark span.cm-attribute { color: #8ec07c; }
+.cm-s-gruvbox-dark span.cm-variable {
+  color: #ebdbb2;
+}
+.cm-s-gruvbox-dark span.cm-variable-2 {
+  color: #ebdbb2;
+}
+.cm-s-gruvbox-dark span.cm-variable-3,
+.cm-s-gruvbox-dark span.cm-type {
+  color: #fabd2f;
+}
+.cm-s-gruvbox-dark span.cm-operator {
+  color: #ebdbb2;
+}
+.cm-s-gruvbox-dark span.cm-callee {
+  color: #ebdbb2;
+}
+.cm-s-gruvbox-dark span.cm-def {
+  color: #ebdbb2;
+}
+.cm-s-gruvbox-dark span.cm-property {
+  color: #ebdbb2;
+}
+.cm-s-gruvbox-dark span.cm-string {
+  color: #b8bb26;
+}
+.cm-s-gruvbox-dark span.cm-string-2 {
+  color: #8ec07c;
+}
+.cm-s-gruvbox-dark span.cm-qualifier {
+  color: #8ec07c;
+}
+.cm-s-gruvbox-dark span.cm-attribute {
+  color: #8ec07c;
+}
 
-.cm-s-gruvbox-dark .CodeMirror-activeline-background { background: #3c3836; }
-.cm-s-gruvbox-dark .CodeMirror-matchingbracket { background: #928374; color:#282828 !important; }
+.cm-s-gruvbox-dark .CodeMirror-activeline-background {
+  background: #3c3836;
+}
+.cm-s-gruvbox-dark .CodeMirror-matchingbracket {
+  background: #928374;
+  color: #282828 !important;
+}
 
-.cm-s-gruvbox-dark span.cm-builtin { color: #fe8019; }
-.cm-s-gruvbox-dark span.cm-tag { color: #fe8019; }
+.cm-s-gruvbox-dark span.cm-builtin {
+  color: #fe8019;
+}
+.cm-s-gruvbox-dark span.cm-tag {
+  color: #fe8019;
+}
+
+.CodeMirror-cursor {
+  background-color: #8e8d8875 !important;
+}
+
+.CodeMirror-cursors {
+  background-color: #8e8d8875 !important;
+}
+
+.cm-animate-fat-cursor {
+  background-color: #8e8d8875 !important;
+}

--- a/theme/gruvbox-dark.css
+++ b/theme/gruvbox-dark.css
@@ -35,3 +35,11 @@
 
 .cm-s-gruvbox-dark span.cm-builtin { color: #fe8019; }
 .cm-s-gruvbox-dark span.cm-tag { color: #fe8019; }
+
+/* changing cursor color in vim mode */
+.CodeMirror-cursor { background-color: #8e8d8875 !important; }
+
+.CodeMirror-cursors { background-color: #8e8d8875 !important; }
+
+.cm-animate-fat-cursor { background-color: #8e8d8875 !important; }
+

--- a/theme/gruvbox-dark.css
+++ b/theme/gruvbox-dark.css
@@ -37,9 +37,6 @@
 .cm-s-gruvbox-dark span.cm-tag { color: #fe8019; }
 
 /* changing cursor color in vim mode */
-.CodeMirror-cursor { background-color: #8e8d8875 !important; }
-
-.CodeMirror-cursors { background-color: #8e8d8875 !important; }
-
-.cm-animate-fat-cursor { background-color: #8e8d8875 !important; }
+.cm-s-gruvbox-dark .CodeMirror-cursor { background-color: #8e8d8875 !important; }
+.cm-s-gruvbox-dark .cm-animate-fat-cursor { background-color: #8e8d8875 !important; }
 

--- a/theme/material-ocean.css
+++ b/theme/material-ocean.css
@@ -133,3 +133,11 @@
   text-decoration: underline;
   color: white !important;
 }
+
+/* changing cursor color in vim mode */
+.CodeMirror-cursor { background-color: #a2a8a175 !important; }
+
+.CodeMirror-cursors { background-color: #a2a8a175 !important; }
+
+.cm-animate-fat-cursor { background-color: #a2a8a175 !important; }
+

--- a/theme/material-ocean.css
+++ b/theme/material-ocean.css
@@ -5,24 +5,24 @@
 */
 
 .cm-s-material-ocean.CodeMirror {
-  background-color: #0F111A;
-  color: #8F93A2;
+  background-color: #0f111a;
+  color: #8f93a2;
 }
 
 .cm-s-material-ocean .CodeMirror-gutters {
-  background: #0F111A;
-  color: #464B5D;
+  background: #0f111a;
+  color: #464b5d;
   border: none;
 }
 
 .cm-s-material-ocean .CodeMirror-guttermarker,
 .cm-s-material-ocean .CodeMirror-guttermarker-subtle,
 .cm-s-material-ocean .CodeMirror-linenumber {
-  color: #464B5D;
+  color: #464b5d;
 }
 
 .cm-s-material-ocean .CodeMirror-cursor {
-  border-left: 1px solid #FFCC00;
+  border-left: 1px solid #ffcc00;
 }
 
 .cm-s-material-ocean div.CodeMirror-selected {
@@ -34,14 +34,14 @@
 }
 
 .cm-s-material-ocean .CodeMirror-line::selection,
-.cm-s-material-ocean .CodeMirror-line>span::selection,
-.cm-s-material-ocean .CodeMirror-line>span>span::selection {
+.cm-s-material-ocean .CodeMirror-line > span::selection,
+.cm-s-material-ocean .CodeMirror-line > span > span::selection {
   background: rgba(128, 203, 196, 0.2);
 }
 
 .cm-s-material-ocean .CodeMirror-line::-moz-selection,
-.cm-s-material-ocean .CodeMirror-line>span::-moz-selection,
-.cm-s-material-ocean .CodeMirror-line>span>span::-moz-selection {
+.cm-s-material-ocean .CodeMirror-line > span::-moz-selection,
+.cm-s-material-ocean .CodeMirror-line > span > span::-moz-selection {
   background: rgba(128, 203, 196, 0.2);
 }
 
@@ -50,15 +50,15 @@
 }
 
 .cm-s-material-ocean .cm-keyword {
-  color: #C792EA;
+  color: #c792ea;
 }
 
 .cm-s-material-ocean .cm-operator {
-  color: #89DDFF;
+  color: #89ddff;
 }
 
 .cm-s-material-ocean .cm-variable-2 {
-  color: #EEFFFF;
+  color: #eeffff;
 }
 
 .cm-s-material-ocean .cm-variable-3,
@@ -67,23 +67,23 @@
 }
 
 .cm-s-material-ocean .cm-builtin {
-  color: #FFCB6B;
+  color: #ffcb6b;
 }
 
 .cm-s-material-ocean .cm-atom {
-  color: #F78C6C;
+  color: #f78c6c;
 }
 
 .cm-s-material-ocean .cm-number {
-  color: #FF5370;
+  color: #ff5370;
 }
 
 .cm-s-material-ocean .cm-def {
-  color: #82AAFF;
+  color: #82aaff;
 }
 
 .cm-s-material-ocean .cm-string {
-  color: #C3E88D;
+  color: #c3e88d;
 }
 
 .cm-s-material-ocean .cm-string-2 {
@@ -91,7 +91,7 @@
 }
 
 .cm-s-material-ocean .cm-comment {
-  color: #464B5D;
+  color: #464b5d;
 }
 
 .cm-s-material-ocean .cm-variable {
@@ -99,37 +99,48 @@
 }
 
 .cm-s-material-ocean .cm-tag {
-  color: #FF5370;
+  color: #ff5370;
 }
 
 .cm-s-material-ocean .cm-meta {
-  color: #FFCB6B;
+  color: #ffcb6b;
 }
 
 .cm-s-material-ocean .cm-attribute {
-  color: #C792EA;
+  color: #c792ea;
 }
 
 .cm-s-material-ocean .cm-property {
-  color: #C792EA;
+  color: #c792ea;
 }
 
 .cm-s-material-ocean .cm-qualifier {
-  color: #DECB6B;
+  color: #decb6b;
 }
 
 .cm-s-material-ocean .cm-variable-3,
 .cm-s-material-ocean .cm-type {
-  color: #DECB6B;
+  color: #decb6b;
 }
 
-
 .cm-s-material-ocean .cm-error {
-  color: rgba(255, 255, 255, 1.0);
-  background-color: #FF5370;
+  color: rgba(255, 255, 255, 1);
+  background-color: #ff5370;
 }
 
 .cm-s-material-ocean .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;
+}
+
+.CodeMirror-cursor {
+  background-color: #a2a8a175 !important;
+}
+
+.CodeMirror-cursors {
+  background-color: #a2a8a175 !important;
+}
+
+.cm-animate-fat-cursor {
+  background-color: #a2a8a175 !important;
 }

--- a/theme/material-ocean.css
+++ b/theme/material-ocean.css
@@ -5,24 +5,24 @@
 */
 
 .cm-s-material-ocean.CodeMirror {
-  background-color: #0f111a;
-  color: #8f93a2;
+  background-color: #0F111A;
+  color: #8F93A2;
 }
 
 .cm-s-material-ocean .CodeMirror-gutters {
-  background: #0f111a;
-  color: #464b5d;
+  background: #0F111A;
+  color: #464B5D;
   border: none;
 }
 
 .cm-s-material-ocean .CodeMirror-guttermarker,
 .cm-s-material-ocean .CodeMirror-guttermarker-subtle,
 .cm-s-material-ocean .CodeMirror-linenumber {
-  color: #464b5d;
+  color: #464B5D;
 }
 
 .cm-s-material-ocean .CodeMirror-cursor {
-  border-left: 1px solid #ffcc00;
+  border-left: 1px solid #FFCC00;
 }
 
 .cm-s-material-ocean div.CodeMirror-selected {
@@ -34,14 +34,14 @@
 }
 
 .cm-s-material-ocean .CodeMirror-line::selection,
-.cm-s-material-ocean .CodeMirror-line > span::selection,
-.cm-s-material-ocean .CodeMirror-line > span > span::selection {
+.cm-s-material-ocean .CodeMirror-line>span::selection,
+.cm-s-material-ocean .CodeMirror-line>span>span::selection {
   background: rgba(128, 203, 196, 0.2);
 }
 
 .cm-s-material-ocean .CodeMirror-line::-moz-selection,
-.cm-s-material-ocean .CodeMirror-line > span::-moz-selection,
-.cm-s-material-ocean .CodeMirror-line > span > span::-moz-selection {
+.cm-s-material-ocean .CodeMirror-line>span::-moz-selection,
+.cm-s-material-ocean .CodeMirror-line>span>span::-moz-selection {
   background: rgba(128, 203, 196, 0.2);
 }
 
@@ -50,15 +50,15 @@
 }
 
 .cm-s-material-ocean .cm-keyword {
-  color: #c792ea;
+  color: #C792EA;
 }
 
 .cm-s-material-ocean .cm-operator {
-  color: #89ddff;
+  color: #89DDFF;
 }
 
 .cm-s-material-ocean .cm-variable-2 {
-  color: #eeffff;
+  color: #EEFFFF;
 }
 
 .cm-s-material-ocean .cm-variable-3,
@@ -67,23 +67,23 @@
 }
 
 .cm-s-material-ocean .cm-builtin {
-  color: #ffcb6b;
+  color: #FFCB6B;
 }
 
 .cm-s-material-ocean .cm-atom {
-  color: #f78c6c;
+  color: #F78C6C;
 }
 
 .cm-s-material-ocean .cm-number {
-  color: #ff5370;
+  color: #FF5370;
 }
 
 .cm-s-material-ocean .cm-def {
-  color: #82aaff;
+  color: #82AAFF;
 }
 
 .cm-s-material-ocean .cm-string {
-  color: #c3e88d;
+  color: #C3E88D;
 }
 
 .cm-s-material-ocean .cm-string-2 {
@@ -91,7 +91,7 @@
 }
 
 .cm-s-material-ocean .cm-comment {
-  color: #464b5d;
+  color: #464B5D;
 }
 
 .cm-s-material-ocean .cm-variable {
@@ -99,48 +99,37 @@
 }
 
 .cm-s-material-ocean .cm-tag {
-  color: #ff5370;
+  color: #FF5370;
 }
 
 .cm-s-material-ocean .cm-meta {
-  color: #ffcb6b;
+  color: #FFCB6B;
 }
 
 .cm-s-material-ocean .cm-attribute {
-  color: #c792ea;
+  color: #C792EA;
 }
 
 .cm-s-material-ocean .cm-property {
-  color: #c792ea;
+  color: #C792EA;
 }
 
 .cm-s-material-ocean .cm-qualifier {
-  color: #decb6b;
+  color: #DECB6B;
 }
 
 .cm-s-material-ocean .cm-variable-3,
 .cm-s-material-ocean .cm-type {
-  color: #decb6b;
+  color: #DECB6B;
 }
 
+
 .cm-s-material-ocean .cm-error {
-  color: rgba(255, 255, 255, 1);
-  background-color: #ff5370;
+  color: rgba(255, 255, 255, 1.0);
+  background-color: #FF5370;
 }
 
 .cm-s-material-ocean .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;
-}
-
-.CodeMirror-cursor {
-  background-color: #a2a8a175 !important;
-}
-
-.CodeMirror-cursors {
-  background-color: #a2a8a175 !important;
-}
-
-.cm-animate-fat-cursor {
-  background-color: #a2a8a175 !important;
 }

--- a/theme/material-ocean.css
+++ b/theme/material-ocean.css
@@ -135,9 +135,6 @@
 }
 
 /* changing cursor color in vim mode */
-.CodeMirror-cursor { background-color: #a2a8a175 !important; }
-
-.CodeMirror-cursors { background-color: #a2a8a175 !important; }
-
-.cm-animate-fat-cursor { background-color: #a2a8a175 !important; }
+.cm-s-material-ocean .CodeMirror-cursor { background-color: #a2a8a175 !important; }
+.cm-s-material-ocean .cm-animate-fat-cursor { background-color: #a2a8a175 !important; }
 

--- a/theme/material-palenight.css
+++ b/theme/material-palenight.css
@@ -5,24 +5,24 @@
 */
 
 .cm-s-material-palenight.CodeMirror {
-  background-color: #292d3e;
-  color: #a6accd;
+  background-color: #292D3E;
+  color: #A6ACCD;
 }
 
 .cm-s-material-palenight .CodeMirror-gutters {
-  background: #292d3e;
-  color: #676e95;
+  background: #292D3E;
+  color: #676E95;
   border: none;
 }
 
 .cm-s-material-palenight .CodeMirror-guttermarker,
 .cm-s-material-palenight .CodeMirror-guttermarker-subtle,
 .cm-s-material-palenight .CodeMirror-linenumber {
-  color: #676e95;
+  color: #676E95;
 }
 
 .cm-s-material-palenight .CodeMirror-cursor {
-  border-left: 1px solid #ffcc00;
+  border-left: 1px solid #FFCC00;
 }
 
 .cm-s-material-palenight div.CodeMirror-selected {
@@ -34,14 +34,14 @@
 }
 
 .cm-s-material-palenight .CodeMirror-line::selection,
-.cm-s-material-palenight .CodeMirror-line > span::selection,
-.cm-s-material-palenight .CodeMirror-line > span > span::selection {
+.cm-s-material-palenight .CodeMirror-line>span::selection,
+.cm-s-material-palenight .CodeMirror-line>span>span::selection {
   background: rgba(128, 203, 196, 0.2);
 }
 
 .cm-s-material-palenight .CodeMirror-line::-moz-selection,
-.cm-s-material-palenight .CodeMirror-line > span::-moz-selection,
-.cm-s-material-palenight .CodeMirror-line > span > span::-moz-selection {
+.cm-s-material-palenight .CodeMirror-line>span::-moz-selection,
+.cm-s-material-palenight .CodeMirror-line>span>span::-moz-selection {
   background: rgba(128, 203, 196, 0.2);
 }
 
@@ -50,15 +50,15 @@
 }
 
 .cm-s-material-palenight .cm-keyword {
-  color: #c792ea;
+  color: #C792EA;
 }
 
 .cm-s-material-palenight .cm-operator {
-  color: #89ddff;
+  color: #89DDFF;
 }
 
 .cm-s-material-palenight .cm-variable-2 {
-  color: #eeffff;
+  color: #EEFFFF;
 }
 
 .cm-s-material-palenight .cm-variable-3,
@@ -67,23 +67,23 @@
 }
 
 .cm-s-material-palenight .cm-builtin {
-  color: #ffcb6b;
+  color: #FFCB6B;
 }
 
 .cm-s-material-palenight .cm-atom {
-  color: #f78c6c;
+  color: #F78C6C;
 }
 
 .cm-s-material-palenight .cm-number {
-  color: #ff5370;
+  color: #FF5370;
 }
 
 .cm-s-material-palenight .cm-def {
-  color: #82aaff;
+  color: #82AAFF;
 }
 
 .cm-s-material-palenight .cm-string {
-  color: #c3e88d;
+  color: #C3E88D;
 }
 
 .cm-s-material-palenight .cm-string-2 {
@@ -91,7 +91,7 @@
 }
 
 .cm-s-material-palenight .cm-comment {
-  color: #676e95;
+  color: #676E95;
 }
 
 .cm-s-material-palenight .cm-variable {
@@ -99,48 +99,37 @@
 }
 
 .cm-s-material-palenight .cm-tag {
-  color: #ff5370;
+  color: #FF5370;
 }
 
 .cm-s-material-palenight .cm-meta {
-  color: #ffcb6b;
+  color: #FFCB6B;
 }
 
 .cm-s-material-palenight .cm-attribute {
-  color: #c792ea;
+  color: #C792EA;
 }
 
 .cm-s-material-palenight .cm-property {
-  color: #c792ea;
+  color: #C792EA;
 }
 
 .cm-s-material-palenight .cm-qualifier {
-  color: #decb6b;
+  color: #DECB6B;
 }
 
 .cm-s-material-palenight .cm-variable-3,
 .cm-s-material-palenight .cm-type {
-  color: #decb6b;
+  color: #DECB6B;
 }
 
+
 .cm-s-material-palenight .cm-error {
-  color: rgba(255, 255, 255, 1);
-  background-color: #ff5370;
+  color: rgba(255, 255, 255, 1.0);
+  background-color: #FF5370;
 }
 
 .cm-s-material-palenight .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;
-}
-
-.CodeMirror-cursor {
-  background-color: #607c8b80 !important;
-}
-
-.CodeMirror-cursors {
-  background-color: #607c8b80 !important;
-}
-
-.cm-animate-fat-cursor {
-  background-color: #607c8b80 !important;
 }

--- a/theme/material-palenight.css
+++ b/theme/material-palenight.css
@@ -5,24 +5,24 @@
 */
 
 .cm-s-material-palenight.CodeMirror {
-  background-color: #292D3E;
-  color: #A6ACCD;
+  background-color: #292d3e;
+  color: #a6accd;
 }
 
 .cm-s-material-palenight .CodeMirror-gutters {
-  background: #292D3E;
-  color: #676E95;
+  background: #292d3e;
+  color: #676e95;
   border: none;
 }
 
 .cm-s-material-palenight .CodeMirror-guttermarker,
 .cm-s-material-palenight .CodeMirror-guttermarker-subtle,
 .cm-s-material-palenight .CodeMirror-linenumber {
-  color: #676E95;
+  color: #676e95;
 }
 
 .cm-s-material-palenight .CodeMirror-cursor {
-  border-left: 1px solid #FFCC00;
+  border-left: 1px solid #ffcc00;
 }
 
 .cm-s-material-palenight div.CodeMirror-selected {
@@ -34,14 +34,14 @@
 }
 
 .cm-s-material-palenight .CodeMirror-line::selection,
-.cm-s-material-palenight .CodeMirror-line>span::selection,
-.cm-s-material-palenight .CodeMirror-line>span>span::selection {
+.cm-s-material-palenight .CodeMirror-line > span::selection,
+.cm-s-material-palenight .CodeMirror-line > span > span::selection {
   background: rgba(128, 203, 196, 0.2);
 }
 
 .cm-s-material-palenight .CodeMirror-line::-moz-selection,
-.cm-s-material-palenight .CodeMirror-line>span::-moz-selection,
-.cm-s-material-palenight .CodeMirror-line>span>span::-moz-selection {
+.cm-s-material-palenight .CodeMirror-line > span::-moz-selection,
+.cm-s-material-palenight .CodeMirror-line > span > span::-moz-selection {
   background: rgba(128, 203, 196, 0.2);
 }
 
@@ -50,15 +50,15 @@
 }
 
 .cm-s-material-palenight .cm-keyword {
-  color: #C792EA;
+  color: #c792ea;
 }
 
 .cm-s-material-palenight .cm-operator {
-  color: #89DDFF;
+  color: #89ddff;
 }
 
 .cm-s-material-palenight .cm-variable-2 {
-  color: #EEFFFF;
+  color: #eeffff;
 }
 
 .cm-s-material-palenight .cm-variable-3,
@@ -67,23 +67,23 @@
 }
 
 .cm-s-material-palenight .cm-builtin {
-  color: #FFCB6B;
+  color: #ffcb6b;
 }
 
 .cm-s-material-palenight .cm-atom {
-  color: #F78C6C;
+  color: #f78c6c;
 }
 
 .cm-s-material-palenight .cm-number {
-  color: #FF5370;
+  color: #ff5370;
 }
 
 .cm-s-material-palenight .cm-def {
-  color: #82AAFF;
+  color: #82aaff;
 }
 
 .cm-s-material-palenight .cm-string {
-  color: #C3E88D;
+  color: #c3e88d;
 }
 
 .cm-s-material-palenight .cm-string-2 {
@@ -91,7 +91,7 @@
 }
 
 .cm-s-material-palenight .cm-comment {
-  color: #676E95;
+  color: #676e95;
 }
 
 .cm-s-material-palenight .cm-variable {
@@ -99,37 +99,48 @@
 }
 
 .cm-s-material-palenight .cm-tag {
-  color: #FF5370;
+  color: #ff5370;
 }
 
 .cm-s-material-palenight .cm-meta {
-  color: #FFCB6B;
+  color: #ffcb6b;
 }
 
 .cm-s-material-palenight .cm-attribute {
-  color: #C792EA;
+  color: #c792ea;
 }
 
 .cm-s-material-palenight .cm-property {
-  color: #C792EA;
+  color: #c792ea;
 }
 
 .cm-s-material-palenight .cm-qualifier {
-  color: #DECB6B;
+  color: #decb6b;
 }
 
 .cm-s-material-palenight .cm-variable-3,
 .cm-s-material-palenight .cm-type {
-  color: #DECB6B;
+  color: #decb6b;
 }
 
-
 .cm-s-material-palenight .cm-error {
-  color: rgba(255, 255, 255, 1.0);
-  background-color: #FF5370;
+  color: rgba(255, 255, 255, 1);
+  background-color: #ff5370;
 }
 
 .cm-s-material-palenight .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;
+}
+
+.CodeMirror-cursor {
+  background-color: #607c8b80 !important;
+}
+
+.CodeMirror-cursors {
+  background-color: #607c8b80 !important;
+}
+
+.cm-animate-fat-cursor {
+  background-color: #607c8b80 !important;
 }

--- a/theme/material-palenight.css
+++ b/theme/material-palenight.css
@@ -135,8 +135,5 @@
 }
 
 /* changing cursor colors in vim mode */
-.CodeMirror-cursor { background-color: #607c8b80 !important; }
-
-.CodeMirror-cursors { background-color: #607c8b80 !important; }
-
-.cm-animate-fat-cursor { background-color: #607c8b80 !important; }
+.cm-s-material-palenight .CodeMirror-cursor { background-color: #607c8b80 !important; }
+.cm-s-material-palenight .cm-animate-fat-cursor { background-color: #607c8b80 !important; }

--- a/theme/material-palenight.css
+++ b/theme/material-palenight.css
@@ -133,3 +133,10 @@
   text-decoration: underline;
   color: white !important;
 }
+
+/* changing cursor colors in vim mode */
+.CodeMirror-cursor { background-color: #607c8b80 !important; }
+
+.CodeMirror-cursors { background-color: #607c8b80 !important; }
+
+.cm-animate-fat-cursor { background-color: #607c8b80 !important; }

--- a/theme/material.css
+++ b/theme/material.css
@@ -133,3 +133,11 @@
   text-decoration: underline;
   color: white !important;
 }
+
+/* changing cursor color in vim mode */
+.CodeMirror-cursor { background-color: #5d6d5c80 !important; }
+
+.CodeMirror-cursors { background-color: #5d6d5c80 !important; }
+
+.cm-animate-fat-cursor { background-color: #5d6d5c80 !important; }
+

--- a/theme/material.css
+++ b/theme/material.css
@@ -135,9 +135,6 @@
 }
 
 /* changing cursor color in vim mode */
-.CodeMirror-cursor { background-color: #5d6d5c80 !important; }
-
-.CodeMirror-cursors { background-color: #5d6d5c80 !important; }
-
-.cm-animate-fat-cursor { background-color: #5d6d5c80 !important; }
+.cm-s-material .CodeMirror-cursor { background-color: #5d6d5c80 !important; }
+.cm-s-material .cm-animate-fat-cursor { background-color: #5d6d5c80 !important; }
 

--- a/theme/material.css
+++ b/theme/material.css
@@ -6,23 +6,23 @@
 
 .cm-s-material.CodeMirror {
   background-color: #263238;
-  color: #EEFFFF;
+  color: #eeffff;
 }
 
 .cm-s-material .CodeMirror-gutters {
   background: #263238;
-  color: #546E7A;
+  color: #546e7a;
   border: none;
 }
 
 .cm-s-material .CodeMirror-guttermarker,
 .cm-s-material .CodeMirror-guttermarker-subtle,
 .cm-s-material .CodeMirror-linenumber {
-  color: #546E7A;
+  color: #546e7a;
 }
 
 .cm-s-material .CodeMirror-cursor {
-  border-left: 1px solid #FFCC00;
+  border-left: 1px solid #ffcc00;
 }
 
 .cm-s-material div.CodeMirror-selected {
@@ -34,14 +34,14 @@
 }
 
 .cm-s-material .CodeMirror-line::selection,
-.cm-s-material .CodeMirror-line>span::selection,
-.cm-s-material .CodeMirror-line>span>span::selection {
+.cm-s-material .CodeMirror-line > span::selection,
+.cm-s-material .CodeMirror-line > span > span::selection {
   background: rgba(128, 203, 196, 0.2);
 }
 
 .cm-s-material .CodeMirror-line::-moz-selection,
-.cm-s-material .CodeMirror-line>span::-moz-selection,
-.cm-s-material .CodeMirror-line>span>span::-moz-selection {
+.cm-s-material .CodeMirror-line > span::-moz-selection,
+.cm-s-material .CodeMirror-line > span > span::-moz-selection {
   background: rgba(128, 203, 196, 0.2);
 }
 
@@ -50,15 +50,15 @@
 }
 
 .cm-s-material .cm-keyword {
-  color: #C792EA;
+  color: #c792ea;
 }
 
 .cm-s-material .cm-operator {
-  color: #89DDFF;
+  color: #89ddff;
 }
 
 .cm-s-material .cm-variable-2 {
-  color: #EEFFFF;
+  color: #eeffff;
 }
 
 .cm-s-material .cm-variable-3,
@@ -67,23 +67,23 @@
 }
 
 .cm-s-material .cm-builtin {
-  color: #FFCB6B;
+  color: #ffcb6b;
 }
 
 .cm-s-material .cm-atom {
-  color: #F78C6C;
+  color: #f78c6c;
 }
 
 .cm-s-material .cm-number {
-  color: #FF5370;
+  color: #ff5370;
 }
 
 .cm-s-material .cm-def {
-  color: #82AAFF;
+  color: #82aaff;
 }
 
 .cm-s-material .cm-string {
-  color: #C3E88D;
+  color: #c3e88d;
 }
 
 .cm-s-material .cm-string-2 {
@@ -91,7 +91,7 @@
 }
 
 .cm-s-material .cm-comment {
-  color: #546E7A;
+  color: #546e7a;
 }
 
 .cm-s-material .cm-variable {
@@ -99,37 +99,48 @@
 }
 
 .cm-s-material .cm-tag {
-  color: #FF5370;
+  color: #ff5370;
 }
 
 .cm-s-material .cm-meta {
-  color: #FFCB6B;
+  color: #ffcb6b;
 }
 
 .cm-s-material .cm-attribute {
-  color: #C792EA;
+  color: #c792ea;
 }
 
 .cm-s-material .cm-property {
-  color: #C792EA;
+  color: #c792ea;
 }
 
 .cm-s-material .cm-qualifier {
-  color: #DECB6B;
+  color: #decb6b;
 }
 
 .cm-s-material .cm-variable-3,
 .cm-s-material .cm-type {
-  color: #DECB6B;
+  color: #decb6b;
 }
 
-
 .cm-s-material .cm-error {
-  color: rgba(255, 255, 255, 1.0);
-  background-color: #FF5370;
+  color: rgba(255, 255, 255, 1);
+  background-color: #ff5370;
 }
 
 .cm-s-material .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;
+}
+
+.CodeMirror-cursor {
+  background-color: #5d6d5c80 !important;
+}
+
+.CodeMirror-cursors {
+  background-color: #5d6d5c80 !important;
+}
+
+.cm-animate-fat-cursor {
+  background-color: #5d6d5c80 !important;
 }

--- a/theme/material.css
+++ b/theme/material.css
@@ -6,23 +6,23 @@
 
 .cm-s-material.CodeMirror {
   background-color: #263238;
-  color: #eeffff;
+  color: #EEFFFF;
 }
 
 .cm-s-material .CodeMirror-gutters {
   background: #263238;
-  color: #546e7a;
+  color: #546E7A;
   border: none;
 }
 
 .cm-s-material .CodeMirror-guttermarker,
 .cm-s-material .CodeMirror-guttermarker-subtle,
 .cm-s-material .CodeMirror-linenumber {
-  color: #546e7a;
+  color: #546E7A;
 }
 
 .cm-s-material .CodeMirror-cursor {
-  border-left: 1px solid #ffcc00;
+  border-left: 1px solid #FFCC00;
 }
 
 .cm-s-material div.CodeMirror-selected {
@@ -34,14 +34,14 @@
 }
 
 .cm-s-material .CodeMirror-line::selection,
-.cm-s-material .CodeMirror-line > span::selection,
-.cm-s-material .CodeMirror-line > span > span::selection {
+.cm-s-material .CodeMirror-line>span::selection,
+.cm-s-material .CodeMirror-line>span>span::selection {
   background: rgba(128, 203, 196, 0.2);
 }
 
 .cm-s-material .CodeMirror-line::-moz-selection,
-.cm-s-material .CodeMirror-line > span::-moz-selection,
-.cm-s-material .CodeMirror-line > span > span::-moz-selection {
+.cm-s-material .CodeMirror-line>span::-moz-selection,
+.cm-s-material .CodeMirror-line>span>span::-moz-selection {
   background: rgba(128, 203, 196, 0.2);
 }
 
@@ -50,15 +50,15 @@
 }
 
 .cm-s-material .cm-keyword {
-  color: #c792ea;
+  color: #C792EA;
 }
 
 .cm-s-material .cm-operator {
-  color: #89ddff;
+  color: #89DDFF;
 }
 
 .cm-s-material .cm-variable-2 {
-  color: #eeffff;
+  color: #EEFFFF;
 }
 
 .cm-s-material .cm-variable-3,
@@ -67,23 +67,23 @@
 }
 
 .cm-s-material .cm-builtin {
-  color: #ffcb6b;
+  color: #FFCB6B;
 }
 
 .cm-s-material .cm-atom {
-  color: #f78c6c;
+  color: #F78C6C;
 }
 
 .cm-s-material .cm-number {
-  color: #ff5370;
+  color: #FF5370;
 }
 
 .cm-s-material .cm-def {
-  color: #82aaff;
+  color: #82AAFF;
 }
 
 .cm-s-material .cm-string {
-  color: #c3e88d;
+  color: #C3E88D;
 }
 
 .cm-s-material .cm-string-2 {
@@ -91,7 +91,7 @@
 }
 
 .cm-s-material .cm-comment {
-  color: #546e7a;
+  color: #546E7A;
 }
 
 .cm-s-material .cm-variable {
@@ -99,48 +99,37 @@
 }
 
 .cm-s-material .cm-tag {
-  color: #ff5370;
+  color: #FF5370;
 }
 
 .cm-s-material .cm-meta {
-  color: #ffcb6b;
+  color: #FFCB6B;
 }
 
 .cm-s-material .cm-attribute {
-  color: #c792ea;
+  color: #C792EA;
 }
 
 .cm-s-material .cm-property {
-  color: #c792ea;
+  color: #C792EA;
 }
 
 .cm-s-material .cm-qualifier {
-  color: #decb6b;
+  color: #DECB6B;
 }
 
 .cm-s-material .cm-variable-3,
 .cm-s-material .cm-type {
-  color: #decb6b;
+  color: #DECB6B;
 }
 
+
 .cm-s-material .cm-error {
-  color: rgba(255, 255, 255, 1);
-  background-color: #ff5370;
+  color: rgba(255, 255, 255, 1.0);
+  background-color: #FF5370;
 }
 
 .cm-s-material .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;
-}
-
-.CodeMirror-cursor {
-  background-color: #5d6d5c80 !important;
-}
-
-.CodeMirror-cursors {
-  background-color: #5d6d5c80 !important;
-}
-
-.cm-animate-fat-cursor {
-  background-color: #5d6d5c80 !important;
 }

--- a/theme/oceanic-next.css
+++ b/theme/oceanic-next.css
@@ -44,9 +44,6 @@
 }
 
 /* changing cursor color in vim */
-.CodeMirror-cursor { background-color: #a2a8a175 !important; }
-
-.CodeMirror-cursors { background-color: #a2a8a175 !important; }
-
-.cm-animate-fat-cursor { background-color: #a2a8a175 !important; }
+.cm-s-oceanic-next .CodeMirror-cursor { background-color: #a2a8a175 !important; }
+.cm-s-oceanic-next .cm-animate-fat-cursor { background-color: #a2a8a175 !important; }
 

--- a/theme/oceanic-next.css
+++ b/theme/oceanic-next.css
@@ -42,3 +42,11 @@
   text-decoration: underline;
   color: white !important;
 }
+
+/* changing cursor color in vim */
+.CodeMirror-cursor { background-color: #a2a8a175 !important; }
+
+.CodeMirror-cursors { background-color: #a2a8a175 !important; }
+
+.cm-animate-fat-cursor { background-color: #a2a8a175 !important; }
+

--- a/theme/oceanic-next.css
+++ b/theme/oceanic-next.css
@@ -7,105 +7,38 @@
 
 */
 
-.cm-s-oceanic-next.CodeMirror {
-  background: #304148;
-  color: #f8f8f2;
-}
-.cm-s-oceanic-next div.CodeMirror-selected {
-  background: rgba(101, 115, 126, 0.33);
-}
-.cm-s-oceanic-next .CodeMirror-line::selection,
-.cm-s-oceanic-next .CodeMirror-line > span::selection,
-.cm-s-oceanic-next .CodeMirror-line > span > span::selection {
-  background: rgba(101, 115, 126, 0.33);
-}
-.cm-s-oceanic-next .CodeMirror-line::-moz-selection,
-.cm-s-oceanic-next .CodeMirror-line > span::-moz-selection,
-.cm-s-oceanic-next .CodeMirror-line > span > span::-moz-selection {
-  background: rgba(101, 115, 126, 0.33);
-}
-.cm-s-oceanic-next .CodeMirror-gutters {
-  background: #304148;
-  border-right: 10px;
-}
-.cm-s-oceanic-next .CodeMirror-guttermarker {
-  color: white;
-}
-.cm-s-oceanic-next .CodeMirror-guttermarker-subtle {
-  color: #d0d0d0;
-}
-.cm-s-oceanic-next .CodeMirror-linenumber {
-  color: #d0d0d0;
-}
-.cm-s-oceanic-next .CodeMirror-cursor {
-  border-left: 1px solid #f8f8f0;
-}
+.cm-s-oceanic-next.CodeMirror { background: #304148; color: #f8f8f2; }
+.cm-s-oceanic-next div.CodeMirror-selected { background: rgba(101, 115, 126, 0.33); }
+.cm-s-oceanic-next .CodeMirror-line::selection, .cm-s-oceanic-next .CodeMirror-line > span::selection, .cm-s-oceanic-next .CodeMirror-line > span > span::selection { background: rgba(101, 115, 126, 0.33); }
+.cm-s-oceanic-next .CodeMirror-line::-moz-selection, .cm-s-oceanic-next .CodeMirror-line > span::-moz-selection, .cm-s-oceanic-next .CodeMirror-line > span > span::-moz-selection { background: rgba(101, 115, 126, 0.33); }
+.cm-s-oceanic-next .CodeMirror-gutters { background: #304148; border-right: 10px; }
+.cm-s-oceanic-next .CodeMirror-guttermarker { color: white; }
+.cm-s-oceanic-next .CodeMirror-guttermarker-subtle { color: #d0d0d0; }
+.cm-s-oceanic-next .CodeMirror-linenumber { color: #d0d0d0; }
+.cm-s-oceanic-next .CodeMirror-cursor { border-left: 1px solid #f8f8f0; }
 
-.cm-s-oceanic-next span.cm-comment {
-  color: #65737e;
-}
-.cm-s-oceanic-next span.cm-atom {
-  color: #c594c5;
-}
-.cm-s-oceanic-next span.cm-number {
-  color: #f99157;
-}
+.cm-s-oceanic-next span.cm-comment { color: #65737E; }
+.cm-s-oceanic-next span.cm-atom { color: #C594C5; }
+.cm-s-oceanic-next span.cm-number { color: #F99157; }
 
-.cm-s-oceanic-next span.cm-property {
-  color: #99c794;
-}
+.cm-s-oceanic-next span.cm-property { color: #99C794; }
 .cm-s-oceanic-next span.cm-attribute,
-.cm-s-oceanic-next span.cm-keyword {
-  color: #c594c5;
-}
-.cm-s-oceanic-next span.cm-builtin {
-  color: #66d9ef;
-}
-.cm-s-oceanic-next span.cm-string {
-  color: #99c794;
-}
+.cm-s-oceanic-next span.cm-keyword { color: #C594C5; }
+.cm-s-oceanic-next span.cm-builtin { color: #66d9ef; }
+.cm-s-oceanic-next span.cm-string { color: #99C794; }
 
 .cm-s-oceanic-next span.cm-variable,
 .cm-s-oceanic-next span.cm-variable-2,
-.cm-s-oceanic-next span.cm-variable-3 {
-  color: #f8f8f2;
-}
-.cm-s-oceanic-next span.cm-def {
-  color: #6699cc;
-}
-.cm-s-oceanic-next span.cm-bracket {
-  color: #5fb3b3;
-}
-.cm-s-oceanic-next span.cm-tag {
-  color: #c594c5;
-}
-.cm-s-oceanic-next span.cm-header {
-  color: #c594c5;
-}
-.cm-s-oceanic-next span.cm-link {
-  color: #c594c5;
-}
-.cm-s-oceanic-next span.cm-error {
-  background: #c594c5;
-  color: #f8f8f0;
-}
+.cm-s-oceanic-next span.cm-variable-3 { color: #f8f8f2; }
+.cm-s-oceanic-next span.cm-def { color: #6699CC; }
+.cm-s-oceanic-next span.cm-bracket { color: #5FB3B3; }
+.cm-s-oceanic-next span.cm-tag { color: #C594C5; }
+.cm-s-oceanic-next span.cm-header { color: #C594C5; }
+.cm-s-oceanic-next span.cm-link { color: #C594C5; }
+.cm-s-oceanic-next span.cm-error { background: #C594C5; color: #f8f8f0; }
 
-.cm-s-oceanic-next .CodeMirror-activeline-background {
-  background: rgba(101, 115, 126, 0.33);
-}
+.cm-s-oceanic-next .CodeMirror-activeline-background { background: rgba(101, 115, 126, 0.33); }
 .cm-s-oceanic-next .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;
-}
-
-.CodeMirror-cursor {
-  background-color: #a2a8a175 !important;
-}
-
-.CodeMirror-cursors {
-  background-color: #a2a8a175 !important;
-}
-
-.cm-animate-fat-cursor {
-  background-color: #a2a8a175 !important;
 }

--- a/theme/oceanic-next.css
+++ b/theme/oceanic-next.css
@@ -7,38 +7,105 @@
 
 */
 
-.cm-s-oceanic-next.CodeMirror { background: #304148; color: #f8f8f2; }
-.cm-s-oceanic-next div.CodeMirror-selected { background: rgba(101, 115, 126, 0.33); }
-.cm-s-oceanic-next .CodeMirror-line::selection, .cm-s-oceanic-next .CodeMirror-line > span::selection, .cm-s-oceanic-next .CodeMirror-line > span > span::selection { background: rgba(101, 115, 126, 0.33); }
-.cm-s-oceanic-next .CodeMirror-line::-moz-selection, .cm-s-oceanic-next .CodeMirror-line > span::-moz-selection, .cm-s-oceanic-next .CodeMirror-line > span > span::-moz-selection { background: rgba(101, 115, 126, 0.33); }
-.cm-s-oceanic-next .CodeMirror-gutters { background: #304148; border-right: 10px; }
-.cm-s-oceanic-next .CodeMirror-guttermarker { color: white; }
-.cm-s-oceanic-next .CodeMirror-guttermarker-subtle { color: #d0d0d0; }
-.cm-s-oceanic-next .CodeMirror-linenumber { color: #d0d0d0; }
-.cm-s-oceanic-next .CodeMirror-cursor { border-left: 1px solid #f8f8f0; }
+.cm-s-oceanic-next.CodeMirror {
+  background: #304148;
+  color: #f8f8f2;
+}
+.cm-s-oceanic-next div.CodeMirror-selected {
+  background: rgba(101, 115, 126, 0.33);
+}
+.cm-s-oceanic-next .CodeMirror-line::selection,
+.cm-s-oceanic-next .CodeMirror-line > span::selection,
+.cm-s-oceanic-next .CodeMirror-line > span > span::selection {
+  background: rgba(101, 115, 126, 0.33);
+}
+.cm-s-oceanic-next .CodeMirror-line::-moz-selection,
+.cm-s-oceanic-next .CodeMirror-line > span::-moz-selection,
+.cm-s-oceanic-next .CodeMirror-line > span > span::-moz-selection {
+  background: rgba(101, 115, 126, 0.33);
+}
+.cm-s-oceanic-next .CodeMirror-gutters {
+  background: #304148;
+  border-right: 10px;
+}
+.cm-s-oceanic-next .CodeMirror-guttermarker {
+  color: white;
+}
+.cm-s-oceanic-next .CodeMirror-guttermarker-subtle {
+  color: #d0d0d0;
+}
+.cm-s-oceanic-next .CodeMirror-linenumber {
+  color: #d0d0d0;
+}
+.cm-s-oceanic-next .CodeMirror-cursor {
+  border-left: 1px solid #f8f8f0;
+}
 
-.cm-s-oceanic-next span.cm-comment { color: #65737E; }
-.cm-s-oceanic-next span.cm-atom { color: #C594C5; }
-.cm-s-oceanic-next span.cm-number { color: #F99157; }
+.cm-s-oceanic-next span.cm-comment {
+  color: #65737e;
+}
+.cm-s-oceanic-next span.cm-atom {
+  color: #c594c5;
+}
+.cm-s-oceanic-next span.cm-number {
+  color: #f99157;
+}
 
-.cm-s-oceanic-next span.cm-property { color: #99C794; }
+.cm-s-oceanic-next span.cm-property {
+  color: #99c794;
+}
 .cm-s-oceanic-next span.cm-attribute,
-.cm-s-oceanic-next span.cm-keyword { color: #C594C5; }
-.cm-s-oceanic-next span.cm-builtin { color: #66d9ef; }
-.cm-s-oceanic-next span.cm-string { color: #99C794; }
+.cm-s-oceanic-next span.cm-keyword {
+  color: #c594c5;
+}
+.cm-s-oceanic-next span.cm-builtin {
+  color: #66d9ef;
+}
+.cm-s-oceanic-next span.cm-string {
+  color: #99c794;
+}
 
 .cm-s-oceanic-next span.cm-variable,
 .cm-s-oceanic-next span.cm-variable-2,
-.cm-s-oceanic-next span.cm-variable-3 { color: #f8f8f2; }
-.cm-s-oceanic-next span.cm-def { color: #6699CC; }
-.cm-s-oceanic-next span.cm-bracket { color: #5FB3B3; }
-.cm-s-oceanic-next span.cm-tag { color: #C594C5; }
-.cm-s-oceanic-next span.cm-header { color: #C594C5; }
-.cm-s-oceanic-next span.cm-link { color: #C594C5; }
-.cm-s-oceanic-next span.cm-error { background: #C594C5; color: #f8f8f0; }
+.cm-s-oceanic-next span.cm-variable-3 {
+  color: #f8f8f2;
+}
+.cm-s-oceanic-next span.cm-def {
+  color: #6699cc;
+}
+.cm-s-oceanic-next span.cm-bracket {
+  color: #5fb3b3;
+}
+.cm-s-oceanic-next span.cm-tag {
+  color: #c594c5;
+}
+.cm-s-oceanic-next span.cm-header {
+  color: #c594c5;
+}
+.cm-s-oceanic-next span.cm-link {
+  color: #c594c5;
+}
+.cm-s-oceanic-next span.cm-error {
+  background: #c594c5;
+  color: #f8f8f0;
+}
 
-.cm-s-oceanic-next .CodeMirror-activeline-background { background: rgba(101, 115, 126, 0.33); }
+.cm-s-oceanic-next .CodeMirror-activeline-background {
+  background: rgba(101, 115, 126, 0.33);
+}
 .cm-s-oceanic-next .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;
+}
+
+.CodeMirror-cursor {
+  background-color: #a2a8a175 !important;
+}
+
+.CodeMirror-cursors {
+  background-color: #a2a8a175 !important;
+}
+
+.cm-animate-fat-cursor {
+  background-color: #a2a8a175 !important;
 }


### PR DESCRIPTION
<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
Changed the cursor color in some theme styles. Changes were made in ayu-dark, ayu-mirage, gruvbox-dark, base16-dark, material-palenight, material , material ocean and oceanic-next. Will be adding more changes for other respective themes

Edit: I am surprised to see the number of changes. Cause I didn't change this much and realized that this was a formatting thing.