### PR TITLE
[soy mode] Add support for const and export const.

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -25,7 +25,7 @@
     "@state": paramData,
     "template": { soyState: "templ-def", variableScope: true},
     "extern": {soyState: "param-def"},
-    "export": {soyState: "param-def"},
+    "export": {soyState: "export"},
     "literal": { },
     "msg": {},
     "fallbackmsg": { noEndTag: true, reduceIndent: true},
@@ -49,6 +49,7 @@
     "log": {},
     "element": { variableScope: true },
     "velog": {},
+    "const": { soyState: "const-def"},
   };
 
   var indentingTags = Object.keys(tags).filter(function(tag) {
@@ -285,9 +286,6 @@
               return "type";
             }
             if (match = stream.match(/^\w+/)) {
-              if (match[0] == 'extern') {
-                return 'keyword';
-              }
               state.variables = prepend(state.variables, match[0]);
               state.soyState.pop();
               state.soyState.push("param-type");
@@ -528,6 +526,27 @@
               return this.token(stream, state);
             }
             return tokenUntil(stream, state, /\{\/literal}/);
+          case "export":
+            if (match = stream.match(/\w+/)) {
+              state.soyState.pop();
+              if (match == "const") {
+                state.soyState.push("const-def")
+                return "keyword";
+              } else if (match == "extern") {
+                state.soyState.push("param-def")
+                return "keyword";
+              }
+            } else {
+              stream.next();
+            }
+            return null;
+          case "const-def":
+            if (stream.match(/^\w+/)) {
+              state.soyState.pop();
+              return "def";
+            }
+            stream.next();
+            return null;
         }
 
         if (stream.match('{literal}')) {

--- a/mode/soy/test.js
+++ b/mode/soy/test.js
@@ -315,4 +315,8 @@
   MT('extern', '[keyword {extern] [def renderer]: ([def s]:[type string])=>[type string][keyword }] [keyword {/extern}]');
 
   MT('export extern', '[keyword {export] [keyword extern] [def renderer]: ([def s]:[type string])=>[type string][keyword }] [keyword {/extern}]');
+
+  MT('const',
+    '[keyword {const] [def FOO] = [atom 5] [keyword /}]',
+    '[keyword {export] [keyword const] [def FOO] = [atom 5] [keyword /}]');
 })();


### PR DESCRIPTION
Add support to soy for:
{const FOO = 5 /}
{export const FOO = 5 /}
