### PR TITLE
Fix #6660. Created regex to match all uppercase ascii/cyrillic chars

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -910,6 +910,7 @@ Wesley Wiser
 Weston Ruter
 Will Binns-Smith
 Will Dean
+Will Hernandez
 William Desportes
 William Jamieson
 William Stein

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -420,6 +420,7 @@
     var numbers = makeKeyRange(48, 10);
     var validMarks = [].concat(upperCaseAlphabet, lowerCaseAlphabet, numbers, ['<', '>']);
     var validRegisters = [].concat(upperCaseAlphabet, lowerCaseAlphabet, numbers, ['-', '"', '.', ':', '_', '/']);
+    var upperCaseChars;
 
     function isLine(cm, line) {
       return line >= cm.firstLine() && line <= cm.lastLine();
@@ -434,7 +435,12 @@
       return numberRegex.test(k);
     }
     function isUpperCase(k) {
-      return (/^[A-Z]$/).test(k);
+      try {
+        upperCaseChars = new RegExp("^[\\p{Lu}]$", "u");
+      } catch (_) {
+        upperCaseChars = /^[A-Z]$/;
+      }
+      return upperCaseChars.test(k);
     }
     function isWhiteSpaceString(k) {
       return (/^\s*$/).test(k);


### PR DESCRIPTION
https://github.com/codemirror/CodeMirror/issues/6660
Created a regex that will match  all uppercase ascii/cyrillic characters. This will improve the accuracy of function isUpperCase() and allow vim shortcut "shift + ~" to convert lowerCaseChars => upperCaseChars & upperCaseChars => lowerCaseChars on cyrillic characters.