### PR TITLE
Highlighted 'var' keyword in Java

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -484,7 +484,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
                     "instanceof interface native new package private protected public " +
                     "return static strictfp super switch synchronized this throw throws transient " +
                     "try volatile while @interface"),
-    types: words("byte short int long float double boolean char void Boolean Byte Character Double Float " +
+    types: words("var byte short int long float double boolean char void Boolean Byte Character Double Float " +
                  "Integer Long Number Object Short String StringBuffer StringBuilder Void"),
     blockKeywords: words("catch class do else finally for if switch try while"),
     defKeywords: words("class interface enum @interface"),


### PR DESCRIPTION
https://github.com/codemirror/CodeMirror/issues/6545
Added the 'var' keyword to the "text/java" types word string. var keyword is now highlighted in the same way 'int' is currently.
Can place 'var' in another section eg. keywords: words('var') etc if you would rather 'var' match other elements. thanks
