### PR TITLE
Add python 3 string prefix `rb` and `rf`

### DIFF
--- a/mode/python/python.js
+++ b/mode/python/python.js
@@ -62,7 +62,7 @@
       var identifiers = parserConf.identifiers|| /^[_A-Za-z\u00A1-\uFFFF][_A-Za-z0-9\u00A1-\uFFFF]*/;
       myKeywords = myKeywords.concat(["nonlocal", "False", "True", "None", "async", "await"]);
       myBuiltins = myBuiltins.concat(["ascii", "bytes", "exec", "print"]);
-      var stringPrefixes = new RegExp("^(([rbuf]|(br)|(fr))?('{3}|\"{3}|['\"]))", "i");
+      var stringPrefixes = new RegExp("^(([rbuf]|(br)|(rb)|(fr)|(rf))?('{3}|\"{3}|['\"]))", "i");
     } else {
       var identifiers = parserConf.identifiers|| /^[_A-Za-z][_A-Za-z0-9]*/;
       myKeywords = myKeywords.concat(["exec", "print"]);


### PR DESCRIPTION
Added `rb` and `rf` to python highlighter.

Only added to python 3 because there's no f-string in python2.

Now we support all python string prefix. See : https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals

fixes #6727