### PR TITLE
Improve folding addon performance

### DIFF
--- a/addon/fold/foldcode.js
+++ b/addon/fold/foldcode.js
@@ -106,13 +106,13 @@
   CodeMirror.commands.foldAll = function(cm) {
     cm.operation(function() {
       for (var i = cm.firstLine(), e = cm.lastLine(); i <= e; i++)
-        cm.foldCode(CodeMirror.Pos(i, 0), null, "fold");
+        cm.foldCode(CodeMirror.Pos(i, 0), { scanUp: false }, "fold");
     });
   };
   CodeMirror.commands.unfoldAll = function(cm) {
     cm.operation(function() {
       for (var i = cm.firstLine(), e = cm.lastLine(); i <= e; i++)
-        cm.foldCode(CodeMirror.Pos(i, 0), null, "unfold");
+        cm.foldCode(CodeMirror.Pos(i, 0), { scanUp: false }, "unfold");
     });
   };
 

--- a/addon/fold/foldcode.js
+++ b/addon/fold/foldcode.js
@@ -24,9 +24,11 @@
     function getRange(allowFolded) {
       var range = finder(cm, pos);
       if (!range || range.to.line - range.from.line < minSize) return null;
+      if (force === "fold") return range;
+
       var marks = cm.findMarksAt(range.from);
       for (var i = 0; i < marks.length; ++i) {
-        if (marks[i].__isFold && force !== "fold") {
+        if (marks[i].__isFold) {
           if (!allowFolded) return null;
           range.cleared = true;
           marks[i].clear();

--- a/addon/fold/foldcode.js
+++ b/addon/fold/foldcode.js
@@ -101,7 +101,7 @@
     cm.foldCode(cm.getCursor(), null, "fold");
   };
   CodeMirror.commands.unfold = function(cm) {
-    cm.foldCode(cm.getCursor(), null, "unfold");
+    cm.foldCode(cm.getCursor(), { scanUp: false }, "unfold");
   };
   CodeMirror.commands.foldAll = function(cm) {
     cm.operation(function() {


### PR DESCRIPTION
A couple of perforance improvements for the fold code addon

## Don't use scanUp for some fold commands

For the `foldAll` and `unfoldAll` commands, the fold addon already iterates through every line in the file, so a secondary loop upward, for every line, is wasteful.

For the `unfold` command, `doFold` exits after `getRange` anyway, and depends on the marker clearing side effect in `getRange` for unfolding. When scanning up, these ranges are not unfolded anyway because of the `allowFolded` check, so having scanUp enabled just causes a bunch of extra `findMarksAt` calls for no reason.

## Exit `getRange` early if `force` is "fold"

`getRange` iterates over all marks at a position and then checks for `force === "fold"` at each loop iteration. This change exits before the loop instead, saving the call to `getMarksAt` and the iteration.
