### PR TITLE
Folding: Allow custom textMarkers

### DIFF
--- a/addon/fold/foldcode.js
+++ b/addon/fold/foldcode.js
@@ -47,11 +47,7 @@
       myRange.clear();
       CodeMirror.e_preventDefault(e);
     });
-    var myRange = cm.markText(range.from, range.to, {
-      replacedWith: myWidget,
-      clearOnEnter: getOption(cm, options, "clearOnEnter"),
-      __isFold: true
-    });
+    var myRange = makeMarker(cm, options, range, myWidget);
     myRange.on("clear", function(from, to) {
       CodeMirror.signal(cm, "unfold", cm, from, to);
     });
@@ -74,6 +70,25 @@
       widget = widget.cloneNode(true)
     }
     return widget;
+  }
+
+  function makeMarker(cm, options, range, widget) {
+    var markerGenerator = getOption(cm, options, "marker");
+    var clearOnEnter = getOption(cm, options, "clearOnEnter");
+    var marker;
+
+    if (typeof markerGenerator === "function") {
+      marker = markerGenerator(range.from, range.to, widget, clearOnEnter);
+      marker.__isFold = true;
+    } else {
+      marker = cm.markText(range.from, range.to, {
+        replacedWith: widget,
+        clearOnEnter: clearOnEnter,
+        __isFold: true
+      });
+    }
+
+    return marker;
   }
 
   // Clumsy backwards-compatible interface


### PR DESCRIPTION
Adds a `marker` option to `foldOptions`, to complement the existing `widget` option.

The `marker` value is expected to be a function that accepts a start and end range, a widget, and boolean for `clearOnEnter`, and returns a TextMarker.

This allows customization of the text marker for inclusive/select left/right properties, custom clear behavior, overriding `clearWhenEmpty`, and can be used as an entry point for code that should be run before adding a fold.