### PR TITLE
Fix passing in Lint options that are not provided as a default.

### DIFF
--- a/addon/lint/lint.js
+++ b/addon/lint/lint.js
@@ -67,7 +67,7 @@
     this.linterOptions = conf.options || {};
     for (var prop in defaults) this.options[prop] = defaults[prop];
     for (var prop in conf) {
-      if (defaults.hasOwnProperty(prop)) {
+      if (conf.hasOwnProperty(prop)) {
         if (conf[prop] != null) this.options[prop] = conf[prop];
       } else if (!conf.options) {
         this.linterOptions[prop] = conf[prop];
@@ -83,12 +83,7 @@
     highlightLines: false,
     tooltips: true,
     delay: 500,
-    lintOnChange: true,
-    getAnnotations: null,
-    async: false,
-    selfContain: null,
-    formatAnnotation: null,
-    onUpdateLinting: null
+    lintOnChange: true
   }
 
   function clearMarks(cm) {
@@ -223,9 +218,9 @@
       // use original annotations[line] to show multiple messages
       if (state.hasGutter)
         cm.setGutterMarker(line, GUTTER_ID, makeMarker(cm, tipLabel, maxSeverity, annotations[line].length > 1,
-                                                       options.tooltips));
+                                                       state.options.tooltips));
 
-      if (options.highlightLines)
+      if (state.options.highlightLines)
         cm.addLineClass(line, "wrap", LINT_LINE_ID + maxSeverity);
     }
     if (options.onUpdateLinting) options.onUpdateLinting(annotationsNotSorted, annotations, cm);


### PR DESCRIPTION
Fixes #6748

Change the hasOwnProperty check to check the conf object instead of the defaults.

<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
