### PR TITLE
set attribute [translate="no"]

### DIFF
--- a/src/display/Display.js
+++ b/src/display/Display.js
@@ -49,6 +49,10 @@ export function Display(place, doc, input, options) {
   // The element in which the editor lives.
   d.wrapper = elt("div", [d.scrollbarFiller, d.gutterFiller, d.scroller], "CodeMirror")
 
+  // This attribute is respected by automatic translation systems such as Google Translate,
+  // and may also be respected by tools used by human translators.
+  d.wrapper.setAttribute('translate', 'no')
+
   // Work around IE7 z-index bug (not perfect, hence IE7 not really being supported)
   if (ie && ie_version < 8) { d.gutters.style.zIndex = -1; d.scroller.style.paddingRight = 0 }
   if (!webkit && !(gecko && mobile)) d.scroller.draggable = true

--- a/src/display/Display.js
+++ b/src/display/Display.js
@@ -100,10 +100,6 @@ export function Display(place, doc, input, options) {
   // Used to track whether anything happened since the context menu
   // was opened.
   d.selForContextMenu = null
-  
-  // This attribute is respected by automatic translation systems such as Google Translate,
-  // and may also be respected by tools used by human translators.
-  d.setAttribute("translate", "no")
 
   d.activeTouch = null
 

--- a/src/display/Display.js
+++ b/src/display/Display.js
@@ -100,6 +100,10 @@ export function Display(place, doc, input, options) {
   // Used to track whether anything happened since the context menu
   // was opened.
   d.selForContextMenu = null
+  
+  // This attribute is respected by automatic translation systems such as Google Translate,
+  // and may also be respected by tools used by human translators.
+  d.setAttribute("translate", "no")
 
   d.activeTouch = null
 

--- a/test/test.js
+++ b/test/test.js
@@ -2672,3 +2672,7 @@ testCM("mode_lookahead", function(cm) {
   eq(cm.getTokenAt(Pos(0, 1)).type, null)
   eq(cm.getTokenAt(Pos(1, 1)).type, "atom")
 }, {value: "foo\na\nx\nx\n", mode: "lookahead_mode"})
+
+testCM("should has [translate=no]", function (cm) {
+  eq(cm.getWrapperElement().getAttribute("translate"), "no")
+}, {})


### PR DESCRIPTION
<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->

I think don't need to translate programming code.

ref https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate