### PR TITLE
[vim] fix fat cursor for non-monospace fonts

### DIFF
--- a/src/display/selection.js
+++ b/src/display/selection.js
@@ -37,6 +37,11 @@ export function drawSelectionCursor(cm, head, output) {
   cursor.style.top = pos.top + "px"
   cursor.style.height = Math.max(0, pos.bottom - pos.top) * cm.options.cursorHeight + "px"
 
+  if (/cm-fat-cursor/.test(cm.getWrapperElement().className)) {
+    let charPos = charCoords(cm, head, "div", null, null);
+    cursor.style.width = Math.max(0, charPos.right - charPos.left) + "px";
+  }
+
   if (pos.other) {
     // Secondary cursor, shown when on a 'jump' in bi-directional text
     let otherCursor = output.appendChild(elt("div", "\u00a0", "CodeMirror-cursor CodeMirror-secondarycursor"))


### PR DESCRIPTION
This pull request should fix https://github.com/codemirror/CodeMirror/issues/3256

(non monospace font and header size is different from other portion of a text)
![image](https://user-images.githubusercontent.com/910691/129453444-05150c67-cf8d-48b9-8ce9-13a44d08ad06.png)
![image](https://user-images.githubusercontent.com/910691/129453472-d7bd68f3-9bd9-4ee0-99ff-3cf1987090e1.png)



I don't think it's good idea to check if vim mode is enabled directly in `cursorCoords` but I don't really see the better way. 

Could somebody help me with better solution? 

Thanks
