### PR TITLE
Fix emacs scroll-up / scroll-down bindings

### DIFF
--- a/keymap/emacs.js
+++ b/keymap/emacs.js
@@ -330,9 +330,9 @@
 
   cmds.previousLine = move(byLine, -1);
 
-  cmds.scrollDownCommand = move(byPage, 1);
+  cmds.scrollDownCommand = move(byPage, -1);
 
-  cmds.scrollUpCommand = move(byPage, -1);
+  cmds.scrollUpCommand = move(byPage, 1);
 
   cmds.backwardParagraph = move(byParagraph, -1);
 
@@ -480,8 +480,8 @@
     "Home": "goLineStart",
     "Alt-V": "scrollDownCommand",
     "Ctrl-V": "scrollUpCommand",
-    "PageUp": "scrollUpCommand",
-    "PageDown": "scrollDownCommand",
+    "PageUp": "scrollDownCommand",
+    "PageDown": "scrollUpCommand",
     "Ctrl-Up": "backwardParagraph",
     "Ctrl-Down": "forwardParagraph",
     "Alt-{": "backwardParagraph",


### PR DESCRIPTION
Commit https://github.com/codemirror/CodeMirror/commit/97ee57515599e95972567c41ed9176ddfb1f4fb9 changed the baviour of Ctrl-V and Alt-V and I believe this was unintentional.

Previously, it was set to
```
    "Alt-V": move(byPage, -1), "Ctrl-V": move(byPage, 1),
    "PageUp": move(byPage, -1), "PageDown": move(byPage, 1),
```

So Alt-V and PageUp were the same command and Ctrl-V and PageDown likewise.

I think this is the correct behaviour and is as is described here: https://www.gnu.org/software/emacs/manual/html_node/emacs/Scrolling.html

This PR updates it accordingly.
I have set scrollUpCommand to move forward by 1 page, inverting the functionality of that command as that is close to how the command is described in the emacs docs. (And likewise with scrollDownCommand.)