### PR TITLE
Fix 0-width fat cursor at EOL

### DIFF
--- a/src/display/selection.js
+++ b/src/display/selection.js
@@ -39,7 +39,9 @@ export function drawSelectionCursor(cm, head, output) {
 
   if (/\bcm-fat-cursor\b/.test(cm.getWrapperElement().className)) {
     let charPos = charCoords(cm, head, "div", null, null)
-    cursor.style.width = Math.max(0, charPos.right - charPos.left) + "px"
+    if (charPos.right - charPos.left > 0) {
+      cursor.style.width = (charPos.right - charPos.left) + "px"
+    }
   }
 
   if (pos.other) {


### PR DESCRIPTION
In particular the fat cursor would be invisible on empty lines.

<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
