### PR TITLE
[vim] add support for guu

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -951,7 +951,12 @@
           if (!keysMatcher) { clearInputState(cm); return false; }
           var context = vim.visualMode ? 'visual' :
                                          'normal';
-          var match = commandDispatcher.matchCommand(keysMatcher[2] || keysMatcher[1], defaultKeymap, vim.inputState, context);
+          var mainKey = keysMatcher[2] || keysMatcher[1];
+          if (vim.inputState.operatorShortcut && vim.inputState.operatorShortcut.slice(-1) == mainKey) {
+            // multikey operators act linewise by repeating only the last character
+            mainKey = vim.inputState.operatorShortcut;
+          }
+          var match = commandDispatcher.matchCommand(mainKey, defaultKeymap, vim.inputState, context);
           if (match.type == 'none') { clearInputState(cm); return false; }
           else if (match.type == 'partial') { return true; }
 
@@ -1311,6 +1316,9 @@
         }
         inputState.operator = command.operator;
         inputState.operatorArgs = copyArgs(command.operatorArgs);
+        if (command.keys.length > 1) {
+          inputState.operatorShortcut = command.keys;
+        }
         if (command.exitVisualBlock) {
             vim.visualBlock = false;
             updateCmSelection(cm);

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1232,12 +1232,19 @@ testVim('gu_and_gU', function(cm, vim, helpers) {
   eq(cm.getValue(), 'wa wb Xx wc wd');
   eqCursorPos(makeCursor(0, 3), cm.getCursor());
 
-  // TODO: support gUgU guu
-  // eqCursorPos(makeCursor(0, 0), cm.getCursor());
-
   var register = helpers.getRegisterController().getRegister();
   eq('', register.toString());
   is(!register.linewise);
+  
+  cm.setCursor(curStart);
+  cm.setValue('abc efg\nxyz');
+  helpers.doKeys('g', 'U', 'g', 'U');
+  eq(cm.getValue(), 'ABC EFG\nxyz');
+  helpers.doKeys('g', 'u', 'u');
+  eq(cm.getValue(), 'abc efg\nxyz');
+  eqCursorPos(makeCursor(0, 0), cm.getCursor());
+  helpers.doKeys('g', 'U', '2', 'U');
+  eq(cm.getValue(), 'ABC EFG\nXYZ');
 }, { value: 'wa wb xx wc wd' });
 testVim('visual_block_~', function(cm, vim, helpers) {
   cm.setCursor(1, 1);


### PR DESCRIPTION
For multikey operators gu, gU, gq repeating the last key must act the same way as repeating the whole operator.