### PR TITLE
Remove text-shadow from solarized theme.

### DIFF
--- a/theme/solarized.css
+++ b/theme/solarized.css
@@ -124,7 +124,6 @@ http://ethanschoonover.com/solarized/img/solarized-palette.png
 
 .cm-s-solarized.cm-s-dark .CodeMirror-linenumber {
   color: #586e75;
-  text-shadow: #021014 0 -1px;
 }
 
 /* Light */

--- a/theme/solarized.css
+++ b/theme/solarized.css
@@ -35,12 +35,10 @@ http://ethanschoonover.com/solarized/img/solarized-palette.png
 .cm-s-solarized.cm-s-dark {
   color: #839496;
   background-color: #002b36;
-  text-shadow: #002b36 0 1px;
 }
 .cm-s-solarized.cm-s-light {
   background-color: #fdf6e3;
   color: #657b83;
-  text-shadow: #eee8d5 0 1px;
 }
 
 .cm-s-solarized .CodeMirror-widget {


### PR DESCRIPTION
The text drop shadow unnecessarily makes text slightly blurry.