### PR TITLE
Add esm as rollup output

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "5.63.3",
   "main": "lib/codemirror.js",
   "style": "lib/codemirror.css",
+  "type": "module",
+  "exports": {
+    "import": "./lib/codemirror.esm.js",
+    "require": "./addon/runmode/runmode.node.js"
+  },
   "author": {
     "name": "Marijn Haverbeke",
     "email": "marijnh@gmail.com",
@@ -21,11 +26,10 @@
     "lint": "bin/lint"
   },
   "devDependencies": {
-    "@rollup/plugin-buble": "^0.21.3",
     "blint": "^1.1.0",
     "node-static": "0.7.11",
     "puppeteer": "^1.20.0",
-    "rollup": "^1.26.3"
+    "rollup": "^2.59.0"
   },
   "bugs": "http://github.com/codemirror/CodeMirror/issues",
   "keywords": [
@@ -42,6 +46,5 @@
     "directories": {},
     "dependencies": {},
     "devDependencies": {}
-  },
-  "dependencies": {}
+  }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,10 @@
-import buble from '@rollup/plugin-buble';
-
 export default [
   {
-    input: "src/codemirror.js",
+    input: 'src/codemirror.js',
     output: {
+      name: 'CodeMirror',
+      file: 'lib/codemirror.js',
+      format: 'umd',
       banner: `// CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
 
@@ -13,30 +14,32 @@ export default [
 // You can find some technical background for some of the code below
 // at http://marijnhaverbeke.nl/blog/#cm-internals .
 `,
-      format: "umd",
-      file: "lib/codemirror.js",
-      name: "CodeMirror"
     },
-    plugins: [ buble({namedFunctionExpressions: false}) ]
   },
   {
-    input: ["src/addon/runmode/runmode-standalone.js"],
+    input: 'src/addon/runmode/runmode-standalone.js',
     output: {
-      format: "iife",
-      file: "addon/runmode/runmode-standalone.js",
-      name: "CodeMirror",
+      format: 'iife',
+      file: 'addon/runmode/runmode-standalone.js',
+      name: 'CodeMirror',
       freeze: false, // IE8 doesn't support Object.freeze.
-    },
-    plugins: [ buble({namedFunctionExpressions: false}) ]
+    }
   },
   {
-    input: ["src/addon/runmode/runmode.node.js"],
+    input: 'src/addon/runmode/runmode.node.js',
     output: {
-      format: "cjs",
-      file: "addon/runmode/runmode.node.js",
-      name: "CodeMirror",
+      format: 'cjs',
+      file: 'addon/runmode/runmode.node.js',
+      name: 'CodeMirror',
       freeze: false, // IE8 doesn't support Object.freeze.
-    },
-    plugins: [ buble({namedFunctionExpressions: false}) ]
+    }
   },
-];
+  {
+    input: 'src/codemirror.js',
+    output: {
+      format: 'es',
+      file: 'lib/codemirror.esm.js',
+      name: 'CodeMirror'
+    }
+  },
+]


### PR DESCRIPTION
I was trying to use `CodeMirror` in a [SvelteKit](https://kit.svelte.dev/) project. Because `SvelteKit` currently only supports es-modules, and `CodeMirror` didn't have that yet, I added it. How does the configuration look? Anything I should change?