### PR TITLE
Fix bad matches of map, record, from, as, import.

### DIFF
--- a/mode/soy/soy.js
+++ b/mode/soy/soy.js
@@ -140,10 +140,10 @@
         state.context = new Context(state.context, "list-literal", state.variables);
         state.lookupVariables = false;
         return null;
-      } else if (stream.match(/map\b/)) {
+      } else if (stream.match(/\bmap(?=\()/)) {
         state.soyState.push("map-literal");
         return "keyword";
-      } else if (stream.match(/record\b/)) {
+      } else if (stream.match(/\brecord(?=\()/)) {
         state.soyState.push("record-literal");
         return "keyword";
       } else if (stream.match(/([\w]+)(?=\()/)) {
@@ -454,11 +454,11 @@
               state.indent -= 2 * config.indentUnit;
               return null;
             }
-            if (stream.match(/\w+(?=\s+as)/)) {
+            if (stream.match(/\w+(?=\s+as\b)/)) {
               return "variable";
             }
             if (match = stream.match(/\w+/)) {
-              return /(from|as)/.test(match[0]) ? "keyword" : "def";
+              return /\b(from|as)\b/.test(match[0]) ? "keyword" : "def";
             }
             if (match = stream.match(/^["']/)) {
               state.soyState.push("string");
@@ -605,7 +605,7 @@
           state.indent += 2 * config.indentUnit;
           state.soyState.push("tag");
           return "keyword";
-        } else if (!state.context && stream.match(/\bimport\b/)) {
+        } else if (!state.context && stream.sol() && stream.match(/import\b/)) {
           state.soyState.push("import");
           state.indent += 2 * config.indentUnit;
           return "keyword";


### PR DESCRIPTION
Fix, or at least reduce, some issues where keywords are matched in the wrong place.
- `record` should only match as part of `record(foo: 1, bar: 2)`.
- `map` should only match as part of `map("foo": 1, "bar": 2)`.
- `import`, `from` and `as` in the statement `import {foo as bar} from 'my.import';`