### PR TITLE
Update meta.js: add "dataviewjs" as alias for JS

### DIFF
--- a/mode/meta.js
+++ b/mode/meta.js
@@ -71,7 +71,7 @@
     {name: "Java", mime: "text/x-java", mode: "clike", ext: ["java"]},
     {name: "Java Server Pages", mime: "application/x-jsp", mode: "htmlembedded", ext: ["jsp"], alias: ["jsp"]},
     {name: "JavaScript", mimes: ["text/javascript", "text/ecmascript", "application/javascript", "application/x-javascript", "application/ecmascript"],
-     mode: "javascript", ext: ["js"], alias: ["ecmascript", "js", "node"]},
+     mode: "javascript", ext: ["js"], alias: ["ecmascript", "js", "node", "dataviewjs"]},
     {name: "JSON", mimes: ["application/json", "application/x-json"], mode: "javascript", ext: ["json", "map"], alias: ["json5"]},
     {name: "JSON-LD", mime: "application/ld+json", mode: "javascript", ext: ["jsonld"], alias: ["jsonld"]},
     {name: "JSX", mime: "text/jsx", mode: "jsx", ext: ["jsx"]},


### PR DESCRIPTION
Hoping this doesn't count as contributing a new mode, but feel free to close this if I've misread the guidance! 

I'm a user of the [Obsidian.md](https://obsidian.md) note taking app. There is a popular plugin called [Dataview](https://github.com/blacksmithgu/obsidian-dataview/), which allows you to write queries in Javascript to compose/present notes. I've also been using a [syntax highlighting](https://github.com/deathau/cm-editor-syntax-highlight-obsidian) plugin.

Javascript blocks to be used by dataview are annotated with the type `dataviewjs`. This PR just adds an alias to the Javascript mode such that `dataviewjs` blocks are highlighted the same as Javascript.
