### PR TITLE
[nsis mode] fix variable pattern

### DIFF
--- a/mode/nsis/nsis.js
+++ b/mode/nsis/nsis.js
@@ -71,7 +71,7 @@ CodeMirror.defineSimpleMode("nsis",{
     {regex: /[-+\/*=<>!]+/, token: "operator"},
 
     // Variable
-    {regex: /\$\w+/, token: "variable"},
+    {regex: /\$\w[\w\.]+/, token: "variable"},
 
     // Constant
     {regex: /\${[\w\.:-]+}/, token: "variable-2"},


### PR DESCRIPTION
NSIS variables are actually allowed to contain a `.`-character unless it's at the start of the variable name. See [example](https://github.com/kichik/nsis/blob/master/Contrib/Modern%20UI%202/Interface.nsh#L11-L25).