### PR TITLE
[nsis mode] fix defines pattern

### DIFF
--- a/mode/nsis/nsis.js
+++ b/mode/nsis/nsis.js
@@ -74,7 +74,7 @@ CodeMirror.defineSimpleMode("nsis",{
     {regex: /\$\w+/, token: "variable"},
 
     // Constant
-    {regex: /\${[\w\.:-]+}/, token: "variable-2"},
+    {regex: /\${[\!\w\.:-]+}/, token: "variable-2"},
 
     // Language String
     {regex: /\$\([\w\.:-]+\)/, token: "variable-3"}


### PR DESCRIPTION
NSIS definitions can contain `!`-characters, as you can see on the [NSIS wiki](https://nsis.sourceforge.io/Check_if_a_file_exists_at_compile_time) (note the `!define !defineifexist` part)