### PR TITLE
[css mode] add caseInsensitive hint

### DIFF
--- a/addon/hint/css-hint.js
+++ b/addon/hint/css-hint.js
@@ -30,7 +30,7 @@
       return {list: ["!important"], from: CodeMirror.Pos(cur.line, token.start),
               to: CodeMirror.Pos(cur.line, token.end)};
 
-    var start = token.start, end = cur.ch, word = token.string.slice(0, end - start);
+    var start = token.start, end = cur.ch, word = token.string.slice(0, end - start).toLowerCase();
     if (/[^\w$_-]/.test(word)) {
       word = ""; start = end = cur.ch;
     }
@@ -41,7 +41,7 @@
     function add(keywords) {
       for (var name in keywords)
         if (!word || name.lastIndexOf(word, 0) == 0)
-          result.push(name);
+          result.push(keywords[name]);
     }
 
     var st = inner.state.state;

--- a/mode/css/css.js
+++ b/mode/css/css.js
@@ -419,7 +419,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
   function keySet(array) {
     var keys = {};
     for (var i = 0; i < array.length; ++i) {
-      keys[array[i].toLowerCase()] = true;
+      keys[array[i].toLowerCase()] = array[i];
     }
     return keys;
   }

--- a/mode/css/test.js
+++ b/mode/css/test.js
@@ -213,5 +213,11 @@
      "[def @font-face] [comment /* foo */] {",
      "  [property src]: [variable&callee url]([string x]);",
      "  [property font-family]: [variable One];",
-     "}")
+     "}");
+
+  MT("property-with-uPpeRCaSe",
+      "[tag p] { [property cOlOr]:[keyword red]; }");
+
+  MT("keyword-with-uPpeRCaSe",
+      "[tag p] { [property color]:[keyword oRanGe]; }");
 })();


### PR DESCRIPTION
Current PR allow to invoke CSS hint for property or value in any case:

<img width="503" alt="Снимок экрана 2021-12-24 в 00 07 14" src="https://user-images.githubusercontent.com/2073959/147291521-cb6eb0a9-9ad6-466b-bc9d-c1d0a3f37af0.png">

<img width="549" alt="Снимок экрана 2021-12-24 в 00 07 35" src="https://user-images.githubusercontent.com/2073959/147291528-129d9d33-28f5-43a1-b685-3483ef879243.png">

