### PR TITLE
[fortran mode] Generate regular expression using wordRegexp

### DIFF
--- a/mode/fortran/fortran.js
+++ b/mode/fortran/fortran.js
@@ -20,6 +20,10 @@ CodeMirror.defineMode("fortran", function() {
     return keys;
   }
 
+  function wordRegexp(words) {
+    return new RegExp("^((" + words.join(")|(") + "))\\b");
+  }
+
   var keywords = words([
                   "abstract", "accept", "allocatable", "allocate",
                   "array", "assign", "asynchronous", "backspace",
@@ -112,7 +116,7 @@ CodeMirror.defineMode("fortran", function() {
                      "c_short", "c_signed_char", "c_size_t", "character",
                      "complex", "double", "integer", "logical", "real"]);
   var isOperatorChar = /[+\-*&=<>\/\:]/;
-  var litOperator = new RegExp("(\.and\.|\.or\.|\.eq\.|\.lt\.|\.le\.|\.gt\.|\.ge\.|\.ne\.|\.not\.|\.eqv\.|\.neqv\.)", "i");
+  var litOperator = wordRegexp(["and", "or", "eq", "lt", "le", "gt", "ge", "ne", "not", "eqv", "neqv"]);
 
   function tokenBase(stream, state) {
 


### PR DESCRIPTION
The regular expression used to highlight operators has issues with certain functions such as "len" and "new_line", especially if there is an opening bracket right before these functions.

This issue was originally reported in https://github.com/carbon-app/carbon/issues/1308 and https://github.com/highlightjs/highlight.js/issues/3450. The original issue is at https://github.com/Beliavsky/FortranTip/issues/24.