### PR TITLE
Addition to regex to matches numbers with underscores in pearl

### DIFF
--- a/mode/perl/perl.js
+++ b/mode/perl/perl.js
@@ -514,7 +514,7 @@ CodeMirror.defineMode("perl",function(){
                 if(state.chain)
                         return tokenChain(stream,state,state.chain,state.style,state.tail);
                 if(stream.match(/^\-?[\d\.]/,false))
-                        if(stream.match(/^(\-?(\d*\.\d+(e[+-]?\d+)?|\d+\.\d*)|0x[\da-fA-F]+|0b[01]+|\d+(e[+-]?\d+)?)/))
+                        if(stream.match(/^(\-?(\d*\.\d+(e[+-]?\d+)?|\d+\.\d*|[\d_]*)|0x[\da-fA-F]+|0b[01]+|\d+(e[+-]?\d+)?)/))
                                 return 'number';
                 if(stream.match(/^<<(?=[_a-zA-Z])/)){                  // NOTE: <<SOMETHING\n...\nSOMETHING\n
                         stream.eatWhile(/\w/);


### PR DESCRIPTION
#6683 
Made an addition to the current regex pearl.js uses to match a 'number'. Numbers that contain underscores as separators are now matched. 
<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
