### PR TITLE
[htmlmixed mode] Fixed escaping in double-quote regex string

### DIFF
--- a/mode/htmlmixed/htmlmixed.js
+++ b/mode/htmlmixed/htmlmixed.js
@@ -50,7 +50,7 @@
   }
 
   function getTagRegexp(tagName, anchored) {
-    return new RegExp((anchored ? "^" : "") + "<\/\s*" + tagName + "\s*>", "i");
+    return new RegExp((anchored ? "^" : "") + "<\/\\s*" + tagName + "\\s*>", "i");
   }
 
   function addTags(from, to) {


### PR DESCRIPTION
The htmlmixed mode's `getTagRegexp()` function composes a regex out of double-quoted strings, which contain the `\s` regex character specifier. However, this is first being interpreted as a string escape code, which ends up being equivalent to `/<\/s*/` (zero or more instances of the 's' character) instead of the intended `/<\/\s*/` (zero or more instances of any whitespace character).

This pull request fixes the escaping to be consistent with that used in the `getAttrRegexp()` function a few lines above.