### PR TITLE
Allow mapping <Esc> in vim normal mode

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -865,13 +865,17 @@
         }
         function handleEsc() {
           if (key == '<Esc>') {
-            // Clear input state and get back to normal mode.
-            clearInputState(cm);
             if (vim.visualMode) {
+              // Get back to normal mode.
               exitVisualMode(cm);
             } else if (vim.insertMode) {
+              // Get back to normal mode.
               exitInsertMode(cm);
+            } else {
+              // We're already in normal mode. Let '<Esc>' be handled normally.
+              return;
             }
+            clearInputState(cm);
             return true;
           }
         }

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -4667,6 +4667,15 @@ testVim('ex_map_key2key_from_colon', function(cm, vim, helpers) {
   CodeMirror.Vim.mapclear();
 }, { value: 'abc' });
 
+testVim('map <Esc> in normal mode', function(cm, vim, helpers) {
+  CodeMirror.Vim.noremap('<Esc>', 'i', 'normal');
+  helpers.doKeys('<Esc>');
+  is(vim.insertMode, "Didn't switch to insert mode.");
+  helpers.doKeys('<Esc>');
+  is(!vim.insertMode, "Didn't switch to normal mode.");
+  CodeMirror.Vim.mapclear();
+});
+
 testVim('noremap', function(cm, vim, helpers) {
   CodeMirror.Vim.noremap(';', 'l');
   cm.setCursor(0, 0);


### PR DESCRIPTION
Resolves  #6234 

This change only affects normal mode. It's still possible to map <Esc> in insert and visual mode, and it will be ignored in favour of the default action of exiting to normal mode.