### PR TITLE
fixed option(keyMap) to check for undefined keymap

### DIFF
--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -89,9 +89,11 @@ export function defineOptions(CodeMirror) {
   }, true)
   option("keyMap", "default", (cm, val, old) => {
     let next = getKeyMap(val)
-    let prev = old != Init && getKeyMap(old)
-    if (prev && prev.detach) prev.detach(cm, next)
-    if (next.attach) next.attach(cm, prev || null)
+    if(next !== undefined) {
+      let prev = old != Init && getKeyMap(old)
+      if (prev && prev.detach) prev.detach(cm, next)
+      if (next.attach) next.attach(cm, prev || null)
+    }
   })
   option("extraKeys", null)
   option("configureMouse", null)


### PR DESCRIPTION
<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
This is a rather minor fix but it prevents setting unknown keyMap options from crashing editor