### PR TITLE
Don't use italics for styling code boxes (in Joplin)

### DIFF
--- a/theme/solarized.css
+++ b/theme/solarized.css
@@ -60,7 +60,7 @@ http://ethanschoonover.com/solarized/img/solarized-palette.png
 .cm-s-solarized .cm-property { color: #2aa198; }
 .cm-s-solarized .cm-operator { color: #6c71c4; }
 
-.cm-s-solarized .cm-comment { color: #586e75; font-style:italic; }
+.cm-s-solarized .cm-comment { color: #586e75; font-style:normal; }
 
 .cm-s-solarized .cm-string { color: #859900; }
 .cm-s-solarized .cm-string-2 { color: #b58900; }


### PR DESCRIPTION
I'm coming here from the Joplin forums, this theme is used as the "Solarized Light/Dark" themes over there. Some other users and me agreed on that having italic styled text is not a good choice for monospaced text, it is hard to read. In Joplin this style is used when "editing codeboxes (inside tripple backticks) in markdown)

Have a look at the discussion here and tell me what you think: https://discourse.joplinapp.org/t/why-is-the-markdown-editor-monospace-font-italics/24801/6

Thanks for a great theme and a great editor though!

<!--
NOTE: We are not accepting pull requests for new modes or addons. Please put such code in a separate repository, and release them as stand-alone npm packages. See for example the [Elixir mode](https://github.com/ianwalter/codemirror-mode-elixir).

Also pull requests that rewrite big chunks of code or adjust code style to your own taste are generally not welcome. Make your changes in focused steps that fix or improve a specific thing.
-->
