### PR TITLE
Fix Java textblock syntax

### DIFF
--- a/mode/clike/clike.js
+++ b/mode/clike/clike.js
@@ -500,7 +500,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
         return "meta";
       },
       '"': function(stream, state) {
-        if (!stream.match('""\n')) return false;
+        if (!stream.match(/""$/)) return false;
         state.tokenize = tokenTripleString;
         return state.tokenize(stream, state);
       }


### PR DESCRIPTION
For #6873

Before the fix:
![image](https://user-images.githubusercontent.com/639336/163123422-9133daa7-5796-4606-ada2-01dd58667816.png)


After the fix:

![image](https://user-images.githubusercontent.com/639336/163123351-2d6d9e20-2a1c-4453-860a-877ee5f215ed.png)
