### PR TITLE
Style variables correctly in functions 

### DIFF
--- a/mode/sparql/sparql.js
+++ b/mode/sparql/sparql.js
@@ -60,11 +60,6 @@ CodeMirror.defineMode("sparql", function(config) {
       stream.skipToEnd();
       return "comment";
     }
-    else if (ch === "^") {
-      ch = stream.peek();
-      if (ch === "^") stream.eat("^");
-      return "operator";
-    }
     else if (operatorChars.test(ch)) {
       return "operator";
     }

--- a/mode/sparql/sparql.js
+++ b/mode/sparql/sparql.js
@@ -63,11 +63,9 @@ CodeMirror.defineMode("sparql", function(config) {
     else if (ch === "^") {
       ch = stream.peek();
       if (ch === "^") stream.eat("^");
-      else stream.eatWhile(operatorChars);
       return "operator";
     }
     else if (operatorChars.test(ch)) {
-      stream.eatWhile(operatorChars);
       return "operator";
     }
     else if (ch == ":") {


### PR DESCRIPTION
Question-mark characters should only be styled as operators within triple patterns. For example the command

SELECT * WHERE { BIND(?A+?B AS ?C) }

should not have the "+?" sequence styled as "operator".  NB the problem does not occur if there is a space between these two characters. With the fix, "?A" and "?B" will both be styled as variable-2 (and "+" as operator).

By processing operators characters one at a time,  the existing code on line 40 to zealously interpret anything beginning with '?' as a variable can run in this case. We also don't need one of my earlier fixes that prevented "^^<" being treated as a three operators rather than two operators then the start of a verbose turtle-encoded IRI.

NB Line 40 actually causes a false positive in the case where the '?' appears in a triple pattern as a property path operator: this fix does not address this existing bug: it is quite complicated as '?' can appear in both variables and property paths while the parser is in the "pattern" state.