### PR TITLE
fix the paste operation when the cell is unfocused

### DIFF
--- a/src/input/input.js
+++ b/src/input/input.js
@@ -72,7 +72,7 @@ export function handlePaste(e, cm) {
   let pasted = e.clipboardData && e.clipboardData.getData("Text")
   if (pasted) {
     e.preventDefault()
-    if (!cm.isReadOnly() && !cm.options.disableInput)
+    if (!cm.isReadOnly() && !cm.options.disableInput && cm.hasFocus())
       runInOp(cm, () => applyTextInput(cm, pasted, 0, null, "paste"))
     return true
   }


### PR DESCRIPTION
I noticed that when the border of the CodeMirror component is clicked but the editor has not received the blinking cursor, that the paste operation can still happen.

Reproduce in master:
This can be seen by copying some text, click the border of the CodeMirror editor exactly (e.g., at https://codemirror.net/demo/html5complete.html), and paste using the system keyboard shortcut. The pasted text appears in the editor without a blinking cursor.
