### PR TITLE
Preserve whitespace when commenting

### DIFF
--- a/addon/comment/comment.js
+++ b/addon/comment/comment.js
@@ -78,7 +78,8 @@
         var baseString = null;
         for (var i = from.line; i < end; ++i) {
           var line = self.getLine(i);
-          var whitespace = line.trim().length === 0 ? line : line.slice(0, firstNonWS(line));
+          var nonWS = firstNonWS(line);
+          var whitespace = nonWS === 0 ? line : line.slice(0, nonWS);
           if (baseString == null || baseString.length > whitespace.length) {
             baseString = whitespace;
           }

--- a/addon/comment/comment.js
+++ b/addon/comment/comment.js
@@ -78,7 +78,7 @@
         var baseString = null;
         for (var i = from.line; i < end; ++i) {
           var line = self.getLine(i);
-          var whitespace = line.slice(0, firstNonWS(line));
+          var whitespace = line.trim().length === 0 ? line : line.slice(0, firstNonWS(line));
           if (baseString == null || baseString.length > whitespace.length) {
             baseString = whitespace;
           }

--- a/addon/comment/comment.js
+++ b/addon/comment/comment.js
@@ -78,8 +78,8 @@
         var baseString = null;
         for (var i = from.line; i < end; ++i) {
           var line = self.getLine(i);
-          var nonWS = firstNonWS(line);
-          var whitespace = nonWS === 0 ? line : line.slice(0, nonWS);
+          var nonWSPosition = firstNonWS(line);
+          var whitespace = nonWSPosition === 0 ? line : line.slice(0, nonWSPosition);
           if (baseString == null || baseString.length > whitespace.length) {
             baseString = whitespace;
           }

--- a/addon/comment/comment.js
+++ b/addon/comment/comment.js
@@ -78,8 +78,7 @@
         var baseString = null;
         for (var i = from.line; i < end; ++i) {
           var line = self.getLine(i);
-          var nonWSPosition = firstNonWS(line);
-          var whitespace = nonWSPosition === 0 ? line : line.slice(0, nonWSPosition);
+          var whitespace = line.search(nonWS) === -1 ? line : line.slice(0, firstNonWS(line));
           if (baseString == null || baseString.length > whitespace.length) {
             baseString = whitespace;
           }

--- a/test/comment_test.js
+++ b/test/comment_test.js
@@ -81,6 +81,10 @@ namespace = "comment_";
     cm.lineComment(Pos(1, 0), Pos(2), {indent: true});
   }, simpleProg, "function foo() {\n//   return bar;\n// }");
 
+  test("emptyIndentedLine", "javascript", function(cm) {
+    cm.lineComment(Pos(1, 2), Pos(1, 2), {indent: true});
+  }, "function foo() {\n  \n}", "function foo() {\n  // \n}");
+
   test("singleEmptyLine", "javascript", function(cm) {
     cm.setCursor(1);
     cm.execCommand("toggleComment");


### PR DESCRIPTION
Currently, when you comment the first line of an empty function you lose the indent.

![165898422-09f03ca5-863a-4ff8-90fa-cf6b02fc6781](https://user-images.githubusercontent.com/741344/169014675-525a76fe-0eaa-47ff-b456-e7cd07271bb5.png)

This PR has a simple fix that means commenting an indented empty line will keep the indent.